### PR TITLE
feat(config): adding outbound rpc settle configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror",
+ "toml",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/agglayer.toml
+++ b/agglayer.toml
@@ -24,3 +24,8 @@ Keyring = ""
 KeyName = ""
 
 [Telemetry]
+
+[outbound.rpc.settle]
+max_retries = 10
+retry_interval = 1
+confirmations = 3

--- a/crates/agglayer-config/Cargo.toml
+++ b/crates/agglayer-config/Cargo.toml
@@ -17,6 +17,7 @@ url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+toml.workspace = true
 
 [features]
 default = []

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use auth::deserialize_auth;
+use outbound::OutboundConfig;
 use serde::Deserialize;
 use url::Url;
 
@@ -17,6 +18,7 @@ pub(crate) mod auth;
 pub(crate) mod epoch;
 pub(crate) mod l1;
 pub mod log;
+pub(crate) mod outbound;
 pub(crate) mod rpc;
 pub(crate) mod telemetry;
 
@@ -42,6 +44,9 @@ pub struct Config {
     /// The local RPC server configuration.
     #[serde(rename = "RPC")]
     pub rpc: RpcConfig,
+    /// The configuration for every outbound network component.
+    #[serde(default)]
+    pub outbound: OutboundConfig,
     /// The L1 configuration.
     #[serde(rename = "L1")]
     pub l1: L1,

--- a/crates/agglayer-config/src/outbound.rs
+++ b/crates/agglayer-config/src/outbound.rs
@@ -1,0 +1,130 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_with::serde_as;
+use serde_with::DurationSeconds;
+
+/// Outbound configuration.
+#[derive(Default, Debug, Deserialize)]
+#[serde(rename = "outbound")]
+pub struct OutboundConfig {
+    pub rpc: OutboundRpcConfig,
+}
+
+/// Outbound RPC configuration that is used to configure the outbound RPC
+/// clients and their RPC calls.
+#[derive(Default, Debug, Deserialize)]
+#[serde(rename = "rpc")]
+pub struct OutboundRpcConfig {
+    /// Outbound configuration of the RPC settle function call.
+    pub settle: OutboundRpcSettleConfig,
+}
+
+/// Outbound RPC settle configuration that is used to configure the outbound
+/// RPC settle function call.
+#[serde_as]
+#[derive(Debug, Deserialize)]
+#[serde(rename = "settle")]
+pub struct OutboundRpcSettleConfig {
+    /// Maximum number of retries for the transaction.
+    #[serde(default = "default_rpc_retries")]
+    pub max_retries: usize,
+
+    /// Interval for the polling of the transaction.
+    #[serde(default = "default_rpc_retry_interval")]
+    #[serde_as(as = "DurationSeconds")]
+    pub retry_interval: Duration,
+
+    /// Number of confirmations required for the transaction to resolve a
+    /// receipt.
+    #[serde(default = "default_rpc_confirmations")]
+    pub confirmations: usize,
+}
+
+impl Default for OutboundRpcSettleConfig {
+    fn default() -> Self {
+        OutboundRpcSettleConfig {
+            max_retries: default_rpc_retries(),
+            retry_interval: default_rpc_retry_interval(),
+            confirmations: default_rpc_confirmations(),
+        }
+    }
+}
+
+/// Default number of retries for the transaction. It matches the ethers default
+/// value.
+const fn default_rpc_retries() -> usize {
+    3
+}
+
+/// Default interval for the polling of the transaction.
+const fn default_rpc_retry_interval() -> Duration {
+    Duration::from_secs(7)
+}
+
+/// Default number of confirmations required for the transaction to resolve a
+/// receipt.
+const fn default_rpc_confirmations() -> usize {
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    mod outbound {
+        use serde::Deserialize;
+
+        use crate::outbound::OutboundConfig;
+
+        #[test]
+        fn expected_namespace() {
+            #[derive(Debug, Deserialize)]
+            struct DummyContainer {
+                outbound: OutboundConfig,
+            }
+
+            let toml = r#"
+                [outbound.rpc.settle]
+                max_retries = 10
+                "#;
+
+            let config = toml::from_str::<DummyContainer>(toml).unwrap();
+
+            assert_eq!(config.outbound.rpc.settle.max_retries, 10);
+        }
+
+        mod rpc {
+            mod settle {
+                use std::time::Duration;
+
+                use crate::outbound::OutboundRpcSettleConfig;
+
+                #[test]
+                fn test_default() {
+                    let toml = r#"
+                        "#;
+
+                    let config = toml::from_str::<OutboundRpcSettleConfig>(toml).unwrap();
+
+                    assert_eq!(config.max_retries, 3);
+                    assert_eq!(config.retry_interval, Duration::from_secs(7));
+                    assert_eq!(config.confirmations, 1);
+                }
+
+                #[test]
+                fn test_custom() {
+                    let toml = r#"
+                        max_retries = 10
+                        retry_interval = 1
+                        confirmations = 5
+                        "#;
+
+                    let config = toml::from_str::<OutboundRpcSettleConfig>(toml).unwrap();
+
+                    assert_eq!(config.max_retries, 10);
+                    assert_eq!(config.retry_interval, Duration::from_secs(1));
+                    assert_eq!(config.confirmations, 5);
+                }
+            }
+        }
+    }
+}

--- a/crates/agglayer-node/src/kernel/mod.rs
+++ b/crates/agglayer-node/src/kernel/mod.rs
@@ -326,6 +326,9 @@ where
             .send()
             .await
             .map_err(SettlementError::ContractError)?
+            .interval(self.config.outbound.rpc.settle.retry_interval)
+            .retries(self.config.outbound.rpc.settle.max_retries)
+            .confirmations(self.config.outbound.rpc.settle.confirmations)
             .await
             .map_err(SettlementError::ProviderError)?
             // If the result is `None`, it means the transaction is no longer in the mempool.


### PR DESCRIPTION
# Description

This PR is adding a new configuration object to configure the different `outbound` RPC calls that we can make.
Currently, Only one RPC is configurable, the `settle`.

## Additions and Changes

The `settle` RPC is configurable using:

```toml
[outbound.rpc.settle]
max_retries = X
retry_interval = X
confirmations = X
```

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
