### PR TITLE
[DRAFT] Moving to Local Pessimistic Proof Generation

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/agglayer.iml
+++ b/.idea/agglayer.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/agglayer.iml
+++ b/.idea/agglayer.iml
@@ -2,7 +2,20 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/crates/agglayer-certificate-orchestrator/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/agglayer-clock/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/agglayer-config/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/agglayer-gcp-kms/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/agglayer-node/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/agglayer-signer/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/agglayer-telemetry/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/agglayer/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/pessimistic-proof/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/pessimistic-proof/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/xtask/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/agglayer.iml" filepath="$PROJECT_DIR$/.idea/agglayer.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/crates/agglayer-node/src/node/notifier.rs
+++ b/crates/agglayer-node/src/node/notifier.rs
@@ -1,6 +1,6 @@
 use agglayer_certificate_orchestrator::{EpochPacker, Error};
 use futures::future::BoxFuture;
-use pessimistic_proof::certificate::Certificate;
+use pessimistic_proof::batch_header::BatchHeader;
 use tracing::debug;
 
 #[derive(Clone)]
@@ -13,7 +13,7 @@ impl AggregatorNotifier {
 }
 
 impl EpochPacker for AggregatorNotifier {
-    type Item = Certificate;
+    type Item = BatchHeader;
     fn pack<T: IntoIterator<Item = Self::Item>>(
         &self,
         epoch: u64,
@@ -25,7 +25,7 @@ impl EpochPacker for AggregatorNotifier {
 
         Ok(Box::pin(async move {
             debug!(
-                "Start packing epoch {} with {} certificates",
+                "Start packing epoch {} with {} headers",
                 epoch,
                 to_pack.len()
             );

--- a/crates/agglayer-node/src/rpc/tests.rs
+++ b/crates/agglayer-node/src/rpc/tests.rs
@@ -12,7 +12,7 @@ use hyper_util::rt::TokioExecutor;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::rpc_params;
-use pessimistic_proof::certificate::Certificate;
+use pessimistic_proof::batch_header::BatchHeader;
 
 use crate::rpc::TxStatus;
 use crate::{kernel::Kernel, rpc::AgglayerImpl};
@@ -146,7 +146,7 @@ async fn send_certificate_method_can_be_called() {
     let _: () = client
         .request(
             "interop_sendCertificate",
-            rpc_params![Certificate::default()],
+            rpc_params![BatchHeader::default()],
         )
         .await
         .unwrap();
@@ -187,7 +187,7 @@ async fn send_certificate_method_can_be_called_and_fail() {
     let res: Result<(), _> = client
         .request(
             "interop_sendCertificate",
-            rpc_params![Certificate::default()],
+            rpc_params![BatchHeader::default()],
         )
         .await;
 

--- a/crates/pessimistic-proof-program/src/main.rs
+++ b/crates/pessimistic-proof-program/src/main.rs
@@ -10,8 +10,10 @@ pub fn main() {
 
     let new_roots = generate_leaf_proof(initial_state, &batch_header).unwrap();
 
-    if let Some(imported_roots) = &batch_header.imported_lers_root {
-        sp1_zkvm::io::commit(imported_roots);
+    if let Some(imported_roots) = &batch_header.imported_lers {
+        imported_bridge_exits.iter().for_each(|imported_root| {
+            sp1_zkvm::io::commit(imported_root)
+        });
     }else {
         sp1_zkvm::io::commit(None);
     }

--- a/crates/pessimistic-proof-program/src/main.rs
+++ b/crates/pessimistic-proof-program/src/main.rs
@@ -10,5 +10,23 @@ pub fn main() {
 
     let new_roots = generate_leaf_proof(initial_state, &batch_header).unwrap();
 
+    if let Some(imported_roots) = &batch_header.imported_lers_root {
+        sp1_zkvm::io::commit(imported_roots);
+    }else {
+        sp1_zkvm::io::commit(None);
+    }
+
+    if let Some(imported_global_root) = &batch_header.imported_global_exit_root {
+        sp1_zkvm::io::commit(imported_global_root);
+    }else {
+        sp1_zkvm::io::commit(None);
+    }
+
+    if let Some(imported_exits_root) = &batch_header.imported_exits_root {
+        sp1_zkvm::io::commit(imported_exits_root);
+    }else {
+        sp1_zkvm::io::commit(None);
+    }
+
     sp1_zkvm::io::commit(&new_roots);
 }

--- a/crates/pessimistic-proof-program/src/main.rs
+++ b/crates/pessimistic-proof-program/src/main.rs
@@ -1,14 +1,14 @@
 #![no_main]
 
-use pessimistic_proof::{certificate::Certificate, generate_leaf_proof, LocalNetworkState};
+use pessimistic_proof::{batch_header::BatchHeader, generate_leaf_proof, LocalNetworkState};
 
 sp1_zkvm::entrypoint!(main);
 
 pub fn main() {
     let initial_state = sp1_zkvm::io::read::<LocalNetworkState>();
-    let certificate = sp1_zkvm::io::read::<Certificate>();
+    let batch_header = sp1_zkvm::io::read::<BatchHeader>();
 
-    let new_roots = generate_leaf_proof(initial_state, &certificate).unwrap();
+    let new_roots = generate_leaf_proof(initial_state, &batch_header).unwrap();
 
     sp1_zkvm::io::commit(&new_roots);
 }

--- a/crates/pessimistic-proof/src/batch_header.rs
+++ b/crates/pessimistic-proof/src/batch_header.rs
@@ -42,7 +42,7 @@ pub struct BatchHeader {
     pub imported_exits_root: Option<Digest>,
 
     /// A commitment to the set of imported local exit roots
-    pub imported_lers_root: Option<Digest>,
+    pub imported_lers: Option<Vec<(NetworkId, Digest)>>,
 
     /// An imported global exit root, used to process deposits from Ethereum
     pub imported_global_exit_root: Option<Digest>,
@@ -65,7 +65,7 @@ impl BatchHeader {
         bridge_exits: Vec<BridgeExit>,
         imported_bridge_exits: Option<Vec<ImportedBridgeExit>>,
         imported_exits_root: Option<Digest>,
-        imported_lers_root: Option<Digest>,
+        imported_lers: Option<Vec<(NetworkId, Digest)>>,
         imported_global_exit_root: Option<Digest>,
     ) -> Self {
         Self {
@@ -74,7 +74,7 @@ impl BatchHeader {
             bridge_exits,
             imported_bridge_exits,
             imported_exits_root,
-            imported_lers_root,
+            imported_lers,
             imported_global_exit_root,
         }
     }

--- a/crates/pessimistic-proof/src/batch_header.rs
+++ b/crates/pessimistic-proof/src/batch_header.rs
@@ -8,13 +8,13 @@ use crate::{bridge_exit::NetworkId, keccak::Digest, BridgeExit};
 /// the state transition, resp. the amount that goes out and the amount that comes in.
 ///
 /// The bridge exits refer to the [`BridgeExit`]  emitted by
-/// the origin network of the [`Certificate`].
+/// the origin network of the [`BatchHeader`].
 ///
 /// The imported bridge exits refer to the [`BridgeExit`] received and imported
-/// by the origin network of the [`Certificate`].
+/// by the origin network of the [`BatchHeader].
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Certificate {
-    /// The origin network which emitted this certificate.
+pub struct BatchHeader {
+    /// The origin network which emitted this BatchHeader.
     pub origin_network: NetworkId,
     /// The initial local exit root.
     pub prev_local_exit_root: Digest,
@@ -24,8 +24,8 @@ pub struct Certificate {
     pub imported_bridge_exits: Vec<BridgeExit>,
 }
 
-impl Certificate {
-    /// Creates a new [`Certificate`].
+impl BatchHeader {
+    /// Creates a new [`BatchHeader`].
     pub fn new(
         origin_network: NetworkId,
         prev_local_exit_root: Digest,

--- a/crates/pessimistic-proof/src/batch_header.rs
+++ b/crates/pessimistic-proof/src/batch_header.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{bridge_exit::NetworkId, keccak::Digest, BridgeExit};
+use crate::{bridge_exit::NetworkId, keccak::Digest, BridgeExit, ImportedBridgeExit};
 
 /// Represents the data submitted by the CDKs to the AggLayer.
 ///
@@ -15,19 +15,28 @@ use crate::{bridge_exit::NetworkId, keccak::Digest, BridgeExit};
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct BatchHeader {
     /// The origin network which emitted this BatchHeader.
+    /// TODO: we should clarify naming. We use origin to refer to the issuing network of a token. Could consider using "sending" or "local" to refer to the network that created a batch.
     pub origin_network: NetworkId,
 
-    /// The start slot height and end block height for the batch. Unsure if required
-    /// pub start_block_height: u32,
-    /// pub end_block_height u32,
+    // /// The start slot height and end block height for the batch. Unsure if required
+    // pub start_block_height: u32,
+    // pub end_block_height u32,
 
-    /// The state root produced by the current block
-    pub state_root: Option<Digest>,
+    // /// The state root produced by the current block
+    // TODO: Determine if this is necessary - I think that it is.
+    // pub state_root: Option<Digest>,
 
     /// The initial local exit root.
-    pub prev_local_exit_root: Option<Digest>,
-    /// The updated local exit root
-    pub local_exit_root: Digest,
+    /// TODO: should probably be optional
+    pub prev_local_exit_root: Digest,
+
+    /// The set of bridge exits created in this batch
+    /// TODO: move out of the header and into a separate struct
+    pub bridge_exits: Vec<BridgeExit>,
+
+    /// The set of imported bridge exits claimed in this batch
+    /// TODO: move out of the header and into a separate struct
+    pub imported_bridge_exits: Option<Vec<ImportedBridgeExit>>,
 
     /// A commitment to the set of imported bridge exits for which the origin network is the target.
     pub imported_exits_root: Option<Digest>,
@@ -38,32 +47,32 @@ pub struct BatchHeader {
     /// An imported global exit root, used to process deposits from Ethereum
     pub imported_global_exit_root: Option<Digest>,
 
-    /// A validity proof verifying transaction execution
-    ///pub validity_proof: Option<ValidityProof>,
+    // /// A validity proof verifying transaction execution
+    //pub validity_proof: Option<ValidityProof>,
 
-    /// A consensus proof for the latest block
-    ///pub consensus_proof: Option<ConsensusProof>,
+    // /// A consensus proof for the latest block
+    //pub consensus_proof: Option<ConsensusProof>,
 
-    /// The signature that commits to the state transition.
-    ///pub signature: (),
+    // /// The signature that commits to the state transition.
+    //pub signature: (),
 }
 
 impl BatchHeader {
     /// Creates a new [`BatchHeader`].
     pub fn new(
         origin_network: NetworkId,
-        state_root: Option<Digest>,
-        prev_local_exit_root: Option<Digest>,
-        local_exit_root: Digest,
+        prev_local_exit_root: Digest,
+        bridge_exits: Vec<BridgeExit>,
+        imported_bridge_exits: Option<Vec<ImportedBridgeExit>>,
         imported_exits_root: Option<Digest>,
         imported_lers_root: Option<Digest>,
         imported_global_exit_root: Option<Digest>,
     ) -> Self {
         Self {
             origin_network,
-            state_root,
             prev_local_exit_root,
-            local_exit_root,
+            bridge_exits,
+            imported_bridge_exits,
             imported_exits_root,
             imported_lers_root,
             imported_global_exit_root,

--- a/crates/pessimistic-proof/src/batch_header.rs
+++ b/crates/pessimistic-proof/src/batch_header.rs
@@ -16,26 +16,57 @@ use crate::{bridge_exit::NetworkId, keccak::Digest, BridgeExit};
 pub struct BatchHeader {
     /// The origin network which emitted this BatchHeader.
     pub origin_network: NetworkId,
+
+    /// The start slot height and end block height for the batch. Unsure if required
+    /// pub start_block_height: u32,
+    /// pub end_block_height u32,
+
+    /// The state root produced by the current block
+    pub state_root: Option<Digest>,
+
     /// The initial local exit root.
-    pub prev_local_exit_root: Digest,
-    /// The set of bridge exits emitted by the origin network.
-    pub bridge_exits: Vec<BridgeExit>,
-    /// The set of imported bridge exits for which the origin network is the target.
-    pub imported_bridge_exits: Vec<BridgeExit>,
+    pub prev_local_exit_root: Option<Digest>,
+    /// The updated local exit root
+    pub local_exit_root: Digest,
+
+    /// A commitment to the set of imported bridge exits for which the origin network is the target.
+    pub imported_exits_root: Option<Digest>,
+
+    /// A commitment to the set of imported local exit roots
+    pub imported_lers_root: Option<Digest>,
+
+    /// An imported global exit root, used to process deposits from Ethereum
+    pub imported_global_exit_root: Option<Digest>,
+
+    /// A validity proof verifying transaction execution
+    ///pub validity_proof: Option<ValidityProof>,
+
+    /// A consensus proof for the latest block
+    ///pub consensus_proof: Option<ConsensusProof>,
+
+    /// The signature that commits to the state transition.
+    ///pub signature: (),
 }
 
 impl BatchHeader {
     /// Creates a new [`BatchHeader`].
     pub fn new(
         origin_network: NetworkId,
-        prev_local_exit_root: Digest,
-        bridge_exits: Vec<BridgeExit>,
+        state_root: Option<Digest>,
+        prev_local_exit_root: Option<Digest>,
+        local_exit_root: Digest,
+        imported_exits_root: Option<Digest>,
+        imported_lers_root: Option<Digest>,
+        imported_global_exit_root: Option<Digest>,
     ) -> Self {
         Self {
             origin_network,
+            state_root,
             prev_local_exit_root,
-            bridge_exits,
-            imported_bridge_exits: Default::default(),
+            local_exit_root,
+            imported_exits_root,
+            imported_lers_root,
+            imported_global_exit_root,
         }
     }
 }

--- a/crates/pessimistic-proof/src/bridge_exit.rs
+++ b/crates/pessimistic-proof/src/bridge_exit.rs
@@ -24,7 +24,7 @@ impl TokenInfo {
     }
 }
 
-/// Represents a token bridge exit from the network.
+/// Represents a token bridge exit from the local network.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BridgeExit {
     pub leaf_type: u8,
@@ -32,7 +32,7 @@ pub struct BridgeExit {
     /// Unique ID for the token being transferred.
     pub token_info: TokenInfo,
 
-    /// Network which the token is transfered to
+    /// Network which the token is transferred to
     pub dest_network: NetworkId,
     /// Address which will own the received token
     pub dest_address: Address,

--- a/crates/pessimistic-proof/src/imported_bridge_exit.rs
+++ b/crates/pessimistic-proof/src/imported_bridge_exit.rs
@@ -21,7 +21,7 @@ pub struct ImportedBridgeExit {
 
     /// The Network ID for the foreign network. May not be strictly
     /// necessary depending on the final structure of the Imprted Local Exit Root
-    pub origin_network_id:NetworkId,
+    pub sending_network:NetworkId,
 
     /// The Imported Local Exit Root for the Local Exit Tree containing this bridge exit.
     pub imported_local_exit_root:KeccakDigest,
@@ -32,6 +32,27 @@ pub struct ImportedBridgeExit {
     /// The inclusion proof of the imported bridge exit in the foreign local exit root
     /// TODO: create a type for the inclusion proof of a leaf in an LET
     pub inclusion_proof:Vec<KeccakDigest>
+}
+
+impl ImportedBridgeExit {
+    /// Creates a new [`ImportedBridgeExit`].
+    pub fn new(
+        bridge_exit: BridgeExit,
+        sending_network: NetworkId,
+        imported_local_exit_root:KeccakDigest,
+        leaf_index: u32,
+        inclusion_proof:Vec<KeccakDigest>,
+    ) -> Self {
+        Self {
+            bridge_exit,
+            sending_network,
+            imported_local_exit_root,
+            leaf_index,
+            inclusion_proof,
+        }
+    }
+
+    // TODO: write method to verify inclusion proof in provided foreign LER
 }
 
 

--- a/crates/pessimistic-proof/src/imported_bridge_exit.rs
+++ b/crates/pessimistic-proof/src/imported_bridge_exit.rs
@@ -52,7 +52,11 @@ impl ImportedBridgeExit {
         }
     }
 
-    // TODO: write method to verify inclusion proof in provided foreign LER
+    /// Verifies that the provided inclusion path is valid and consistent with the provided LER
+    /// TODO: write method to verify inclusion proof in provided foreign LER
+    pub fn verify_path(&mut self) -> bool {
+        return true;
+    }
 }
 
 

--- a/crates/pessimistic-proof/src/imported_bridge_exit.rs
+++ b/crates/pessimistic-proof/src/imported_bridge_exit.rs
@@ -1,0 +1,37 @@
+use std::ops::Deref;
+
+use reth_primitives::{revm_primitives::bitvec::view::BitViewSized, Address, U256};
+use serde::{Deserialize, Serialize};
+
+use crate::keccak::{keccak256, keccak256_combine, Digest as KeccakDigest};
+
+use crate::{
+    BridgeExit,
+    bridge_exit::{NetworkId},
+};
+
+
+/// Represents a token bridge exit originating on another network but claimed on the current network.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportedBridgeExit {
+    /// The bridge exit initiated on another network, called the "foreign" network.
+    /// Need to verify that the destination network matches the current network, and that
+    /// the bridge exit is included in an imported LER
+    pub bridge_exit:BridgeExit,
+
+    /// The Network ID for the foreign network. May not be strictly
+    /// necessary depending on the final structure of the Imprted Local Exit Root
+    pub origin_network_id:NetworkId,
+
+    /// The Imported Local Exit Root for the Local Exit Tree containing this bridge exit.
+    pub imported_local_exit_root:KeccakDigest,
+
+    /// The index of the bridge exit in the foreign local exit tree. Used to compute the path
+    pub leaf_index: u32,
+
+    /// The inclusion proof of the imported bridge exit in the foreign local exit root
+    /// TODO: create a type for the inclusion proof of a leaf in an LET
+    pub inclusion_proof:Vec<KeccakDigest>
+}
+
+

--- a/crates/pessimistic-proof/src/lib.rs
+++ b/crates/pessimistic-proof/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod keccak;
 pub mod local_exit_tree;
+pub mod nullifier_set;
 
 mod proof;
 pub use proof::{generate_leaf_proof, LeafProofOutput, ProofError};
@@ -16,4 +17,5 @@ pub mod imported_bridge_exit;
 pub use imported_bridge_exit::{ImportedBridgeExit};
 
 pub mod local_state;
+
 pub use local_state::LocalNetworkState;

--- a/crates/pessimistic-proof/src/lib.rs
+++ b/crates/pessimistic-proof/src/lib.rs
@@ -7,11 +7,13 @@ pub use proof::{generate_leaf_proof, LeafProofOutput, ProofError};
 pub mod test_utils;
 
 pub mod batch_header;
-pub mod imported_bridge_exit;
 pub mod local_balance_tree;
 
 mod bridge_exit;
 pub use bridge_exit::{BridgeExit, NetworkId, TokenInfo};
+
+pub mod imported_bridge_exit;
+pub use imported_bridge_exit::{ImportedBridgeExit};
 
 pub mod local_state;
 pub use local_state::LocalNetworkState;

--- a/crates/pessimistic-proof/src/lib.rs
+++ b/crates/pessimistic-proof/src/lib.rs
@@ -6,7 +6,7 @@ pub use proof::{generate_leaf_proof, LeafProofOutput, ProofError};
 
 pub mod test_utils;
 
-pub mod certificate;
+pub mod batch_header;
 pub mod local_balance_tree;
 
 mod bridge_exit;

--- a/crates/pessimistic-proof/src/lib.rs
+++ b/crates/pessimistic-proof/src/lib.rs
@@ -7,6 +7,7 @@ pub use proof::{generate_leaf_proof, LeafProofOutput, ProofError};
 pub mod test_utils;
 
 pub mod batch_header;
+pub mod imported_bridge_exit;
 pub mod local_balance_tree;
 
 mod bridge_exit;

--- a/crates/pessimistic-proof/src/local_balance_tree.rs
+++ b/crates/pessimistic-proof/src/local_balance_tree.rs
@@ -23,6 +23,7 @@ use crate::{
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BalanceTreeByNetwork(BTreeMap<NetworkId, BalanceTree>);
 
+// TODO: we should be able to remove all logic for maintaining a global balance tree, as this is no longer necessary.
 impl BalanceTreeByNetwork {
     /// Creates a new empty [`BalanceTreeByNetwork`].
     pub fn new() -> Self {

--- a/crates/pessimistic-proof/src/local_balance_tree.rs
+++ b/crates/pessimistic-proof/src/local_balance_tree.rs
@@ -24,6 +24,7 @@ use crate::{
 pub struct BalanceTreeByNetwork(BTreeMap<NetworkId, BalanceTree>);
 
 // TODO: we should be able to remove all logic for maintaining a global balance tree, as this is no longer necessary.
+// The only balance tree that we care about is the one for the current network!
 impl BalanceTreeByNetwork {
     /// Creates a new empty [`BalanceTreeByNetwork`].
     pub fn new() -> Self {

--- a/crates/pessimistic-proof/src/local_state.rs
+++ b/crates/pessimistic-proof/src/local_state.rs
@@ -48,6 +48,7 @@ impl LocalNetworkState {
         // 3: each imported_local_exit_root in an imported_bridge_exit is contained in the imported_lers set in the batch_header
         if let Some(imported_bridge_exits) = &batch_header.imported_bridge_exits {
             imported_bridge_exits.iter().for_each(|imported_bridge_exit| {
+                // TODO: check provided inclusion path in the imported_bridge_exit
                 // TODO: check that the LER for the imported bridge exit is contained in the batch header
                 // TODO: update nullifier set
                 self.balance_tree.deposit(imported_bridge_exit.bridge_exit.token_info, imported_bridge_exit.bridge_exit.amount);

--- a/crates/pessimistic-proof/src/local_state.rs
+++ b/crates/pessimistic-proof/src/local_state.rs
@@ -42,9 +42,14 @@ impl LocalNetworkState {
         });
 
         // Apply the imported bridge exits
-        // TODO: omitting two required checks: 1: that each imported bridge exit is valid according to the imported local exit roots, and that 2: each imported bridge exit has not been claimed in the nullifier set
+        // TODO: omitting three required checks:
+        // 1: that each imported bridge exit is valid according to the imported local exit roots,
+        // 2: each imported bridge exit has not been claimed in the nullifier set,
+        // 3: each imported_local_exit_root in an imported_bridge_exit is contained in the imported_lers set in the batch_header
         if let Some(imported_bridge_exits) = &batch_header.imported_bridge_exits {
             imported_bridge_exits.iter().for_each(|imported_bridge_exit| {
+                // TODO: check that the LER for the imported bridge exit is contained in the batch header
+                // TODO: update nullifier set
                 self.balance_tree.deposit(imported_bridge_exit.bridge_exit.token_info, imported_bridge_exit.bridge_exit.amount);
             })
         }

--- a/crates/pessimistic-proof/src/nullifier_set/mod.rs
+++ b/crates/pessimistic-proof/src/nullifier_set/mod.rs
@@ -7,8 +7,9 @@ pub struct NullifierSet(BTreeMap<NetworkId, NetworkNullifierSet>);
 
 // TODO: implement hashing for the nullifier set. Insert the root of each non-empty NetworkNullifierSet at the index in NullifierSet matching foreign_network_id
 
-/// The nullifier sets for each network. These can be represented as 0-initialized bit masks,
-/// where each index corresponds to an index in the network's local exit tree.
+/// The nullifier sets for each foreign network tracked by the local network.
+/// Each network nullifier set can be represented as 0-initialized bit masks,
+/// where each index corresponds to an index in the foreign network's local exit tree.
 /// The value at an index is 1 if the message has been claimed by the local network,
 /// and 0 if it has not.
 pub struct NetworkNullifierSet <const TREE_DEPTH: usize = 32> {

--- a/crates/pessimistic-proof/src/nullifier_set/mod.rs
+++ b/crates/pessimistic-proof/src/nullifier_set/mod.rs
@@ -1,0 +1,19 @@
+use std::collections::BTreeMap;
+use crate::bridge_exit::{NetworkId};
+
+/// A commitment to the set of per-network nullifier sets maintained by the local network
+/// TODO: determine the appropriate TREE_DEPTH - unlikely that we'll have 4 billion chains :)
+pub struct NullifierSet(BTreeMap<NetworkId, NetworkNullifierSet>);
+
+// TODO: implement hashing for the nullifier set. Insert the root of each non-empty NetworkNullifierSet at the index in NullifierSet matching foreign_network_id
+
+/// The nullifier sets for each network. These can be represented as 0-initialized bit masks,
+/// where each index corresponds to an index in the network's local exit tree.
+/// The value at an index is 1 if the message has been claimed by the local network,
+/// and 0 if it has not.
+pub struct NetworkNullifierSet <const TREE_DEPTH: usize = 32> {
+    /// The set of indices that have been claimed.
+    pub claimed_indices: Vec<u32>,
+}
+
+// TODO: implement hashing for the network nullifier set. Would recommend a zero-initialized tree with num_leaves = first claimed index, then adding zero-initialized subtrees as the number of leaves increases. We can update a claim by taking the current path to the index and re-hashing.

--- a/crates/pessimistic-proof/src/proof.rs
+++ b/crates/pessimistic-proof/src/proof.rs
@@ -14,7 +14,7 @@ pub type ExitRoot = Digest;
 pub type BalanceRoot = Digest;
 pub type LeafProofOutput = (ExitRoot, BalanceRoot);
 
-/// Proves that the given [`Certificate`] can be applied on the given [`LocalNetworkState`].
+/// Proves that the given [`BatchHeader`] can be applied on the given [`LocalNetworkState`].
 pub fn generate_leaf_proof(
     initial_network_state: LocalNetworkState,
     batch_header: &BatchHeader,

--- a/crates/pessimistic-proof/src/proof.rs
+++ b/crates/pessimistic-proof/src/proof.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bridge_exit::NetworkId, certificate::Certificate, keccak::Digest,
+    bridge_exit::NetworkId, batch_header::BatchHeader, keccak::Digest,
     local_state::LocalNetworkState,
 };
 
@@ -17,11 +17,11 @@ pub type LeafProofOutput = (ExitRoot, BalanceRoot);
 /// Proves that the given [`Certificate`] can be applied on the given [`LocalNetworkState`].
 pub fn generate_leaf_proof(
     initial_network_state: LocalNetworkState,
-    certificate: &Certificate,
+    batch_header: &BatchHeader,
 ) -> Result<LeafProofOutput, ProofError> {
     let mut network_state = initial_network_state;
 
-    let (new_exit_root, new_balance_root) = network_state.apply_certificate(certificate)?;
+    let (new_exit_root, new_balance_root) = network_state.apply_batch_header(batch_header)?;
 
     Ok((new_exit_root, new_balance_root))
 }

--- a/crates/pessimistic-proof/tests/leaf_proof.rs
+++ b/crates/pessimistic-proof/tests/leaf_proof.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use lazy_static::lazy_static;
 use pessimistic_proof::{
-    certificate::Certificate,
+    batch_header::BatchHeader,
     generate_leaf_proof,
     local_balance_tree::{Balance, BalanceTree, Deposit},
     local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
@@ -52,11 +52,16 @@ fn make_tx(_from: u32, to: u32, token: &TokenInfo, amount: u32) -> BridgeExit {
     )
 }
 
-fn state_transition(v: Amounts) -> Certificate {
-    Certificate::new(
+
+fn state_transition(v: Amounts) -> BatchHeader {
+    BatchHeader::new(
         *NETWORK_A,
         DUMMY_LET.get_root(),
         vec![make_tx(0, 1, &ETH, v.eth), make_tx(0, 1, &USDC, v.usdc)],
+        None,
+        None,
+        None,
+        None,
     )
 }
 


### PR DESCRIPTION
# Description

Please do not merge! This PR is in-progress and designed to give an idea of the changes required to move from global to local pessimistic proof generation. This is highly beneficial as it removes the requirement for networks to sync with global state, or for all AggLayer nodes to maintain complete Local Balance Trees for every chain.

## Additions and Changes

Added the Nullifier Set, ImportedBridgeExit, added additional public inputs to the proof, renamed Certificate to BatchHeader and added additional fields to the struct, and modified the local state computation used in the proof.

Because we're exposing the imported local exit roots as public inputs, we're preparing for the introduction of fast interop between networks.

### New feature (non-breaking change which adds functionality)

Local PP generation, fast tinerop.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
