### PR TITLE
test: add a simple signer test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "ethers",
  "ethers-gcp-kms-signer",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "async-trait",
  "ethers",
  "ethers-gcp-kms-signer",
+ "rstest",
  "thiserror",
  "tokio",
 ]
@@ -4117,6 +4118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4383,6 +4390,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b241d2e59b74ef9e98d94c78c47623d04c8392abaf82014dfd372a16041128f"
 dependencies = [
  "sha2",
+]
+
+[[package]]
+name = "rstest"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.0",
+ "syn 2.0.68",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3.30"
 hex = "0.4.3"
 jsonrpsee = { version = "0.23.2", features = ["full"] }
 lazy_static = "1.5.0"
+rstest = "0.21.0"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 serde_with = "3.8.3"

--- a/crates/agglayer-signer/Cargo.toml
+++ b/crates/agglayer-signer/Cargo.toml
@@ -14,3 +14,4 @@ agglayer-gcp-kms = { path = "../agglayer-gcp-kms" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
+rstest.workspace = true

--- a/crates/agglayer-signer/Cargo.toml
+++ b/crates/agglayer-signer/Cargo.toml
@@ -11,3 +11,6 @@ thiserror.workspace = true
 
 agglayer-config = { path = "../agglayer-config" }
 agglayer-gcp-kms = { path = "../agglayer-gcp-kms" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/agglayer-signer/src/lib.rs
+++ b/crates/agglayer-signer/src/lib.rs
@@ -121,3 +121,6 @@ impl Signer for ConfiguredSigner {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/agglayer-signer/src/tests.rs
+++ b/crates/agglayer-signer/src/tests.rs
@@ -1,0 +1,43 @@
+use ethers::types::{Eip1559TransactionRequest, H160};
+
+use super::*;
+
+async fn check_signer_works(signer: &ConfiguredSigner) {
+    let txn = Eip1559TransactionRequest {
+        from: Some(signer.address()),
+        to: Some(H160([0x11; 20]).into()),
+        gas: None,
+        value: Some(1_000_000_000_u64.into()),
+        data: None,
+        nonce: Some(123_u64.into()),
+        access_list: Default::default(),
+        max_priority_fee_per_gas: None,
+        max_fee_per_gas: None,
+        chain_id: Some(1337.into()),
+    };
+    let txn = TypedTransaction::Eip1559(txn);
+
+    // Check the signature returned by the signer successfully verifies
+    let signature = signer.sign_transaction(&txn).await.unwrap();
+    assert!(signature.verify(txn.sighash(), signer.address()).is_ok());
+
+    // Change the amount, check the signature no longer verifies
+    let txn = {
+        let mut txn = txn;
+        match &mut txn {
+            TypedTransaction::Eip1559(txn) => {
+                txn.value = Some(2_000_000_000_u64.into());
+            }
+            _ => panic!("Must be Eip1559, constructed just a few lines above"),
+        };
+        txn
+    };
+
+    assert!(signature.verify(txn.sighash(), signer.address()).is_err());
+}
+
+#[tokio::test]
+async fn wallet_signer_works() {
+    let signer = ConfiguredSigner::Local(LocalWallet::from_bytes([0x55; 32].as_slice()).unwrap());
+    check_signer_works(&signer).await;
+}

--- a/crates/agglayer-signer/src/tests.rs
+++ b/crates/agglayer-signer/src/tests.rs
@@ -2,7 +2,14 @@ use ethers::types::{Eip1559TransactionRequest, H160};
 
 use super::*;
 
-async fn check_signer_works(signer: &ConfiguredSigner) {
+fn testing_local_wallet() -> ConfiguredSigner {
+    ConfiguredSigner::Local(LocalWallet::from_bytes([0x55; 32].as_slice()).unwrap())
+}
+
+#[rstest::rstest]
+#[case(testing_local_wallet())]
+#[tokio::test]
+async fn signer_works(#[case] signer: ConfiguredSigner) {
     let txn = Eip1559TransactionRequest {
         from: Some(signer.address()),
         to: Some(H160([0x11; 20]).into()),
@@ -34,10 +41,4 @@ async fn check_signer_works(signer: &ConfiguredSigner) {
     };
 
     assert!(signature.verify(txn.sighash(), signer.address()).is_err());
-}
-
-#[tokio::test]
-async fn wallet_signer_works() {
-    let signer = ConfiguredSigner::Local(LocalWallet::from_bytes([0x55; 32].as_slice()).unwrap());
-    check_signer_works(&signer).await;
 }


### PR DESCRIPTION
# Description

Adding a very basic signer test of questionable value. It only checks the wallet signer for now but should be easy to extend to check GCP KMS and other signers too.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
