### PR TITLE
test: Enforce RPC tests are run under nextest

### DIFF
--- a/crates/agglayer-node/src/rpc/tests.rs
+++ b/crates/agglayer-node/src/rpc/tests.rs
@@ -189,6 +189,11 @@ async fn send_certificate_method_can_be_called_and_fail() {
 fn next_available_addr() -> std::net::SocketAddr {
     use std::net::{TcpListener, TcpStream};
 
+    assert!(
+        std::env::var("NEXTEST").is_ok(),
+        "Due to concurrency issues, the rpc tests have to be run under `cargo nextest`",
+    );
+
     let host = "127.0.0.1";
     // Request a random available port from the OS
     let listener = TcpListener::bind((host, 0)).expect("Can't bind to an available port");


### PR DESCRIPTION
# Description

The `cargo test` command does not work out of the box due to concurrency issues. Add an assertion that checks the relevant tests are run using `nextest` with an error message that guides the users towards a resolution.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
