### PR TITLE
feat: telemetry extract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,6 @@ name = "agglayer-config"
 version = "0.1.0"
 dependencies = [
  "agglayer-signer",
- "agglayer-telemetry",
  "ethers",
  "ethers-gcp-kms-signer",
  "jsonrpsee",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 [workspace.dependencies]
 anyhow = "1.0.81"
 async-trait = "0.1.80"
-lazy_static = "1.4.0"
 buildstructor = "0.5.4"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 dotenvy = "0.15.7"
@@ -19,6 +18,7 @@ ethers-gcp-kms-signer = "0.1.5"
 futures = "0.3.30"
 hex = "0.4.3"
 jsonrpsee = { version = "0.22.5", features = ["full"] }
+lazy_static = "1.4.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.116"
 serde_with = "3.7.0"

--- a/crates/agglayer-config/Cargo.toml
+++ b/crates/agglayer-config/Cargo.toml
@@ -16,7 +16,6 @@ tracing.workspace = true
 url = { workspace = true, features = ["serde"] }
 
 agglayer-signer = { path = "../agglayer-signer" }
-agglayer-telemetry = { path = "../agglayer-telemetry" }
 
 [features]
 default = []

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -6,14 +6,15 @@
 use std::collections::HashMap;
 
 use agglayer_signer::ConfiguredSigner;
-use agglayer_telemetry::TelemetryConfig;
 use ethers::signers::{LocalWallet, Signer};
 use ethers_gcp_kms_signer::{GcpKeyRingRef, GcpKmsProvider, GcpKmsSigner};
 use serde::Deserialize;
 use tracing::debug;
 use url::Url;
 
-use self::{eth_tx_manager::PrivateKey, rpc::deserialize_rpc_map};
+use self::{eth_tx_manager::PrivateKey, rpc::deserialize_rpc_map, telemetry::TelemetryConfig};
+
+pub(crate) const DEFAULT_IP: std::net::Ipv4Addr = std::net::Ipv4Addr::new(0, 0, 0, 0);
 
 pub(crate) mod epoch;
 pub(crate) mod error;
@@ -21,6 +22,7 @@ pub(crate) mod eth_tx_manager;
 pub(crate) mod l1;
 pub mod log;
 pub(crate) mod rpc;
+pub(crate) mod telemetry;
 
 pub use epoch::Epoch;
 pub use error::ConfigError;

--- a/crates/agglayer-config/src/telemetry.rs
+++ b/crates/agglayer-config/src/telemetry.rs
@@ -2,9 +2,7 @@ use std::net::SocketAddr;
 
 use serde::Deserialize;
 
-pub(crate) const DEFAULT_IP: std::net::Ipv4Addr = std::net::Ipv4Addr::new(0, 0, 0, 0);
-pub(crate) const AGGLAYER_RPC_OTEL_SCOPE_NAME: &str = "rpc";
-pub(crate) const AGGLAYER_KERNEL_OTEL_SCOPE_NAME: &str = "kernel";
+use super::DEFAULT_IP;
 
 #[derive(Deserialize, Debug, Clone, Copy)]
 #[serde(rename_all = "PascalCase")]

--- a/crates/agglayer-telemetry/Cargo.toml
+++ b/crates/agglayer-telemetry/Cargo.toml
@@ -4,14 +4,14 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-lazy_static.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
-buildstructor.workspace = true
 axum = "0.7.5"
+buildstructor.workspace = true
+lazy_static.workspace = true
 opentelemetry = "0.22.0"
 opentelemetry-prometheus = "0.15.0"
 opentelemetry_sdk = "0.22.1"
 prometheus = "0.13.3"
 serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true

--- a/crates/agglayer-telemetry/src/constant.rs
+++ b/crates/agglayer-telemetry/src/constant.rs
@@ -1,0 +1,2 @@
+pub(crate) const AGGLAYER_RPC_OTEL_SCOPE_NAME: &str = "rpc";
+pub(crate) const AGGLAYER_KERNEL_OTEL_SCOPE_NAME: &str = "kernel";

--- a/crates/agglayer-telemetry/src/error.rs
+++ b/crates/agglayer-telemetry/src/error.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, thiserror::Error)]
-pub enum TelemetryError {
+pub enum Error {
     #[error("Unable to bind metrics server: {0}")]
     UnableToBindMetricsServer(#[from] std::io::Error),
 }

--- a/crates/agglayer-telemetry/src/lib.rs
+++ b/crates/agglayer-telemetry/src/lib.rs
@@ -13,15 +13,16 @@ use opentelemetry_sdk::metrics::SdkMeterProvider;
 use prometheus::{Encoder as _, Registry, TextEncoder};
 use tracing::info;
 
-mod config;
+use crate::{
+    constant::{AGGLAYER_KERNEL_OTEL_SCOPE_NAME, AGGLAYER_RPC_OTEL_SCOPE_NAME},
+    error::MetricsError,
+};
+
+mod constant;
 mod error;
 
-pub use config::TelemetryConfig;
-pub use error::TelemetryError;
+pub use error::Error;
 pub use opentelemetry::KeyValue;
-
-use crate::config::{AGGLAYER_KERNEL_OTEL_SCOPE_NAME, AGGLAYER_RPC_OTEL_SCOPE_NAME};
-use crate::error::MetricsError;
 
 lazy_static! {
     // Backward compatibility with the old metrics from agglayer go implementation
@@ -102,7 +103,7 @@ impl ServerBuilder {
     pub async fn serve(
         addr: SocketAddr,
         registry: Option<Registry>,
-    ) -> Result<Serve<axum::routing::IntoMakeService<Router>, axum::Router>, TelemetryError> {
+    ) -> Result<Serve<axum::routing::IntoMakeService<Router>, axum::Router>, Error> {
         let registry = registry.unwrap_or_default();
         let _ = Self::init_meter_provider(&registry);
 


### PR DESCRIPTION
# Description

Extract telemetry in a separate crate. We need that to be generic to allow a different set of telemetry to be used.

## Additions and Changes

- create `agglayer-telemetry` crate
- move the telemetry code type from `agglayer-node` to `agglayer-telemetry`

## PR Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added or updated tests that comprehensively prove my change is effective or that my feature works
