### PR TITLE
feat(clock): implement graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "futures",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0.116"
 serde_with = "3.7.0"
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = ["full"] }
+tokio-util = "0.7.11"
 toml = "0.8.12"
 tower = "0.4.13"
 tracing = "0.1.40"

--- a/crates/agglayer-clock/Cargo.toml
+++ b/crates/agglayer-clock/Cargo.toml
@@ -8,5 +8,6 @@ async-trait.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/agglayer-clock/src/lib.rs
+++ b/crates/agglayer-clock/src/lib.rs
@@ -13,6 +13,7 @@ use tokio::sync::broadcast;
 mod time;
 
 pub use time::TimeClock;
+use tokio_util::sync::CancellationToken;
 
 const BROADCAST_CHANNEL_SIZE: usize = 100;
 
@@ -21,7 +22,7 @@ const BROADCAST_CHANNEL_SIZE: usize = 100;
 #[async_trait::async_trait]
 pub trait Clock {
     /// Spawn the Clock task and return a [`ClockRef`] to interact with it.
-    async fn spawn(self) -> Result<ClockRef, Error>;
+    async fn spawn(self, cancellation_token: CancellationToken) -> Result<ClockRef, Error>;
 }
 
 /// The ClockRef is a reference to the Clock instance.

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -18,7 +18,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
-tokio-util = "0.7.11"
+tokio-util = { workspace = true }
 toml.workspace = true
 # Fixed until jsonrpsee update to hyper 1.0
 tower-http = { version = "0.4.0", features = ["full"] }

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -78,7 +78,7 @@ impl Node {
                     ))?;
                 let clock = TimeClock::new_now(duration);
 
-                clock.spawn().await?
+                clock.spawn(cancellation_token.clone()).await?
             }
         };
 

--- a/crates/agglayer-telemetry/Cargo.toml
+++ b/crates/agglayer-telemetry/Cargo.toml
@@ -15,5 +15,5 @@ prometheus = "0.13.3"
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
-tokio-util = "0.7.11"
+tokio-util = { workspace = true }
 tracing.workspace = true


### PR DESCRIPTION
# Description

This PR adds the graceful shutdown mechanism to the `Clock`.
A `CancellationToken` is used to listen for node shutdown, but also to notify in case of any error in the `Clock` that the node should start shutting down

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
