### PR TITLE
fix: fix `apply_batch_header` mutation issue

### DIFF
--- a/crates/pessimistic-proof/src/local_state.rs
+++ b/crates/pessimistic-proof/src/local_state.rs
@@ -31,10 +31,22 @@ impl LocalNetworkState {
     pub fn roots(&self) -> LeafProofOutput {
         (self.exit_tree.get_root(), self.balance_tree.root, self.nullifier_set.root)
     }
+    /// Apply the [`MultiBatchHeader`] on the current [`State`].
+    /// The state isn't modified on error.
+    pub fn apply_batch_header(
+        &mut self,
+        multi_batch_header: &MultiBatchHeader<Keccak256Hasher>,
+    ) -> Result<(), ProofError> {
+        let mut clone = self.clone();
+        clone.apply_batch_header_helper(multi_batch_header)?;
+        *self = clone;
+
+        Ok(())
+    }
 
     /// Apply the [`MultiBatchHeader`] on the current [`State`].
-    /// Returns the commitment on the resulting state if successful.
-    pub fn apply_batch_header(
+    /// The state can be modified on error.
+    fn apply_batch_header_helper(
         &mut self,
         multi_batch_header: &MultiBatchHeader<Keccak256Hasher>,
     ) -> Result<(), ProofError> {


### PR DESCRIPTION
Fix the issue described in #239 by implementing a roll-back in `apply_batch_header`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
