### PR TITLE
chore: unify sp1 versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,8 @@ tracing = "0.1.40"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = { version = "2.5.2", features = ["serde"] }
+
+sp1-core = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.5-testnet" }
+sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.5-testnet" }
+sp1-recursion-core = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.5-testnet" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.5-testnet" }

--- a/crates/agglayer-aggregator-notifier/Cargo.toml
+++ b/crates/agglayer-aggregator-notifier/Cargo.toml
@@ -16,7 +16,7 @@ agglayer-certificate-orchestrator = { path = "../agglayer-certificate-orchestrat
 agglayer-config = { path = "../agglayer-config" }
 pessimistic-proof = { path = "../pessimistic-proof" }
 
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.5-testnet" }
+sp1-sdk.workspace = true
 
 [features]
 sp1-tests = ["sp1-mock", "sp1-local", "sp1-network"]

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -33,10 +33,10 @@ agglayer-certificate-orchestrator = { path = "../agglayer-certificate-orchestrat
 pessimistic-proof = { path = "../pessimistic-proof" }
 agglayer-aggregator-notifier = { path = "../agglayer-aggregator-notifier" }
 
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.5-testnet" }
-sp1-core = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.5-testnet" }
-sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.5-testnet" }
-sp1-recursion-core = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.5-testnet" }
+sp1-core.workspace = true
+sp1-recursion-compiler.workspace = true
+sp1-recursion-core.workspace = true
+sp1-sdk.workspace = true
 
 [dev-dependencies]
 jsonrpsee-test-utils = { git = "https://github.com/paritytech/jsonrpsee.git", tag = "v0.23.2" }


### PR DESCRIPTION
Specify `sp1` versions in the workspace rather than individual crates. This only applies to the top-level workspace. Unfortunately, it is not straightforward to unify host-side and prover-side sp1 version given how Cargo works.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
