### PR TITLE
chore: add safety comment to `keccak256_combine`

### DIFF
--- a/crates/pessimistic-proof/src/keccak.rs
+++ b/crates/pessimistic-proof/src/keccak.rs
@@ -38,6 +38,7 @@ pub fn keccak256(data: &[u8]) -> Digest {
 }
 
 /// Hashes the input items using a Keccak hasher with a 256-bit security level.
+/// Safety: This function should only be called with fixed-size items to avoid collisions.
 pub fn keccak256_combine<I, T>(items: I) -> Digest
 where
     I: IntoIterator<Item = T>,


### PR DESCRIPTION
As noted in #234, `keccak256_combine` should only be called with fixed-size inputs (which is currently the case in the code). This PR adds a comment mentioning that in the function's doc comment so that implementers are aware.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
