### PR TITLE
build(e2e): fix the kurtosis version to resolve breaking change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          sudo apt install kurtosis-cli
+          sudo apt install kurtosis-cli=0.88.19
           kurtosis analytics disable
 
       - name: Install Foundry


### PR DESCRIPTION
# Description

This PR is updating the Github actions related to e2e tests to fix a breaking in the new release of kurtosis-cli.
The PR is fixing the version to a stable one.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
