### PR TITLE
feat: return proper error codes from RPC calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,11 @@ dependencies = [
  "futures",
  "hex",
  "hyper 0.14.29",
+ "insta",
  "jsonrpsee",
  "jsonrpsee-test-utils",
  "lazy_static",
+ "rstest",
  "serde",
  "serde_json",
  "serde_with",
@@ -823,6 +825,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1161,12 @@ checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -2228,6 +2248,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,6 +2614,12 @@ dependencies = [
  "bitflags 2.5.0",
  "libc",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3425,6 +3464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3545,6 +3590,36 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "rstest"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.66",
+ "unicode-ident",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -4009,6 +4084,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core",
 ]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "simple_asn1"

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -32,7 +32,9 @@ agglayer-telemetry = { path = "../agglayer-telemetry" }
 agglayer-signer = { path = "../agglayer-signer" }
 
 [dev-dependencies]
+insta = { version = "1.39.0", features = ["json"] }
 jsonrpsee-test-utils = { git = "https://github.com/paritytech/jsonrpsee.git", tag = "v0.22.3" }
+rstest = "0.22.0"
 serde_json = "1.0.116"
 agglayer-config = { path = "../agglayer-config", features = ["testutils"] }
 

--- a/crates/agglayer-node/src/rpc/error.rs
+++ b/crates/agglayer-node/src/rpc/error.rs
@@ -1,0 +1,164 @@
+//! Support for structured errors in RPC.
+
+use ethers::{middleware::Middleware, types::H256};
+use jsonrpsee::types::error::ErrorObjectOwned;
+use serde::Serialize;
+
+use crate::kernel::{CheckTxStatusError, SignatureVerificationError, ZkevmNodeVerificationError};
+
+/// RPC error codes.
+pub mod code {
+    /// Rollup is not registered.
+    pub const ROLLUP_NOT_REGISTERED: i32 = -10001;
+
+    /// Rollup signature verification failure.
+    pub const SIGNATURE_MISMATCH: i32 = -10002;
+
+    /// Proof or state validation failed.
+    pub const VALIDATION_FAILURE: i32 = -10003;
+
+    /// L1 settlement failure.
+    pub const SETTLEMENT_ERROR: i32 = -10004;
+
+    /// Transaction status retrieval error.
+    pub const STATUS_ERROR: i32 = -10005;
+}
+
+#[derive(PartialEq, Eq, Serialize, Debug, Clone, thiserror::Error)]
+#[serde(rename_all = "kebab-case")]
+pub enum ValidationError {
+    #[error("Dry run failed")]
+    DryRun { detail: String },
+
+    #[error("State root verification failed")]
+    RootVerification { detail: String },
+}
+
+#[derive(PartialEq, Eq, Serialize, Debug, Clone, thiserror::Error)]
+#[serde(rename_all = "kebab-case")]
+pub enum SettlementError {
+    #[error("No receipt")]
+    NoReceipt,
+
+    #[error("IO error")]
+    IoError(String),
+
+    #[error("Contract error")]
+    Contract { detail: String },
+}
+
+impl<R: Middleware> From<crate::kernel::SettlementError<R>> for SettlementError {
+    fn from(err: crate::kernel::SettlementError<R>) -> Self {
+        match err {
+            crate::kernel::SettlementError::NoReceipt => Self::NoReceipt,
+            crate::kernel::SettlementError::ProviderError(e) => Self::IoError(e.to_string()),
+            crate::kernel::SettlementError::ContractError(e) => {
+                let detail = e.to_string();
+                Self::Contract { detail }
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Serialize, Debug, Clone, thiserror::Error)]
+#[serde(rename_all = "kebab-case")]
+pub enum StatusError {
+    #[error("Transaction not found")]
+    TxNotFound { hash: H256 },
+
+    #[error("Failed to get the current L1 block")]
+    L1Block { detail: String },
+
+    #[error("Failed to get tx status")]
+    TxStatus { detail: String },
+}
+
+impl StatusError {
+    pub(crate) fn tx_not_found(hash: H256) -> Self {
+        Self::TxNotFound { hash }
+    }
+
+    pub(crate) fn tx_status<R: Middleware>(err: CheckTxStatusError<R>) -> Self {
+        let detail = err.to_string();
+        Self::TxStatus { detail }
+    }
+
+    pub(crate) fn l1_block<R: Middleware>(err: CheckTxStatusError<R>) -> Self {
+        let detail = err.to_string();
+        Self::L1Block { detail }
+    }
+}
+
+/// Application-level RPC errors returned by AggLayer.
+///
+/// Implementation note:
+/// RPC errors contain three pieces of information.
+/// They are obtained as follows:
+/// * `"code"` (the numeric error code) is taken from a call to [Self::code].
+/// * `"message"` comes from the `Display` trait impl provided by `thiserror`.
+/// * The `"data"` field comes from the `Serialize` trait impl.
+#[derive(PartialEq, Eq, Serialize, Debug, Clone, thiserror::Error)]
+#[serde(rename_all = "kebab-case")]
+pub enum Error {
+    #[error("Rollup {rollup_id} not registered")]
+    #[serde(rename_all = "kebab-case")]
+    RollupNotRegistered { rollup_id: u32 },
+
+    #[error("Rollup signature verification failed")]
+    #[serde(rename_all = "kebab-case")]
+    SignatureMismatch { detail: String },
+
+    #[error("Validation failed: {0}")]
+    Validation(#[from] ValidationError),
+
+    #[error("L1 settlement error: {0}")]
+    Settlement(#[from] SettlementError),
+
+    #[error("Status retrieval error: {0}")]
+    Status(#[from] StatusError),
+}
+
+impl Error {
+    pub(crate) fn rollup_not_registered(rollup_id: u32) -> Self {
+        Self::RollupNotRegistered { rollup_id }
+    }
+
+    pub(crate) fn signature_mismatch<R: Middleware>(err: SignatureVerificationError<R>) -> Self {
+        let detail = err.to_string();
+        Self::SignatureMismatch { detail }
+    }
+
+    pub(crate) fn dry_run(detail: String) -> Self {
+        ValidationError::DryRun { detail }.into()
+    }
+
+    pub(crate) fn root_verification(err: ZkevmNodeVerificationError) -> Self {
+        let detail = err.to_string();
+        ValidationError::RootVerification { detail }.into()
+    }
+
+    pub(crate) fn settlement<R: Middleware>(err: crate::kernel::SettlementError<R>) -> Self {
+        Self::Settlement(err.into())
+    }
+
+    /// Get the jsonrpc error code for this error.
+    pub fn code(&self) -> i32 {
+        match self {
+            Self::RollupNotRegistered { .. } => code::ROLLUP_NOT_REGISTERED,
+            Self::SignatureMismatch { .. } => code::SIGNATURE_MISMATCH,
+            Self::Validation(_) => code::VALIDATION_FAILURE,
+            Self::Settlement(_) => code::SETTLEMENT_ERROR,
+            Self::Status(_) => code::STATUS_ERROR,
+        }
+    }
+}
+
+// This impl establishes the integration with `jsonrpsee` errors.
+impl From<Error> for ErrorObjectOwned {
+    fn from(err: Error) -> Self {
+        ErrorObjectOwned::owned(err.code(), err.to_string(), Some(err))
+    }
+}
+
+/// Type returned from RPC methods, uses [RpcError].
+pub type RpcResult<T> = Result<T, Error>;

--- a/crates/agglayer-node/src/rpc/mod.rs
+++ b/crates/agglayer-node/src/rpc/mod.rs
@@ -9,25 +9,21 @@ use ethers::{
 };
 use futures::TryFutureExt;
 use jsonrpsee::{
-    core::{async_trait, RpcResult},
+    core::async_trait,
     proc_macros::rpc,
     server::{middleware::http::ProxyGetRequestLayer, PingConfig, ServerBuilder, ServerHandle},
-    types::{
-        error::{
-            CALL_EXECUTION_FAILED_CODE, INTERNAL_ERROR_CODE, INTERNAL_ERROR_MSG,
-            INVALID_PARAMS_CODE, INVALID_PARAMS_MSG,
-        },
-        ErrorObject, ErrorObjectOwned,
-    },
 };
 use tokio::try_join;
 use tower_http::cors::CorsLayer;
 use tracing::{debug, error, info, instrument};
 
 use crate::{
-    kernel::{Kernel, ZkevmNodeVerificationError},
+    kernel::Kernel,
+    rpc::error::{Error, RpcResult, StatusError},
     signed_tx::SignedTx,
 };
+
+mod error;
 
 #[cfg(test)]
 mod tests;
@@ -117,16 +113,6 @@ where
     }
 }
 
-/// Helper function to create an invalid params error with a custom message.
-fn invalid_params_error(msg: impl Into<String>) -> ErrorObjectOwned {
-    ErrorObject::owned(INVALID_PARAMS_CODE, INVALID_PARAMS_MSG, Some(msg.into()))
-}
-
-/// Helper function to create an internal error with a custom message.
-fn internal_error(msg: impl Into<String>) -> ErrorObjectOwned {
-    ErrorObject::owned(INTERNAL_ERROR_CODE, INTERNAL_ERROR_MSG, Some(msg.into()))
-}
-
 #[async_trait]
 impl<Rpc> AgglayerServer for AgglayerImpl<Rpc>
 where
@@ -148,9 +134,7 @@ where
 
         if !self.kernel.check_rollup_registered(tx.tx.rollup_id) {
             // Return an invalid params error if the rollup is not registered.
-            return Err(invalid_params_error(
-                ZkevmNodeVerificationError::InvalidRollupId(tx.tx.rollup_id).to_string(),
-            ));
+            return Err(Error::rollup_not_registered(tx.tx.rollup_id));
         }
 
         agglayer_telemetry::CHECK_TX.add(1, metrics_attrs);
@@ -161,7 +145,7 @@ where
                 .verify_signature(&tx)
                 .map_err(|e| {
                     error!(error = %e, hash, "Failed to verify the signature of transaction {hash}: {e}");
-                    invalid_params_error(e.to_string())
+                    Error::signature_mismatch(e)
                 })
                 .map_ok(|_| {
                     agglayer_telemetry::VERIFY_SIGNATURE.add(1, metrics_attrs);
@@ -171,7 +155,7 @@ where
                 .map_err(|e| {
                     let zkevm_error = decode_contract_error::<
                         _,
-                        crate::contracts::polygon_zk_evm::PolygonZkEvmErrors
+                        crate::contracts::polygon_zk_evm::PolygonZkEvmErrors,
                     >(&e);
 
                     let rollup_error = decode_contract_error::<
@@ -192,7 +176,7 @@ where
                         "Failed to dry-run the verify_batches_trusted_aggregator for transaction \
                          {hash}: {error}"
                     );
-                    invalid_params_error(error)
+                    Error::dry_run(error)
                 })
                 .map_ok(|_| {
                     agglayer_telemetry::EXECUTE.add(1, metrics_attrs);
@@ -206,7 +190,7 @@ where
                         "Failed to verify the batch local_exit_root and state_root of transaction \
                          {hash}: {e}"
                     );
-                    invalid_params_error(e.to_string())
+                    Error::root_verification(e)
                 })
                 .map_ok(|_| {
                     agglayer_telemetry::VERIFY_ZKP.add(1, metrics_attrs);
@@ -220,7 +204,7 @@ where
                 hash,
                 "Failed to settle transaction {hash} on L1: {e}"
             );
-            internal_error(e.to_string())
+            Error::settlement(e)
         })?;
 
         agglayer_telemetry::SETTLE.add(1, metrics_attrs);
@@ -233,39 +217,24 @@ where
     #[instrument(skip(self), fields(hash = hash.to_string()), level = "info")]
     async fn get_tx_status(&self, hash: H256) -> RpcResult<TxStatus> {
         debug!("Received request to get transaction status for hash {hash}");
-        let recipt = self.kernel.check_tx_status(hash).await.map_err(|e| {
+        let receipt = self.kernel.check_tx_status(hash).await.map_err(|e| {
             error!("Failed to get transaction status for hash {hash}: {e}");
-
-            ErrorObject::owned(
-                CALL_EXECUTION_FAILED_CODE,
-                INTERNAL_ERROR_MSG,
-                Some(format!("failed to get tx, error: {}", e)),
-            )
+            StatusError::tx_status(e)
         })?;
 
         let current_block = self.kernel.current_l1_block_height().await.map_err(|e| {
             error!("Failed to get current L1 block: {e}");
-
-            ErrorObject::owned(
-                CALL_EXECUTION_FAILED_CODE,
-                INTERNAL_ERROR_MSG,
-                Some(format!("failed to get current L1 block, error: {}", e)),
-            )
+            StatusError::l1_block(e)
         })?;
 
-        recipt
-            .map(|recipt| match recipt.block_number {
-                Some(block_number) if block_number < current_block => "done".to_string(),
-                Some(_) => "pending".to_string(),
-                None => "not found".to_string(),
-            })
-            .ok_or_else(|| {
-                ErrorObject::owned(
-                    CALL_EXECUTION_FAILED_CODE,
-                    INTERNAL_ERROR_MSG,
-                    Some(format!("tx not found for hash: {}", hash)),
-                )
-            })
+        let receipt = receipt.ok_or_else(|| StatusError::tx_not_found(hash))?;
+
+        let status = match receipt.block_number {
+            Some(block_number) if block_number < current_block => "done",
+            Some(_) => "pending",
+            None => "not found",
+        };
+        Ok(status.to_string())
     }
 }
 

--- a/crates/agglayer-node/src/rpc/tests/errors.rs
+++ b/crates/agglayer-node/src/rpc/tests/errors.rs
@@ -1,0 +1,85 @@
+//! Tests for rendering RPC errors
+
+use ethers::{
+    providers::ProviderError,
+    types::{Bytes, SignatureError as EthSignatureError, H160, H256},
+};
+use jsonrpsee::types::ErrorObjectOwned;
+
+use crate::{
+    kernel::{self, ZkevmNodeVerificationError},
+    rpc::Error,
+};
+
+type RpcProvider = ethers::providers::Provider<ethers::providers::Http>;
+type ContractError = ethers::contract::ContractError<RpcProvider>;
+type SignatureError = kernel::SignatureVerificationError<RpcProvider>;
+type SettlementError = kernel::SettlementError<RpcProvider>;
+
+#[rstest::rstest]
+#[case("rollup_not_reg", Error::rollup_not_registered(1337))]
+#[case(
+    "sig_invalid_len",
+    Error::signature_mismatch(SignatureError::CouldNotRecoverSigner(
+        EthSignatureError::InvalidLength(42)
+    ))
+)]
+#[case("sig_verif", Error::signature_mismatch(SignatureError::CouldNotRecoverSigner(
+    EthSignatureError::VerificationError(H160([0x11; 20]), H160([0x22; 20]))
+)))]
+#[case(
+    "sig_recov",
+    Error::signature_mismatch(SignatureError::CouldNotRecoverSigner(
+        EthSignatureError::RecoveryError
+    ))
+)]
+#[case(
+    "sig_signer",
+    Error::signature_mismatch(SignatureError::InvalidSigner{
+        signer: H160([0x33; 20]),
+        trusted_sequencer: H160([0x44; 20]),
+    })
+)]
+#[case("sig_contract", Error::signature_mismatch(ContractError::ContractNotDeployed.into()))]
+#[case("dry_run", Error::dry_run("Dry run flopped.".into()))]
+#[case(
+    "root_bad_rollup",
+    Error::root_verification(ZkevmNodeVerificationError::InvalidRollupId(13))
+)]
+#[case(
+    "root_rpc",
+    Error::root_verification(ZkevmNodeVerificationError::RpcError(
+        jsonrpsee::core::client::Error::Custom("Node smells too much".into())
+    ))
+)]
+#[case(
+    "root_state",
+    Error::root_verification(ZkevmNodeVerificationError::InvalidStateRoot {
+        expected: H256([0x55; 32]),
+        got: H256([0x66; 32]),
+    })
+)]
+#[case(
+    "root_exit",
+    Error::root_verification(ZkevmNodeVerificationError::InvalidExitRoot {
+        expected: H256([0x77; 32]),
+        got: H256([0x88; 32]),
+    })
+)]
+#[case("settle_receipt", Error::settlement(SettlementError::NoReceipt))]
+#[case(
+    "settle_io",
+    Error::settlement(SettlementError::ProviderError(ProviderError::UnsupportedRPC))
+)]
+#[case(
+    "settle_contract",
+    Error::settlement(SettlementError::ContractError(ContractError::Revert(
+        Bytes::from_static(b"foo")
+    )))
+)]
+fn rpc_error_rendering(#[case] name: &str, #[case] err: Error) {
+    let debug_str = format!("{err:?}");
+    let err_obj = serde_json::to_value(ErrorObjectOwned::from(err)).expect("json ok");
+
+    insta::assert_json_snapshot!(name, err_obj, &debug_str);
+}

--- a/crates/agglayer-node/src/rpc/tests/mod.rs
+++ b/crates/agglayer-node/src/rpc/tests/mod.rs
@@ -3,13 +3,16 @@ use std::time::Duration;
 
 use agglayer_config::Config;
 use ethers::providers::{self, Http, Middleware, Provider, ProviderExt as _};
-use ethers::types::TransactionRequest;
+use ethers::types::{TransactionRequest, H256};
 use ethers::utils::Anvil;
+use jsonrpsee::core::ClientError;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::{core::client::ClientT, rpc_params};
 
-use crate::rpc::TxStatus;
+use crate::rpc::{self, TxStatus};
 use crate::{kernel::Kernel, rpc::AgglayerImpl};
+
+mod errors;
 
 #[tokio::test]
 async fn healthcheck_method_can_be_called() {
@@ -104,6 +107,52 @@ async fn check_tx_status() {
         .unwrap();
 
     assert_eq!(res, "done");
+}
+
+#[tokio::test]
+async fn check_tx_status_fail() {
+    let _ = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let anvil = Anvil::new().block_time(1u64).spawn();
+    let client = Provider::<Http>::connect(&anvil.endpoint()).await;
+
+    let mut config = Config::default();
+    let addr = next_available_addr();
+    if let std::net::IpAddr::V4(ip) = addr.ip() {
+        config.rpc.host = ip;
+    }
+    let config = Arc::new(config);
+
+    let kernel = Kernel::new(client, config.clone());
+
+    let _server_handle = AgglayerImpl::new(kernel)
+        .start(config.clone())
+        .await
+        .unwrap();
+
+    let url = format!("http://{}/", config.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
+
+    // Try to get status using a non-existent address
+    let fake_tx_hash = H256([0x27; 32]);
+    let result: Result<TxStatus, ClientError> = client
+        .request("interop_getTxStatus", rpc_params![fake_tx_hash])
+        .await;
+
+    match result.unwrap_err() {
+        ClientError::Call(err) => {
+            assert_eq!(err.code(), rpc::error::code::STATUS_ERROR);
+
+            let data_expected = serde_json::json! {
+                { "status": { "tx-not-found": { "hash":  fake_tx_hash} } }
+            };
+            let data = serde_json::to_value(err.data().expect("data should not be empty")).unwrap();
+            assert_eq!(data_expected, data);
+        }
+        _ => panic!("Unexpected error returned"),
+    }
 }
 
 fn next_available_addr() -> std::net::SocketAddr {

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__dry_run.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__dry_run.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Validation(DryRun { detail: \"Dry run flopped.\" })"
+---
+{
+  "code": -10003,
+  "data": {
+    "validation": {
+      "dry-run": {
+        "detail": "Dry run flopped."
+      }
+    }
+  },
+  "message": "Validation failed: Dry run failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__rollup_not_reg.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__rollup_not_reg.snap
@@ -1,0 +1,13 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "RollupNotRegistered { rollup_id: 1337 }"
+---
+{
+  "code": -10001,
+  "data": {
+    "rollup-not-registered": {
+      "rollup-id": 1337
+    }
+  },
+  "message": "Rollup 1337 not registered"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__root_bad_rollup.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__root_bad_rollup.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Validation(RootVerification { detail: \"invalid rollup id: 13\" })"
+---
+{
+  "code": -10003,
+  "data": {
+    "validation": {
+      "root-verification": {
+        "detail": "invalid rollup id: 13"
+      }
+    }
+  },
+  "message": "Validation failed: State root verification failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__root_exit.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__root_exit.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Validation(RootVerification { detail: \"invalid exit root. expected: 0x7777…7777, got: 0x8888…8888\" })"
+---
+{
+  "code": -10003,
+  "data": {
+    "validation": {
+      "root-verification": {
+        "detail": "invalid exit root. expected: 0x7777…7777, got: 0x8888…8888"
+      }
+    }
+  },
+  "message": "Validation failed: State root verification failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__root_rpc.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__root_rpc.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Validation(RootVerification { detail: \"rpc error: Custom error: Node smells too much\" })"
+---
+{
+  "code": -10003,
+  "data": {
+    "validation": {
+      "root-verification": {
+        "detail": "rpc error: Custom error: Node smells too much"
+      }
+    }
+  },
+  "message": "Validation failed: State root verification failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__root_state.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__root_state.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Validation(RootVerification { detail: \"invalid state root. expected: 0x5555…5555, got: 0x6666…6666\" })"
+---
+{
+  "code": -10003,
+  "data": {
+    "validation": {
+      "root-verification": {
+        "detail": "invalid state root. expected: 0x5555…5555, got: 0x6666…6666"
+      }
+    }
+  },
+  "message": "Validation failed: State root verification failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__settle_contract.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__settle_contract.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Settlement(Contract { detail: \"Contract call reverted with data: 0x666f6f\" })"
+---
+{
+  "code": -10004,
+  "data": {
+    "settlement": {
+      "contract": {
+        "detail": "Contract call reverted with data: 0x666f6f"
+      }
+    }
+  },
+  "message": "L1 settlement error: Contract error"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__settle_io.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__settle_io.snap
@@ -1,0 +1,13 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Settlement(IoError(\"unsupported RPC\"))"
+---
+{
+  "code": -10004,
+  "data": {
+    "settlement": {
+      "io-error": "unsupported RPC"
+    }
+  },
+  "message": "L1 settlement error: IO error"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__settle_receipt.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__settle_receipt.snap
@@ -1,0 +1,11 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: Settlement(NoReceipt)
+---
+{
+  "code": -10004,
+  "data": {
+    "settlement": "no-receipt"
+  },
+  "message": "L1 settlement error: No receipt"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_contract.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_contract.snap
@@ -1,0 +1,13 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "SignatureMismatch { detail: \"contract error: Contract was not deployed\" }"
+---
+{
+  "code": -10002,
+  "data": {
+    "signature-mismatch": {
+      "detail": "contract error: Contract was not deployed"
+    }
+  },
+  "message": "Rollup signature verification failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_invalid_len.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_invalid_len.snap
@@ -1,0 +1,13 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "SignatureMismatch { detail: \"could not recover signer: invalid signature length, got 42, expected 65\" }"
+---
+{
+  "code": -10002,
+  "data": {
+    "signature-mismatch": {
+      "detail": "could not recover signer: invalid signature length, got 42, expected 65"
+    }
+  },
+  "message": "Rollup signature verification failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_recov.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_recov.snap
@@ -1,0 +1,13 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "SignatureMismatch { detail: \"could not recover signer: Public key recovery error\" }"
+---
+{
+  "code": -10002,
+  "data": {
+    "signature-mismatch": {
+      "detail": "could not recover signer: Public key recovery error"
+    }
+  },
+  "message": "Rollup signature verification failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_signer.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_signer.snap
@@ -1,0 +1,13 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "SignatureMismatch { detail: \"invalid signer: expected 0x4444…4444, got 0x3333…3333\" }"
+---
+{
+  "code": -10002,
+  "data": {
+    "signature-mismatch": {
+      "detail": "invalid signer: expected 0x4444…4444, got 0x3333…3333"
+    }
+  },
+  "message": "Rollup signature verification failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_verif.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_verif.snap
@@ -1,0 +1,13 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "SignatureMismatch { detail: \"could not recover signer: Signature verification failed. Expected 0x1111…1111, got 0x2222…2222\" }"
+---
+{
+  "code": -10002,
+  "data": {
+    "signature-mismatch": {
+      "detail": "could not recover signer: Signature verification failed. Expected 0x1111…1111, got 0x2222…2222"
+    }
+  },
+  "message": "Rollup signature verification failed"
+}


### PR DESCRIPTION
Introduce a mechanism to return the proper error codes from failing RPC calls and use it in the existing RPC methods. This also lays the groundwork for adding arbitrary structured data to RPC errors.

This is to make the future rate limiting errors easier to distinguish from other kinds of errors and to prepare for passing additional machine readable data in the RPC error response.

Related to:
* #219
* #213 

## Breaking changes

* Error codes returned from RPC calls have been changed from generic ones, like -20602 (invalid params) to newly introduced ones that specify the issue more precisely. Anyone relying on these error codes will have to update how they are handled. This is unlikely since the original codes were not particularly informative.
* The error message string has moved from the `data` field of the error object to the `message` field which is a better match. Anyone parsing (not the brightest idea) or reading the error message will have to update which field is read.
* The `data` field has been cleared to make space for error-specific structured data to be returned together with the error code and message.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
