### PR TITLE
refactor(node): split tokio runtimes for metrics and node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "agglayer-config",
  "anyhow",
  "axum 0.7.5",
+ "buildstructor",
  "ethers",
  "futures",
  "hex",
@@ -539,6 +540,21 @@ checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2",
  "tinyvec",
+]
+
+[[package]]
+name = "buildstructor"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3907aac66c65520545ae3cb3c195306e20d5ed5c90bfbb992e061cf12a104d0"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "str_inflector",
+ "syn 2.0.60",
+ "thiserror",
+ "try_match",
 ]
 
 [[package]]
@@ -4070,6 +4086,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_inflector"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b848d5a7695b33ad1be00f84a3c079fe85c9278a325ff9159e6c99cef4ef7"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4690,6 +4716,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "try_match"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61ae3c1941e8859e30d28e572683fbfa89ae5330748b45139aedf488389e2be4"
+dependencies = [
+ "try_match_inner",
+]
+
+[[package]]
+name = "try_match_inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a91713132798caecb23c977488945566875e7b61b902fb111979871cbff34e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 anyhow = "1.0.81"
 async-trait = "0.1.80"
 axum = "0.7.5"
+buildstructor = "0.5.4"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 dotenvy = "0.15.7"
 ethers = "2.0.14"

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
+buildstructor.workspace = true
 ethers.workspace = true
 futures.workspace = true
 hex.workspace = true

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use agglayer_config::Config;
+use anyhow::Result;
+use ethers::{
+    middleware::MiddlewareBuilder as _,
+    providers::{Http, Provider},
+};
+
+use crate::{kernel::Kernel, rpc::AgglayerImpl};
+
+pub(crate) struct Node {}
+
+#[buildstructor::buildstructor]
+impl Node {
+    /// Function that setups and starts the Agglayer node.
+    ///
+    /// The available methods are:
+    ///
+    /// - `builder`: Creates a new builder instance.
+    /// - `config`: Sets the configuration.
+    /// - `start`: Starts the Agglayer node.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use agglayer_config::Config;
+    /// # use agglayer_node::Node;
+    /// # use anyhow::Result;
+    /// #
+    /// async fn start_node() -> Result<()> {
+    ///    let config: Arc<Config> = Arc::new(Config::default());
+    ///
+    ///    Node::builder()
+    ///      .config(config)
+    ///      .start()
+    ///      .await?;
+    ///
+    ///    Ok(())
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - The L1 node URL is invalid.
+    /// - The configured signer is invalid.
+    /// - The RPC server failed to start.
+    #[builder(entry = "builder", exit = "start", visibility = "pub(crate)")]
+    pub(crate) async fn start(config: Arc<Config>) -> Result<()> {
+        // Create a new L1 RPC provider with the configured signer.
+        let rpc = Provider::<Http>::try_from(config.l1.node_url.as_str())?
+            .with_signer(config.get_configured_signer().await?);
+
+        // Construct the core.
+        let core = Kernel::new(rpc, config.clone());
+
+        // Bind the core to the RPC server.
+        let server_handle = AgglayerImpl::new(core).start(config).await?;
+
+        server_handle.stopped().await;
+
+        Ok(())
+    }
+}

--- a/crates/agglayer-node/src/telemetry.rs
+++ b/crates/agglayer-node/src/telemetry.rs
@@ -10,7 +10,7 @@ use axum::{
 use lazy_static::lazy_static;
 use opentelemetry::global;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
-use prometheus::{Encoder as _, TextEncoder};
+use prometheus::{Encoder as _, Registry, TextEncoder};
 use tracing::info;
 
 pub(crate) const AGGLAYER_RPC_OTEL_SCOPE_NAME: &str = "rpc";
@@ -54,9 +54,6 @@ lazy_static! {
 pub(crate) enum Error {
     #[error("Unable to bind metrics server: {0}")]
     UnableToBindMetricsServer(#[from] std::io::Error),
-
-    #[error("Metrics server address is not set")]
-    MetricsServerAddressNotSet,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -71,28 +68,54 @@ enum MetricsError {
     OpenTelemetry(#[from] opentelemetry::metrics::MetricsError),
 }
 
-#[derive(Default, Clone)]
-pub struct ServerBuilder {
-    serve_addr: Option<SocketAddr>,
-    registry: prometheus::Registry,
-}
+pub struct ServerBuilder {}
 
+#[buildstructor::buildstructor]
 impl ServerBuilder {
-    pub fn serve_addr(mut self, addr: Option<SocketAddr>) -> Self {
-        self.serve_addr = addr;
-
-        self
-    }
-
-    pub async fn build(
-        mut self,
+    /// Function that builds a new Metrics server and returns a [`Serve`]
+    /// instance ready to be spawn.
+    ///
+    /// The available methods are:
+    ///
+    /// - `builder`: Creates a new builder instance.
+    /// - `addr`: Sets the [`SocketAddr`] to bind the metrics server to.
+    /// - `registry`: Sets the [`Registry`] to use for metrics. (optional)
+    /// - `build`: Builds the metrics server and returns a [`Serve`] instance.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use agglayer_config::Config;
+    /// # use agglayer_node::Node;
+    /// # use anyhow::Result;
+    /// #
+    /// use axum::serve::Serve;
+    ///
+    /// async fn build_metrics() -> Result<Serve, Error> {
+    ///    ServerBuilder::builder()
+    ///      .addr("127.0.0.1".parse().unwrap())
+    ///      .build()
+    ///      .await?;
+    ///
+    ///    Ok(())
+    /// }
+    /// ```
+    ///
+    ///
+    /// # Panics
+    ///
+    /// Panics on failure of the gather_metrics internal methods (unlikely)
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the provided addr is invalid
+    #[builder(entry = "builder", exit = "build", visibility = "pub(crate)")]
+    pub async fn serve(
+        addr: SocketAddr,
+        registry: Option<Registry>,
     ) -> Result<Serve<axum::routing::IntoMakeService<Router>, axum::Router>, Error> {
-        let _ = self.init_meter_provider();
-
-        let serve_addr = self
-            .serve_addr
-            .take()
-            .ok_or(Error::MetricsServerAddressNotSet)?;
+        let registry = registry.unwrap_or_default();
+        let _ = Self::init_meter_provider(&registry);
 
         let app = Router::new()
             .route(
@@ -107,18 +130,18 @@ impl ServerBuilder {
                     }
                 }),
             )
-            .with_state(self.registry);
+            .with_state(registry);
 
-        info!("Starting metrics server on {}", serve_addr);
+        info!("Starting metrics server on {}", addr);
 
-        let listener = tokio::net::TcpListener::bind(serve_addr).await?;
+        let listener = tokio::net::TcpListener::bind(addr).await?;
         Ok(axum::serve(listener, app.into_make_service()))
     }
 
-    fn init_meter_provider(&mut self) -> Result<(), MetricsError> {
+    fn init_meter_provider(registry: &Registry) -> Result<(), MetricsError> {
         // configure OpenTelemetry to use the registry
         let exporter = opentelemetry_prometheus::exporter()
-            .with_registry(self.registry.clone())
+            .with_registry(registry.clone())
             .build()?;
 
         // set up a meter meter to create instruments

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -3,14 +3,13 @@ use cli::Cli;
 
 mod cli;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let cli = Cli::parse();
 
     match cli.cmd {
-        cli::Commands::Run { cfg } => agglayer_node::run(cfg).await?,
+        cli::Commands::Run { cfg } => agglayer_node::main(cfg)?,
     }
 
     Ok(())


### PR DESCRIPTION
# Description

This PR is the first one of an effort to implement Epoch management.
In order to make it possible, we need to make our code base more `async` friendly.


## Additions and Changes

### New feature (non-breaking change which adds functionality)

`metrics` and `node` are now in separated tokio runtimes.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
