### PR TITLE
fix: adjust RPC timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-test-utils",
  "pessimistic-proof",
+ "reqwest 0.11.27",
  "rstest",
  "serde",
  "serde_json",
@@ -3086,6 +3087,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.30",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -5419,11 +5433,13 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.30",
  "hyper-rustls 0.24.2",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5435,6 +5451,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
@@ -5464,7 +5481,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-capture",
  "tracing-subscriber",
 ]
 
@@ -734,7 +735,7 @@ dependencies = [
  "bstr",
  "doc-comment",
  "libc",
- "predicates",
+ "predicates 3.1.2",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -3159,6 +3160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4959,6 +4966,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "itertools 0.10.5",
+ "predicates-core",
+]
 
 [[package]]
 name = "predicates"
@@ -7570,6 +7587,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-capture"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3b1b84b84d7f95504091cb9518dea662eacba7a3bc23f23e98fe5fafede344"
+dependencies = [
+ "id-arena",
+ "predicates 2.1.5",
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-tunnel",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7642,6 +7672,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tunnel"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507bbab1fc2c9e606543558f5656b62e8014ba7e0ffa68b9484511b6871019c5"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-test-utils",
  "pessimistic-proof",
+ "pin-project 1.1.5",
  "reqwest 0.11.27",
  "rstest",
  "serde",

--- a/crates/agglayer-config/src/l1.rs
+++ b/crates/agglayer-config/src/l1.rs
@@ -1,8 +1,12 @@
+use std::time::Duration;
+
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DurationSeconds};
 use url::Url;
 
 /// The L1 configuration.
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct L1 {
@@ -12,6 +16,15 @@ pub struct L1 {
     pub node_url: Url,
     #[serde(alias = "RollupManagerContract")]
     pub rollup_manager_contract: Address,
+    #[serde(default = "L1::default_rpc_timeout")]
+    #[serde_as(as = "DurationSeconds")]
+    pub rpc_timeout: Duration,
+}
+
+impl L1 {
+    const fn default_rpc_timeout() -> Duration {
+        Duration::from_secs(45)
+    }
 }
 
 impl Default for L1 {
@@ -23,6 +36,7 @@ impl Default for L1 {
             rollup_manager_contract: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
                 .parse()
                 .unwrap(),
+            rpc_timeout: Self::default_rpc_timeout(),
         }
     }
 }

--- a/crates/agglayer-config/src/l2.rs
+++ b/crates/agglayer-config/src/l2.rs
@@ -1,0 +1,28 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DurationSeconds};
+
+/// Configuration of the communication with the L2 nodes.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct L2 {
+    #[serde(default = "L2::default_rpc_timeout")]
+    #[serde_as(as = "DurationSeconds")]
+    pub rpc_timeout: Duration,
+}
+
+impl L2 {
+    const fn default_rpc_timeout() -> Duration {
+        Duration::from_secs(45)
+    }
+}
+
+impl Default for L2 {
+    fn default() -> Self {
+        Self {
+            rpc_timeout: Self::default_rpc_timeout(),
+        }
+    }
+}

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod auth;
 pub mod certificate_orchestrator;
 pub mod epoch;
 pub(crate) mod l1;
+pub(crate) mod l2;
 pub mod log;
 pub(crate) mod outbound;
 pub mod proof_signers;
@@ -32,6 +33,7 @@ pub(crate) mod telemetry;
 pub use auth::{AuthConfig, GcpKmsConfig, LocalConfig, PrivateKey};
 pub use epoch::Epoch;
 pub use l1::L1;
+pub use l2::L2;
 pub use log::Log;
 pub use rpc::RpcConfig;
 
@@ -45,6 +47,8 @@ pub struct Config {
     /// endpoint.
     #[serde(alias = "FullNodeRPCs", deserialize_with = "deserialize_rpc_map")]
     pub full_node_rpcs: HashMap<u32, Url>,
+    #[serde(default)]
+    pub l2: L2,
     #[serde(
         alias = "ProofSigners",
         deserialize_with = "deserialize_signers_map",

--- a/crates/agglayer-config/src/rpc.rs
+++ b/crates/agglayer-config/src/rpc.rs
@@ -5,12 +5,14 @@ use serde::{
     de::{MapAccess, Visitor},
     Deserialize, Deserializer, Serialize,
 };
+use serde_with::{serde_as, DurationSeconds};
 use url::Url;
 
 /// The default port for the local RPC server.
 const DEFAULT_PORT: u16 = 9090;
 
 /// The local RPC server configuration.
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct RpcConfig {
@@ -43,6 +45,10 @@ pub struct RpcConfig {
     /// The interval at which to send ping messages
     #[serde(skip)]
     pub ping_interval: Option<Duration>,
+    /// Timeout for completion of an RPC request to the AggLayer node.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(default = "default_request_timeout")]
+    pub request_timeout: Duration,
 }
 
 impl Default for RpcConfig {
@@ -55,6 +61,7 @@ impl Default for RpcConfig {
             max_connections: default_max_connections(),
             batch_request_limit: None,
             ping_interval: None,
+            request_timeout: default_request_timeout(),
         }
     }
 }
@@ -78,6 +85,11 @@ fn default_port() -> u16 {
 /// The default host for the local RPC server.
 const fn default_host() -> Ipv4Addr {
     Ipv4Addr::new(0, 0, 0, 0)
+}
+
+/// Default timeout for completion of an RPC request to the AggLayer node.
+const fn default_request_timeout() -> Duration {
+    Duration::from_secs(180)
 }
 
 fn deserialize_port<'de, D>(deserializer: D) -> Result<u16, D::Error>

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -11,6 +11,7 @@ futures.workspace = true
 hex.workspace = true
 hyper = "1.4.1"
 jsonrpsee = { workspace = true, features = ["full"] }
+pin-project = "1.1.5"
 reqwest = "0.11.27"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -42,6 +42,8 @@ serde_json.workspace = true
 agglayer-config = { path = "../agglayer-config", features = ["testutils"] }
 hyper-util = { version = "0.1.6", features = ["client"] }
 http-body-util = "0.1.2"
+tokio = { workspace = true, features = ["full", "test-util"] }
+tracing-capture = "0.1.0"
 
 [features]
 default = ["sp1"]

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -11,6 +11,7 @@ futures.workspace = true
 hex.workspace = true
 hyper = "1.4.1"
 jsonrpsee = { workspace = true, features = ["full"] }
+reqwest = "0.11.27"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_with.workspace = true

--- a/crates/agglayer-node/src/kernel/mod.rs
+++ b/crates/agglayer-node/src/kernel/mod.rs
@@ -75,9 +75,11 @@ impl<RpcProvider> Kernel<RpcProvider> {
             .get(&rollup_id)
             .ok_or(ZkevmNodeVerificationError::InvalidRollupId(rollup_id))?;
 
-        Ok(ZkevmNodeClient::new(
-            jsonrpsee::http_client::HttpClientBuilder::new().build(url.as_str())?,
-        ))
+        let client = jsonrpsee::http_client::HttpClientBuilder::new()
+            .request_timeout(std::time::Duration::from_secs(45))
+            .build(url.as_str())?;
+
+        Ok(ZkevmNodeClient::new(client))
     }
 
     /// Verify that the given [`SignedTx`] is valid according to the ZkEVM node.

--- a/crates/agglayer-node/src/kernel/mod.rs
+++ b/crates/agglayer-node/src/kernel/mod.rs
@@ -76,7 +76,7 @@ impl<RpcProvider> Kernel<RpcProvider> {
             .ok_or(ZkevmNodeVerificationError::InvalidRollupId(rollup_id))?;
 
         let client = jsonrpsee::http_client::HttpClientBuilder::new()
-            .request_timeout(std::time::Duration::from_secs(45))
+            .request_timeout(self.config.l2.rpc_timeout)
             .build(url.as_str())?;
 
         Ok(ZkevmNodeClient::new(client))

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -70,7 +70,7 @@ impl Node {
         let address = signer.address();
         // Create a new L1 RPC provider with the configured signer.
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(45))
+            .timeout(config.l1.rpc_timeout)
             .build()?;
         let rpc = Provider::new(Http::new_with_client(config.l1.node_url.clone(), client))
             .with_signer(signer)

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -69,7 +69,10 @@ impl Node {
         let signer = ConfiguredSigner::new(config.clone()).await?;
         let address = signer.address();
         // Create a new L1 RPC provider with the configured signer.
-        let rpc = Provider::<Http>::try_from(config.l1.node_url.as_str())?
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(45))
+            .build()?;
+        let rpc = Provider::new(Http::new_with_client(config.l1.node_url.clone(), client))
             .with_signer(signer)
             .nonce_manager(address);
 

--- a/crates/agglayer-node/src/rpc/mod.rs
+++ b/crates/agglayer-node/src/rpc/mod.rs
@@ -120,7 +120,7 @@ where
 
         let server = server_builder
             .set_http_middleware(middleware)
-            .set_rpc_middleware(rpc_middleware::build(&config))
+            .set_rpc_middleware(rpc_middleware::from_config(&config))
             .build(addr)
             .await?;
 

--- a/crates/agglayer-node/src/rpc/mod.rs
+++ b/crates/agglayer-node/src/rpc/mod.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 
 mod error;
+mod rpc_middleware;
 
 #[cfg(test)]
 mod tests;
@@ -119,6 +120,7 @@ where
 
         let server = server_builder
             .set_http_middleware(middleware)
+            .set_rpc_middleware(rpc_middleware::build(&config))
             .build(addr)
             .await?;
 

--- a/crates/agglayer-node/src/rpc/rpc_middleware/cancel_logger.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/cancel_logger.rs
@@ -1,0 +1,83 @@
+//! RPC middleware for recording cancelled requests.
+
+use std::{borrow::Cow, future::Future};
+
+use jsonrpsee::{
+    server::middleware::rpc::RpcServiceT,
+    types::{Id, Request},
+    MethodResponse,
+};
+
+/// An RPC layer that logs request cancellations.
+#[derive(Clone, Debug)]
+pub struct CancelLoggerLayer {}
+
+impl CancelLoggerLayer {
+    pub fn new() -> Self {
+        CancelLoggerLayer {}
+    }
+}
+
+impl<S> tower::Layer<S> for CancelLoggerLayer {
+    type Service = CancelLoggerService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CancelLoggerService(inner)
+    }
+}
+
+pub struct CancelLoggerService<S>(S);
+
+impl<'a, S: RpcServiceT<'a>> RpcServiceT<'a> for CancelLoggerService<S> {
+    type Future = CancelLoggerFuture<'a, S::Future>;
+
+    fn call(&self, request: Request<'a>) -> Self::Future {
+        CancelLoggerFuture {
+            completed: false,
+            method: request.method.clone(),
+            request_id: request.id.clone(),
+            inner: self.0.call(request),
+        }
+    }
+}
+
+#[pin_project::pin_project(PinnedDrop)]
+pub struct CancelLoggerFuture<'a, F> {
+    // Future state.
+    completed: bool,
+
+    // Method information.
+    method: Cow<'a, str>,
+    request_id: Id<'a>,
+
+    // The future to execute under a timeout.
+    #[pin]
+    inner: F,
+}
+
+impl<F: Future<Output = MethodResponse>> Future for CancelLoggerFuture<'_, F> {
+    type Output = MethodResponse;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        let poll_result = this.inner.poll(cx);
+        if poll_result.is_ready() {
+            *this.completed = true;
+        }
+        poll_result
+    }
+}
+
+#[pin_project::pinned_drop]
+impl<F> PinnedDrop for CancelLoggerFuture<'_, F> {
+    fn drop(self: std::pin::Pin<&mut Self>) {
+        if !self.completed {
+            let method = &*self.method;
+            let id = &self.request_id;
+            tracing::warn!("Request ID `{id}` to `{method}` was cancelled");
+        }
+    }
+}

--- a/crates/agglayer-node/src/rpc/rpc_middleware/cancel_logger.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/cancel_logger.rs
@@ -73,7 +73,7 @@ impl<F> PinnedDrop for CancelLoggerFuture<'_, F> {
         if !self.completed {
             let method = &*self.request_info.method;
             let id = &self.request_info.request_id;
-            tracing::warn!("Request ID `{id}` to `{method}` was cancelled");
+            tracing::info!("Request ID `{id}` to `{method}` was cancelled");
         }
     }
 }

--- a/crates/agglayer-node/src/rpc/rpc_middleware/logging_timeout.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/logging_timeout.rs
@@ -4,7 +4,6 @@ use std::{future::Future, time::Duration};
 
 use futures::TryFutureExt;
 use jsonrpsee::{server::middleware::rpc::RpcServiceT, types::ErrorObject, MethodResponse};
-use tracing::warn;
 
 use super::RequestInfo;
 
@@ -84,7 +83,7 @@ impl<F: Future<Output = MethodResponse>> Future for LoggingTimeoutFuture<'_, F> 
         let fut = this.inner.unwrap_or_else(move |e| {
             let method = &*this.request_info.method;
             let id = &this.request_info.request_id;
-            warn!("Request ID `{id}` to `{method}` timed out: {e}");
+            tracing::warn!("Request ID `{id}` to `{method}` timed out: {e}");
 
             let info = serde_json::json!({ "timeout": this.timeout.as_secs() });
             let err = ErrorObject::owned(TIMEOUT_ERROR_CODE, "request timed out", Some(info));

--- a/crates/agglayer-node/src/rpc/rpc_middleware/logging_timeout.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/logging_timeout.rs
@@ -1,0 +1,97 @@
+//! A logging timeout layer.
+
+use std::{borrow::Cow, future::Future, time::Duration};
+
+use futures::TryFutureExt;
+use jsonrpsee::{
+    server::middleware::rpc::RpcServiceT,
+    types::{ErrorObject, Id, Request},
+    MethodResponse,
+};
+use tracing::warn;
+
+/// Error code to return when the response time is too long.
+pub const TIMEOUT_ERROR_CODE: i32 = -32001;
+
+/// A layer that applies a timeout on a request and issues a log entry if the
+/// timeout expires before the request is completed.
+#[derive(Clone, Debug)]
+pub struct LoggingTimeoutLayer {
+    timeout: Duration,
+}
+
+impl LoggingTimeoutLayer {
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout }
+    }
+}
+
+impl<S> tower::Layer<S> for LoggingTimeoutLayer {
+    type Service = LoggingTimeoutService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        LoggingTimeoutService::new(self.timeout, inner)
+    }
+}
+
+pub struct LoggingTimeoutService<S> {
+    inner: S,
+    timeout: Duration,
+}
+
+impl<S> LoggingTimeoutService<S> {
+    pub fn new(timeout: Duration, inner: S) -> Self {
+        Self { inner, timeout }
+    }
+}
+
+impl<'a, S: RpcServiceT<'a>> RpcServiceT<'a> for LoggingTimeoutService<S> {
+    type Future = LoggingTimeoutFuture<'a, S::Future>;
+
+    fn call(&self, request: Request<'a>) -> Self::Future {
+        LoggingTimeoutFuture {
+            timeout: self.timeout,
+            method: request.method.clone(),
+            request_id: request.id.clone(),
+            inner: self.inner.call(request),
+        }
+    }
+}
+
+#[pin_project::pin_project]
+pub struct LoggingTimeoutFuture<'a, F> {
+    // Timeout duration.
+    timeout: Duration,
+
+    // Method information.
+    method: Cow<'a, str>,
+    request_id: Id<'a>,
+
+    // The future to execute under a timeout.
+    #[pin]
+    inner: F,
+}
+
+impl<F: Future<Output = MethodResponse>> Future for LoggingTimeoutFuture<'_, F> {
+    type Output = MethodResponse;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        let timeout = *this.timeout;
+
+        let fut = tokio::time::timeout(timeout, this.inner).unwrap_or_else(move |e| {
+            let method = &**this.method;
+            let id = &*this.request_id;
+            warn!("Request ID `{id}` to `{method}` timed out: {e}");
+
+            let info = serde_json::json!({ "timeout": timeout.as_secs() });
+            let err = ErrorObject::owned(TIMEOUT_ERROR_CODE, "request timed out", Some(info));
+            MethodResponse::error(id.to_owned(), err)
+        });
+
+        std::pin::pin!(fut).as_mut().poll(cx)
+    }
+}

--- a/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
@@ -25,11 +25,16 @@ impl<'a> RequestInfo<'a> {
 }
 
 /// The stack of RPC middleware layers.
-pub type RpcStack = Stack<CancelLoggerLayer, Stack<LoggingTimeoutLayer, Identity>>;
+pub type RpcStack = Stack<LoggingTimeoutLayer, Stack<CancelLoggerLayer, Identity>>;
+
+/// Build the middleware stack with given params.
+pub fn build(request_timeout: std::time::Duration) -> RpcServiceBuilder<RpcStack> {
+    jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new()
+        .layer(CancelLoggerLayer::new())
+        .layer(LoggingTimeoutLayer::new(request_timeout))
+}
 
 /// Build the RPC middleware stack from config.
-pub fn build(config: &agglayer_config::Config) -> RpcServiceBuilder<RpcStack> {
-    jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new()
-        .layer(LoggingTimeoutLayer::new(config.rpc.request_timeout))
-        .layer(CancelLoggerLayer::new())
+pub fn from_config(config: &agglayer_config::Config) -> RpcServiceBuilder<RpcStack> {
+    build(config.rpc.request_timeout)
 }

--- a/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
@@ -1,0 +1,17 @@
+//! RPC middleware layers.
+
+use jsonrpsee::server::middleware::rpc::RpcServiceBuilder;
+use tower::layer::util::{Identity, Stack};
+
+mod logging_timeout;
+
+pub use logging_timeout::LoggingTimeoutLayer;
+
+/// The stack of RPC middleware layers.
+pub type RpcStack = Stack<LoggingTimeoutLayer, Identity>;
+
+/// Build the RPC middleware stack from config.
+pub fn build(config: &agglayer_config::Config) -> RpcServiceBuilder<RpcStack> {
+    jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new()
+        .layer(LoggingTimeoutLayer::new(config.rpc.request_timeout))
+}

--- a/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
@@ -3,15 +3,18 @@
 use jsonrpsee::server::middleware::rpc::RpcServiceBuilder;
 use tower::layer::util::{Identity, Stack};
 
+mod cancel_logger;
 mod logging_timeout;
 
+pub use cancel_logger::CancelLoggerLayer;
 pub use logging_timeout::LoggingTimeoutLayer;
 
 /// The stack of RPC middleware layers.
-pub type RpcStack = Stack<LoggingTimeoutLayer, Identity>;
+pub type RpcStack = Stack<CancelLoggerLayer, Stack<LoggingTimeoutLayer, Identity>>;
 
 /// Build the RPC middleware stack from config.
 pub fn build(config: &agglayer_config::Config) -> RpcServiceBuilder<RpcStack> {
     jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new()
         .layer(LoggingTimeoutLayer::new(config.rpc.request_timeout))
+        .layer(CancelLoggerLayer::new())
 }

--- a/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
@@ -6,6 +6,9 @@ use tower::layer::util::{Identity, Stack};
 mod cancel_logger;
 mod logging_timeout;
 
+#[cfg(test)]
+mod tests;
+
 pub use cancel_logger::CancelLoggerLayer;
 pub use logging_timeout::LoggingTimeoutLayer;
 

--- a/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/mod.rs
@@ -1,6 +1,6 @@
 //! RPC middleware layers.
 
-use jsonrpsee::server::middleware::rpc::RpcServiceBuilder;
+use jsonrpsee::{server::middleware::rpc::RpcServiceBuilder, types::Id};
 use tower::layer::util::{Identity, Stack};
 
 mod cancel_logger;
@@ -8,6 +8,21 @@ mod logging_timeout;
 
 pub use cancel_logger::CancelLoggerLayer;
 pub use logging_timeout::LoggingTimeoutLayer;
+
+/// Information about the method being executed.
+struct RequestInfo<'a> {
+    method: std::borrow::Cow<'a, str>,
+    request_id: Id<'a>,
+}
+
+impl<'a> RequestInfo<'a> {
+    fn from_request(request: &jsonrpsee::types::Request<'a>) -> Self {
+        Self {
+            method: request.method.clone(),
+            request_id: request.id.clone(),
+        }
+    }
+}
 
 /// The stack of RPC middleware layers.
 pub type RpcStack = Stack<CancelLoggerLayer, Stack<LoggingTimeoutLayer, Identity>>;

--- a/crates/agglayer-node/src/rpc/rpc_middleware/tests.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/tests.rs
@@ -1,0 +1,173 @@
+use std::{future::Future, time::Duration};
+
+use jsonrpsee::{
+    core::{async_trait, client::ClientT, ClientError},
+    http_client::HttpClient,
+    proc_macros::rpc,
+    server::{
+        middleware::rpc::{RpcService, RpcServiceT},
+        RpcServiceBuilder,
+    },
+};
+use tracing_subscriber::layer::SubscriberExt;
+
+use super::LoggingTimeoutLayer;
+
+#[rpc(server)]
+trait Test {
+    #[method(name = "do_stuff")]
+    async fn do_stuff(&self) -> &'static str;
+}
+
+/// Test RPC server. Requests take given duration.
+struct TestRpc {
+    stuff_duration: Duration,
+}
+
+#[async_trait]
+impl TestServer for TestRpc {
+    async fn do_stuff(&self) -> &'static str {
+        tokio::time::sleep(self.stuff_duration).await;
+        "stuff done"
+    }
+}
+
+impl TestRpc {
+    async fn start<T>(
+        stuff_duration: Duration,
+        middleware: RpcServiceBuilder<T>,
+    ) -> (ServerGuard, ClientHandle)
+    where
+        T: tower::Layer<RpcService> + Clone + Send + 'static,
+        T::Service: for<'a> RpcServiceT<'a> + Send + Sync + 'static,
+    {
+        let server = jsonrpsee::server::Server::builder()
+            .set_rpc_middleware(middleware)
+            .build("127.0.0.1:0")
+            .await
+            .unwrap();
+        let url = format!("http://{}", server.local_addr().unwrap());
+        let server = ServerGuard(server.start((TestRpc { stuff_duration }).into_rpc()).into());
+        let client = ClientHandle(HttpClient::builder().build(&url).unwrap());
+
+        (server, client)
+    }
+}
+
+/// A slightly more convenient way to `do_stuff`.
+struct ClientHandle(HttpClient);
+
+impl ClientHandle {
+    async fn do_stuff(&self) -> Result<String, ClientError> {
+        self.0.request("do_stuff", [(); 0]).await
+    }
+}
+
+/// Just a guard that stops the server on drop.
+struct ServerGuard(Option<jsonrpsee::server::ServerHandle>);
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        self.0.take().map(|s| s.stop().unwrap());
+    }
+}
+
+async fn capture_log<R>(proc: impl Future<Output = R>) -> (tracing_capture::SharedStorage, R) {
+    let storage = tracing_capture::SharedStorage::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_ansi(false)
+        .compact()
+        .finish()
+        .with(tracing_capture::CaptureLayer::new(&storage));
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let ret = proc.await;
+    (storage, ret)
+}
+
+fn log_contains(log: &tracing_capture::SharedStorage, needle: &str) -> bool {
+    log.lock()
+        .all_events()
+        .any(|e| e.message().is_some_and(|m| m.contains(needle)))
+}
+
+const TIMED_OUT_STR: &'static str = "`do_stuff` timed out";
+const CANCELLED_STR: &'static str = "`do_stuff` was cancelled";
+
+#[tokio::test]
+async fn completed_before_deadline() {
+    tokio::time::pause();
+
+    let (log, res) = capture_log(async {
+        let middleware = super::build(Duration::from_secs(45));
+        let (_server, client) = TestRpc::start(Duration::from_secs(30), middleware).await;
+
+        let test_task = tokio::spawn(async move { client.do_stuff().await });
+        tokio::time::advance(Duration::from_secs(32)).await;
+        test_task.await.unwrap()
+    })
+    .await;
+
+    assert_eq!(res.unwrap(), "stuff done");
+    assert!(!log_contains(&log, TIMED_OUT_STR));
+    assert!(!log_contains(&log, CANCELLED_STR));
+}
+
+#[tokio::test]
+async fn timed_out() {
+    tokio::time::pause();
+
+    let (log, res) = capture_log(async {
+        let middleware = super::build(Duration::from_secs(20));
+        let (_server, client) = TestRpc::start(Duration::from_secs(30), middleware).await;
+
+        let test_task = tokio::spawn(async move { client.do_stuff().await });
+        tokio::time::advance(Duration::from_secs(22)).await;
+
+        test_task.await.unwrap()
+    })
+    .await;
+
+    match res.unwrap_err() {
+        ClientError::Call(err) => {
+            assert_eq!(err.code(), LoggingTimeoutLayer::ERROR_CODE);
+            assert_eq!(err.message(), "request timed out");
+            assert_eq!(
+                serde_json::to_value(err.data()).unwrap(),
+                serde_json::json!({ "timeout": 20 }),
+            );
+        }
+        _ => panic!("Unexpected error kind"),
+    }
+
+    assert!(log_contains(&log, TIMED_OUT_STR));
+    assert!(!log_contains(&log, CANCELLED_STR));
+}
+
+#[tokio::test]
+async fn request_dropped() {
+    tokio::time::pause();
+
+    let (log, res) = capture_log(async {
+        let middleware = super::build(Duration::from_secs(45));
+        let (_server, client) = TestRpc::start(Duration::from_secs(30), middleware).await;
+
+        let test_task = tokio::spawn(async move {
+            tokio::time::timeout(Duration::from_secs(10), client.do_stuff()).await
+        });
+
+        tokio::time::advance(Duration::from_secs(11)).await;
+        let res = test_task.await.unwrap();
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        res
+    })
+    .await;
+
+    // On the client side, the result should be a timeout
+    assert!(res.is_err());
+
+    // On the server side, the request cancellation should have been logged
+    assert!(!log_contains(&log, TIMED_OUT_STR));
+    assert!(log_contains(&log, CANCELLED_STR));
+}

--- a/crates/agglayer-node/src/rpc/tests/errors.rs
+++ b/crates/agglayer-node/src/rpc/tests/errors.rs
@@ -5,7 +5,6 @@ use ethers::{
     types::{Bytes, SignatureError as EthSignatureError, H160, H256},
 };
 use jsonrpsee::types::ErrorObjectOwned;
-use serde::Serialize;
 
 use crate::{
     kernel::{self, ZkevmNodeVerificationError},

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/agglayer/tests/config.rs
-assertion_line: 12
 expression: result
 ---
 [full-node-rpcs]
+
+[l2]
+rpc-timeout = 45
 
 [proof-signers]
 
@@ -25,6 +27,7 @@ confirmations = 1
 chain-id = 1337
 node-url = "http://zkevm-mock-l1-network:8545/"
 rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+rpc-timeout = 45
 
 [auth.local]
 private-keys = []

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -17,6 +17,7 @@ format = "pretty"
 [rpc]
 port = 9090
 host = "0.0.0.0"
+request-timeout = 180
 
 [outbound.rpc.settle]
 max-retries = 3


### PR DESCRIPTION
# Description

Addresses
* #230 
* #231 

For timeouts to the L1 node requests, there was previously none, so introduce one of 45s. Contract execution should fit within 45s easily.

For timeouts to the L2 node requests, there was one of 60s. However, if the request to the agglayer node is dropped before that timeout, we do not get any useful diagnostic. So lower it to 45s as well, so we increase chances that our request to the L2 node times out before the client request to agglayer, which gives us more room to log the error. The requests to L2 nodes are rather trivial so 45s should be more than enough. This is only a partial fix / workaround, ideally cancelled requests are logged regardless of timeout.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
