### PR TITLE
feat: adding default config and switch format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,11 +53,15 @@ dependencies = [
 name = "agglayer"
 version = "0.1.0"
 dependencies = [
+ "agglayer-config",
  "agglayer-node",
  "anyhow",
+ "assert_cmd",
  "clap",
  "dotenvy",
+ "insta",
  "tokio",
+ "toml 0.8.14",
  "tower",
 ]
 
@@ -116,11 +120,12 @@ dependencies = [
  "ethers",
  "ethers-gcp-kms-signer",
  "jsonrpsee",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "serde_with",
  "thiserror",
- "toml",
+ "toml 0.8.14",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -172,7 +177,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml",
+ "toml 0.8.14",
  "tower",
  "tower-http",
  "tracing",
@@ -697,6 +702,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1142,17 @@ checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2",
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.7",
+ "serde",
 ]
 
 [[package]]
@@ -1711,6 +1742,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,6 +1815,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenvy"
@@ -2043,7 +2092,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.71",
- "toml",
+ "toml 0.8.14",
  "walkdir",
 ]
 
@@ -3161,6 +3210,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,6 +3698,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4732,6 +4801,43 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "prettyplease"
@@ -6148,6 +6254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6778,6 +6890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "thiserror"
 version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6992,6 +7110,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crates/agglayer-config/Cargo.toml
+++ b/crates/agglayer-config/Cargo.toml
@@ -16,6 +16,7 @@ tracing.workspace = true
 url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
+pretty_assertions = "1.4.0"
 serde_json = { workspace = true }
 toml.workspace = true
 

--- a/crates/agglayer-config/src/auth.rs
+++ b/crates/agglayer-config/src/auth.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use serde::de::{self, Deserializer};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, NoneAsEmptyString};
 
 /// The transaction management configuration.
@@ -18,8 +18,7 @@ use serde_with::{serde_as, NoneAsEmptyString};
 ///   pick up credentials.
 /// - If the `GOOGLE_APPLICATION_CREDENTIALS` environment is set, attempt to
 ///   load a service account JSON from this path.
-#[derive(Deserialize, Debug)]
-#[serde(untagged, rename_all = "lowercase")]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum AuthConfig {
     Local(LocalConfig),
     GcpKms(GcpKmsConfig),
@@ -35,17 +34,18 @@ impl Default for AuthConfig {
 ///
 /// It includes private keys for a local wallet.
 #[serde_as]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "PascalCase")]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct LocalConfig {
     pub private_keys: Vec<PrivateKey>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "testutils"), derive(Default))]
-#[serde(rename_all = "PascalCase")]
 pub struct PrivateKey {
+    #[serde(alias = "Path")]
     pub path: PathBuf,
+    #[serde(alias = "Password")]
     pub password: String,
 }
 
@@ -53,9 +53,9 @@ pub struct PrivateKey {
 ///
 /// It includes kms config.
 #[serde_as]
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "testutils"), derive(Default))]
-#[serde(rename_all = "PascalCase")]
+#[serde(rename_all = "kebab-case")]
 pub struct GcpKmsConfig {
     #[serde(rename = "ProjectId")]
     #[serde_as(as = "NoneAsEmptyString")]

--- a/crates/agglayer-config/src/certificate_orchestrator.rs
+++ b/crates/agglayer-config/src/certificate_orchestrator.rs
@@ -1,13 +1,16 @@
 use prover::ProverConfig;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub mod prover;
 
 /// The CertificateOrchestrator configuration.
-#[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "PascalCase")]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct CertificateOrchestrator {
-    #[serde(default = "default_input_backpressure_buffer_size_default")]
+    #[serde(
+        alias = "InputBackpressureBufferSize",
+        default = "default_input_backpressure_buffer_size_default"
+    )]
     pub input_backpressure_buffer_size: usize,
 
     #[serde(default = "default_prover_config_default")]

--- a/crates/agglayer-config/src/certificate_orchestrator/prover.rs
+++ b/crates/agglayer-config/src/certificate_orchestrator/prover.rs
@@ -1,9 +1,18 @@
 use serde::{Deserialize, Serialize};
 
 /// The different prover configuration.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum ProverConfig {
-    SP1Network {},
+    #[serde(rename = "sp1-local")]
     SP1Local {},
+    #[serde(rename = "sp1-mock")]
     SP1Mock {},
+    #[serde(rename = "sp1-network")]
+    SP1Network {},
+}
+
+impl Default for ProverConfig {
+    fn default() -> Self {
+        Self::SP1Local {}
+    }
 }

--- a/crates/agglayer-config/src/epoch.rs
+++ b/crates/agglayer-config/src/epoch.rs
@@ -3,9 +3,10 @@ use std::time::Duration;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// The Epoch configuration.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "PascalCase")]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub enum Epoch {
+    #[serde(alias = "TimeClock")]
     TimeClock(TimeClockConfig),
 }
 
@@ -15,13 +16,14 @@ impl Default for Epoch {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct TimeClockConfig {
     #[serde(
         default = "default_epoch_duration",
         serialize_with = "serialize_duration",
         deserialize_with = "deserialize_duration",
-        rename = "EpochDuration"
+        alias = "EpochDuration"
     )]
     pub epoch_duration: Duration,
 }
@@ -63,12 +65,12 @@ mod tests {
         let epoch = Epoch::TimeClock(TimeClockConfig::default());
         let serialized = serde_json::to_string(&epoch).unwrap();
 
-        assert_eq!(serialized, r#"{"TimeClock":{"EpochDuration":5}}"#);
+        assert_eq!(serialized, r#"{"time-clock":{"epoch-duration":5}}"#);
     }
 
     #[test]
     fn deserialize_epoch() {
-        let config = r#"{"TimeClock":{"EpochDuration":3600}}"#;
+        let config = r#"{"time-clock":{"epoch-duration":3600}}"#;
 
         let expected_duration = Duration::from_secs(3600);
         let epoch: Epoch = serde_json::from_str(config).unwrap();

--- a/crates/agglayer-config/src/l1.rs
+++ b/crates/agglayer-config/src/l1.rs
@@ -1,9 +1,10 @@
 use ethers::types::Address;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 /// The L1 configuration.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct L1 {
     #[serde(rename = "ChainID")]
     pub chain_id: u64,
@@ -13,7 +14,6 @@ pub struct L1 {
     pub rollup_manager_contract: Address,
 }
 
-#[cfg(any(test, feature = "testutils"))]
 impl Default for L1 {
     fn default() -> Self {
         // Values are coming from https://github.com/0xPolygon/agglayer/blob/main/config/default.go#L11

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use auth::deserialize_auth;
 use outbound::OutboundConfig;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use shutdown::ShutdownConfig;
 use url::Url;
 
@@ -17,7 +17,7 @@ pub(crate) const DEFAULT_IP: std::net::Ipv4Addr = std::net::Ipv4Addr::new(0, 0, 
 
 pub(crate) mod auth;
 pub mod certificate_orchestrator;
-pub(crate) mod epoch;
+pub mod epoch;
 pub(crate) mod l1;
 pub mod log;
 pub(crate) mod outbound;
@@ -32,36 +32,36 @@ pub use log::Log;
 pub use rpc::RpcConfig;
 
 /// The Agglayer configuration.
-#[derive(Deserialize, Debug)]
-#[cfg_attr(any(test, feature = "testutils"), derive(Default))]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct Config {
     /// A map of Zkevm node RPC endpoints for each rollup.
     ///
     /// The key is the rollup ID, and the value is the URL of the associated RPC
     /// endpoint.
-    #[serde(rename = "FullNodeRPCs", deserialize_with = "deserialize_rpc_map")]
+    #[serde(alias = "FullNodeRPCs", deserialize_with = "deserialize_rpc_map")]
     pub full_node_rpcs: HashMap<u32, Url>,
     /// The log configuration.
-    #[serde(rename = "Log")]
+    #[serde(alias = "Log")]
     pub log: Log,
     /// The local RPC server configuration.
-    #[serde(rename = "RPC")]
+    #[serde(alias = "RPC")]
     pub rpc: RpcConfig,
     /// The configuration for every outbound network component.
     #[serde(default)]
     pub outbound: OutboundConfig,
     /// The L1 configuration.
-    #[serde(rename = "L1")]
+    #[serde(alias = "L1")]
     pub l1: L1,
     /// The authentication configuration.
     #[serde(alias = "EthTxManager", default, deserialize_with = "deserialize_auth")]
     pub auth: AuthConfig,
     /// Telemetry configuration.
-    #[serde(rename = "Telemetry")]
+    #[serde(alias = "Telemetry")]
     pub telemetry: TelemetryConfig,
 
     /// The Epoch configuration.
-    #[serde(rename = "Epoch", default = "Epoch::default")]
+    #[serde(alias = "Epoch", default = "Epoch::default")]
     pub epoch: Epoch,
 
     /// The list of configuration options used during shutdown.
@@ -69,7 +69,7 @@ pub struct Config {
     pub shutdown: ShutdownConfig,
 
     /// The certificate orchestrator configuration.
-    #[serde(rename = "CertificateOrchestrator", default)]
+    #[serde(alias = "CertificateOrchestrator", default)]
     pub certificate_orchestrator: certificate_orchestrator::CertificateOrchestrator,
 }
 

--- a/crates/agglayer-config/src/log.rs
+++ b/crates/agglayer-config/src/log.rs
@@ -1,23 +1,24 @@
 use std::{fmt::Display, path::PathBuf};
 
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use tracing_subscriber::{fmt::writer::BoxMakeWriter, EnvFilter};
 
 /// The log configuration.
-#[derive(Deserialize, Debug, Clone, Default)]
-#[serde(rename_all = "PascalCase")]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct Log {
     /// The `RUST_LOG` environment variable will take precedence over the
     /// configuration log level.
-    #[serde(default)]
+    #[serde(default, alias = "Level")]
     pub level: LogLevel,
+    #[serde(alias = "Outputs")]
     pub outputs: Vec<LogOutput>,
-    #[serde(default)]
+    #[serde(default, alias = "Format")]
     pub format: LogFormat,
 }
 
 /// The log format.
-#[derive(Deserialize, Debug, Default, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum LogFormat {
     #[default]
@@ -26,7 +27,7 @@ pub enum LogFormat {
 }
 
 /// The log level.
-#[derive(Deserialize, Debug, Default, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     Trace,
@@ -67,7 +68,7 @@ impl From<LogLevel> for EnvFilter {
 /// specify the output location as a string, which is then parsed into the
 /// appropriate enum variant. If the string is not recognized to be either
 /// `stdout` or `stderr`, it is assumed to be a file path.
-#[derive(Debug, Clone, Default)]
+#[derive(Serialize, Debug, Clone, Default, PartialEq, Eq)]
 pub enum LogOutput {
     #[default]
     Stdout,

--- a/crates/agglayer-config/src/outbound.rs
+++ b/crates/agglayer-config/src/outbound.rs
@@ -1,20 +1,21 @@
 use std::time::Duration;
 
 use serde::Deserialize;
+use serde::Serialize;
 use serde_with::serde_as;
 use serde_with::DurationSeconds;
 
 /// Outbound configuration.
-#[derive(Default, Debug, Deserialize)]
-#[serde(rename = "outbound")]
+#[derive(Serialize, Default, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename = "outbound", rename_all = "kebab-case")]
 pub struct OutboundConfig {
     pub rpc: OutboundRpcConfig,
 }
 
 /// Outbound RPC configuration that is used to configure the outbound RPC
 /// clients and their RPC calls.
-#[derive(Default, Debug, Deserialize)]
-#[serde(rename = "rpc")]
+#[derive(Serialize, Default, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename = "rpc", rename_all = "kebab-case")]
 pub struct OutboundRpcConfig {
     /// Outbound configuration of the RPC settle function call.
     pub settle: OutboundRpcSettleConfig,
@@ -23,8 +24,8 @@ pub struct OutboundRpcConfig {
 /// Outbound RPC settle configuration that is used to configure the outbound
 /// RPC settle function call.
 #[serde_as]
-#[derive(Debug, Deserialize)]
-#[serde(rename = "settle")]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename = "settle", rename_all = "kebab-case")]
 pub struct OutboundRpcSettleConfig {
     /// Maximum number of retries for the transaction.
     #[serde(default = "default_rpc_retries")]
@@ -84,7 +85,7 @@ mod tests {
 
             let toml = r#"
                 [outbound.rpc.settle]
-                max_retries = 10
+                max-retries = 10
                 "#;
 
             let config = toml::from_str::<DummyContainer>(toml).unwrap();
@@ -113,8 +114,8 @@ mod tests {
                 #[test]
                 fn test_custom() {
                     let toml = r#"
-                        max_retries = 10
-                        retry_interval = 1
+                        max-retries = 10
+                        retry-interval = 1
                         confirmations = 5
                         "#;
 

--- a/crates/agglayer-config/src/rpc.rs
+++ b/crates/agglayer-config/src/rpc.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, net::Ipv4Addr, str::FromStr, time::Duration};
 use jsonrpsee::core::TEN_MB_SIZE_BYTES;
 use serde::{
     de::{MapAccess, Visitor},
-    Deserialize, Deserializer,
+    Deserialize, Deserializer, Serialize,
 };
 use url::Url;
 
@@ -11,14 +11,18 @@ use url::Url;
 const DEFAULT_PORT: u16 = 9090;
 
 /// The local RPC server configuration.
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "PascalCase")]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct RpcConfig {
     /// If the `PORT` environment variable is set, it will take precedence over
     /// the configuration file.
-    #[serde(default = "default_port", deserialize_with = "deserialize_port")]
+    #[serde(
+        alias = "Port",
+        default = "default_port",
+        deserialize_with = "deserialize_port"
+    )]
     pub port: u16,
-    #[serde(default = "default_host")]
+    #[serde(alias = "Host", default = "default_host")]
     pub host: Ipv4Addr,
 
     // Skip serialization of these fields as we don't need to expose them in the

--- a/crates/agglayer-config/src/shutdown.rs
+++ b/crates/agglayer-config/src/shutdown.rs
@@ -1,11 +1,13 @@
 use std::time::Duration;
 
 use serde::Deserialize;
+use serde::Serialize;
 use serde_with::serde_as;
 use serde_with::DurationSeconds;
 
 #[serde_as]
-#[derive(Deserialize, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct ShutdownConfig {
     #[serde(default = "default_shutdown_runtime_timeout")]
     #[serde_as(as = "DurationSeconds")]

--- a/crates/agglayer-config/src/telemetry.rs
+++ b/crates/agglayer-config/src/telemetry.rs
@@ -1,11 +1,11 @@
 use std::net::SocketAddr;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::DEFAULT_IP;
 
-#[derive(Deserialize, Debug, Clone, Copy)]
-#[serde(rename_all = "PascalCase")]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct TelemetryConfig {
     #[serde(rename = "PrometheusAddr", default = "default_metrics_api_addr")]
     pub addr: SocketAddr,

--- a/crates/agglayer-config/tests/backward_compatibility-kurtosis.toml
+++ b/crates/agglayer-config/tests/backward_compatibility-kurtosis.toml
@@ -1,0 +1,32 @@
+[FullNodeRPCs]
+1 = "http://zkevm-node:8123"
+
+[RPC]
+Port = 8080
+Host = "0.0.0.0"
+ReadTimeout = "60s"
+WriteTimeout = "60s"
+MaxRequestsPerIPAndSecond = 5000
+
+[Log]
+Environment = "production" # "production" or "development"
+Level = "info"
+Outputs = ["stderr"]
+Format = "json"
+
+[EthTxManager]
+FrequencyToMonitorTxs = "1s"
+WaitTxToBeMined = "2m"
+ForcedGas = 0
+GasPriceMarginFactor = 1
+MaxGasPriceLimit = 0
+PrivateKeys = [{ Path = "/etc/zkevm/agglayer.keystore", Password = "test" }]
+KMSKeyName = ""                                                              # Disable for local
+
+[L1]
+ChainID = 0
+NodeURL = "https://rpc-cdk-validium-cardona-03-zkevm.polygondev.tools"
+RollupManagerContract = "0x32d33D5137a7cFFb54c5Bf8371172bcEc5f310ff"
+
+[Telemetry]
+PrometheusAddr = "0.0.0.0:8080"

--- a/crates/agglayer-config/tests/backward_compatibility.rs
+++ b/crates/agglayer-config/tests/backward_compatibility.rs
@@ -1,0 +1,109 @@
+use std::{io::Read, net::SocketAddr, path::PathBuf, str::FromStr, time::Duration};
+
+use agglayer_config::{
+    epoch::TimeClockConfig,
+    log::{LogFormat, LogOutput},
+    AuthConfig, Config, Epoch, PrivateKey,
+};
+use ethers::types::H160;
+use pretty_assertions::assert_eq;
+use url::Url;
+
+fn backward_compatibility_config(file: &str) -> PathBuf {
+    env!("CARGO_MANIFEST_DIR")
+        .parse::<PathBuf>()
+        .unwrap()
+        .join("./tests/")
+        .join(file)
+}
+
+#[test]
+fn all_config() {
+    let mut reader = String::new();
+    let mut file =
+        std::fs::File::open(backward_compatibility_config("backward_compatibility.toml")).unwrap();
+    file.read_to_string(&mut reader).unwrap();
+
+    let config: Config = toml::from_str(&reader).unwrap();
+
+    let mut base_config = Config::default();
+
+    base_config
+        .full_node_rpcs
+        .insert(1, Url::parse("http://zkevm-node:8123").unwrap());
+    // Update log
+    base_config.log.format = LogFormat::Json;
+
+    // Update rpc
+    base_config.outbound.rpc.settle.max_retries = 10;
+    base_config.outbound.rpc.settle.retry_interval = Duration::from_secs(10);
+    base_config.outbound.rpc.settle.confirmations = 10;
+
+    // Update L1
+    base_config.l1.chain_id = 1338;
+
+    // Update telemetry
+    base_config.telemetry.addr = SocketAddr::V4(std::net::SocketAddrV4::new(
+        std::net::Ipv4Addr::new(0, 0, 0, 0),
+        3030,
+    ));
+
+    base_config.epoch = Epoch::TimeClock(TimeClockConfig {
+        epoch_duration: Duration::from_secs(10),
+    });
+    base_config.shutdown.runtime_timeout = Duration::from_secs(10);
+    base_config
+        .certificate_orchestrator
+        .input_backpressure_buffer_size = 10000;
+
+    base_config.auth = AuthConfig::Local(agglayer_config::LocalConfig {
+        private_keys: vec![PrivateKey {
+            path: PathBuf::from_str("/pk/agglayer.keystore").unwrap(),
+            password: "testonly".into(),
+        }],
+    });
+    assert_eq!(config, base_config);
+}
+
+#[test]
+fn kurtosis() {
+    let mut reader = String::new();
+    let mut file = std::fs::File::open(backward_compatibility_config(
+        "backward_compatibility-kurtosis.toml",
+    ))
+    .unwrap();
+    file.read_to_string(&mut reader).unwrap();
+
+    let config: Config = toml::from_str(&reader).unwrap();
+
+    let mut base_config = Config::default();
+
+    base_config
+        .full_node_rpcs
+        .insert(1, Url::parse("http://zkevm-node:8123").unwrap());
+
+    base_config.log.format = LogFormat::Json;
+    base_config.log.outputs = vec![LogOutput::Stderr];
+
+    base_config.rpc.port = 8080;
+
+    base_config.l1.node_url =
+        Url::parse("https://rpc-cdk-validium-cardona-03-zkevm.polygondev.tools").unwrap();
+    base_config.l1.rollup_manager_contract =
+        H160::from_str("0x32d33D5137a7cFFb54c5Bf8371172bcEc5f310ff").unwrap();
+    base_config.l1.chain_id = 0;
+
+    base_config.telemetry.addr = SocketAddr::V4(std::net::SocketAddrV4::new(
+        std::net::Ipv4Addr::new(0, 0, 0, 0),
+        8080,
+    ));
+
+    base_config.auth = AuthConfig::Local(agglayer_config::LocalConfig {
+        private_keys: vec![PrivateKey {
+            path: PathBuf::from_str("/etc/zkevm/agglayer.keystore").unwrap(),
+            password: "test".into(),
+        }],
+    });
+
+    assert_eq!(config, base_config);
+}

--- a/crates/agglayer-config/tests/backward_compatibility.toml
+++ b/crates/agglayer-config/tests/backward_compatibility.toml
@@ -1,0 +1,36 @@
+[FullNodeRPCs]
+1 = "http://zkevm-node:8123"
+
+[Log]
+Level = "info"
+Outputs = []
+Format = "json"
+
+[RPC]
+Port = 9090
+Host = "0.0.0.0"
+
+[outbound.rpc.settle]
+max-retries = 10
+retry-interval = 10
+confirmations = 10
+
+[L1]
+ChainID = 1338
+NodeURL = "http://zkevm-mock-l1-network:8545/"
+RollupManagerContract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+
+[auth]
+PrivateKeys = [{ Path = "/pk/agglayer.keystore", Password = "testonly" }]
+
+[Telemetry]
+PrometheusAddr = "0.0.0.0:3030"
+
+[Epoch.TimeClock]
+EpochDuration = 10
+
+[shutdown]
+runtime-timeout = 10
+
+[CertificateOrchestrator]
+InputBackpressureBufferSize = 10000

--- a/crates/agglayer/Cargo.toml
+++ b/crates/agglayer/Cargo.toml
@@ -8,6 +8,12 @@ anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 dotenvy.workspace = true
 tokio = { workspace = true, features = ["full"] }
+toml.workspace = true
+tower = { workspace = true, features = ["full"] }
 
 agglayer-node = { path = "../agglayer-node" }
-tower = { workspace = true, features = ["full"] }
+agglayer-config = { path = "../agglayer-config" }
+
+[dev-dependencies]
+assert_cmd = "2.0.14"
+insta = { version = "1.39.0", features = ["toml", "yaml"] }

--- a/crates/agglayer/src/cli.rs
+++ b/crates/agglayer/src/cli.rs
@@ -17,4 +17,6 @@ pub(crate) enum Commands {
         #[arg(long, short, value_hint = ValueHint::FilePath, default_value = "agglayer.toml", env = "CONFIG_PATH")]
         cfg: PathBuf,
     },
+
+    Config {},
 }

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -10,6 +10,10 @@ fn main() -> anyhow::Result<()> {
 
     match cli.cmd {
         cli::Commands::Run { cfg } => agglayer_node::main(cfg)?,
+        cli::Commands::Config {} => println!(
+            "{}",
+            toml::to_string(&agglayer_config::Config::default()).unwrap()
+        ),
     }
 
     Ok(())

--- a/crates/agglayer/tests/config.rs
+++ b/crates/agglayer/tests/config.rs
@@ -1,0 +1,15 @@
+use assert_cmd::Command;
+
+#[test]
+fn config_display() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("agglayer")?;
+    cmd.arg("config");
+
+    let output = cmd.assert().success();
+
+    let result: &str = std::str::from_utf8(&output.get_output().stdout)?;
+
+    insta::assert_snapshot!(result);
+
+    Ok(())
+}

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -1,0 +1,41 @@
+---
+source: crates/agglayer/tests/config.rs
+expression: result
+---
+[full-node-rpcs]
+
+[log]
+level = "info"
+outputs = []
+format = "pretty"
+
+[rpc]
+port = 9090
+host = "0.0.0.0"
+
+[outbound.rpc.settle]
+max-retries = 3
+retry-interval = 7
+confirmations = 1
+
+[l1]
+ChainID = 1337
+NodeURL = "http://zkevm-mock-l1-network:8545/"
+RollupManagerContract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+
+[auth.Local]
+private-keys = []
+
+[telemetry]
+PrometheusAddr = "0.0.0.0:3000"
+
+[epoch.time-clock]
+epoch-duration = 5
+
+[shutdown]
+runtime-timeout = 5
+
+[certificate-orchestrator]
+input-backpressure-buffer-size = 1000
+
+[certificate-orchestrator.prover.sp1-local]


### PR DESCRIPTION
# Description

This PR is adding a `default` mode to the configuration, a CLI command to generate a default `config` and it switches the format from `PascalCase/lowercase` to `kebab-case`. It is related to the discussion #147 

There are backward compatibility tests in the config crate to cover most of the config used currently.
More can be added to prevent any regression, and when we're confident on the deprecation of the old format, we can clean them up.

This PR closes #83 and closes #89 

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
