### PR TITLE
build: update time to wait for e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,7 +188,7 @@ jobs:
           COMMAND: "cast rpc zkevm_batchNumber && cast rpc zkevm_virtualBatchNumber && cast rpc zkevm_verifiedBatchNumber"
           ETH_RPC_URL: ${{ env.ETH_RPC_URL }}
           INTERVAL_SECONDS: 10
-          TIMEOUT_SECONDS: 300
+          TIMEOUT_SECONDS: 600
         run: >
           ./.github/workflows/scripts/are_counters_progressing.sh
           "$COMMAND"


### PR DESCRIPTION
# Description

CI was red because of a timing issue, increasing the timeout a bit.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
