### PR TITLE
chore: move cycle tracker to new workflow

### DIFF
--- a/.github/workflows/cycle-tracker.yml
+++ b/.github/workflows/cycle-tracker.yml
@@ -1,0 +1,57 @@
+name: Cycle tracker
+
+on:
+  workflow_dispatch:
+    branches:
+      - "**"
+  schedule:
+    - cron: '0 13 * * 3'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unit:
+    name: Cycle tracker report
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install SP1UP
+        run: curl -L https://sp1.succinct.xyz | bash
+
+      - name: Install SP1 toolchain
+        run: /home/runner/.sp1/bin/sp1up
+        shell: bash
+
+      - name: Set up rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@nextest
+
+      - name: Install Anvil
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Set up rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+            cache-on-failure: true
+
+      - name: Cycle tracker report
+        env:
+          # Make sure we get useful output and a handy summary at the end
+          RUST_LOG: warn,cycle_tracker=info
+          NEXTEST_SUCCESS_OUTPUT: immediate-final
+          NEXTEST_FAILURE_OUTPUT: immediate-final
+        run: cargo nextest run --release -j1 -p pessimistic-proof --test cycle-tracker --run-ignored=all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,15 +57,6 @@ jobs:
       - name: Test
         run: cargo nextest run --workspace --nocapture && cargo test --doc --workspace
 
-      - name: Cycle tracker report
-        continue-on-error: true
-        env:
-          # Make sure we get useful output and a handy summary at the end
-          RUST_LOG: warn,cycle_tracker=info
-          NEXTEST_SUCCESS_OUTPUT: immediate-final
-          NEXTEST_FAILURE_OUTPUT: immediate-final
-        run: cargo nextest run --release -j1 -p pessimistic-proof --test cycle-tracker --run-ignored=all
-
   elf:
     if: ${{ false }}
     name: Check ELF compatibility


### PR DESCRIPTION
# Description

This PR moves the cycle tracker test to its own dedicated workflows.

We do not need to run it often, and we shouldn't slow the PR tests with it.

The workflow is configured to be runnable manually, targeting any branch.
And it is scheduled each Wednesday at 13.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
