### PR TITLE
feat: add pp generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,7 +4684,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "clap",
  "ethers-signers",
+ "hex",
  "hex-literal",
  "lazy_static",
  "pessimistic-proof",
@@ -4696,6 +4698,7 @@ dependencies = [
  "sp1-sdk",
  "thiserror",
  "tracing",
+ "uuid 1.10.0",
 ]
 
 [[package]]
@@ -7769,6 +7772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
+ "rand",
 ]
 
 [[package]]

--- a/crates/pessimistic-proof-test-suite/Cargo.toml
+++ b/crates/pessimistic-proof-test-suite/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/bin/ppgen.rs"
 
 [dependencies]
 base64.workspace = true
-clap = { version = "4.0", features = ["derive", "env"] }
+clap.workspace = true
 ethers-signers.workspace = true
 reth-primitives = { git = "https://github.com/sp1-patches/reth", default-features = false, branch = "sp1-reth" }
 serde.workspace = true

--- a/crates/pessimistic-proof-test-suite/Cargo.toml
+++ b/crates/pessimistic-proof-test-suite/Cargo.toml
@@ -3,8 +3,13 @@ name = "pessimistic-proof-test-suite"
 version.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "ppgen"
+path = "src/bin/ppgen.rs"
+
 [dependencies]
 base64.workspace = true
+clap = { version = "4.0", features = ["derive", "env"] }
 ethers-signers.workspace = true
 reth-primitives = { git = "https://github.com/sp1-patches/reth", default-features = false, branch = "sp1-reth" }
 serde.workspace = true
@@ -16,6 +21,9 @@ lazy_static.workspace = true
 anyhow.workspace = true
 rand.workspace = true
 hex-literal = "0.4"
+hex.workspace = true
+tracing = "0.1.40"
+uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/pessimistic-proof-test-suite/src/bin/README.md
+++ b/crates/pessimistic-proof-test-suite/src/bin/README.md
@@ -11,14 +11,14 @@ cargo run -r -p pessimistic-proof-test-suite --bin ppgen -- --help
 The following command will generate one plonk proof for 10 bridge exits, with the default mode which is local.
 
 ```
-RUST_LOG=info ./target/release/ppgen --proof-dir ./data/proofs/ --n-exits 10
+RUST_LOG=info cargo run -r -p pessimistic-proof-test-suite --bin ppgen -- --proof-dir ./data/proofs/ --n-exits 10
 ```
 
 The local mode requires a large machine with ~128GB RAM.
 
 ## Network mode
 
-Necessary environment variables to generate with the succinct infrastructure:
+The succinct infrastructure generates the proof upon request. This requires to define two environment variables:
 
 ```
 SP1_PROVER=network
@@ -28,7 +28,7 @@ SP1_PRIVATE_KEY=...
 Then, the command remains the same:
 
 ```
-RUST_LOG=info ./target/release/ppgen --proof-dir ./data/proofs/ --n-exits 10
+RUST_LOG=info cargo run -r -p pessimistic-proof-test-suite --bin ppgen -- --proof-dir ./data/proofs/ --n-exits 10
 ```
 
 Expected logs:
@@ -47,3 +47,7 @@ Expected logs:
 2024-08-30T13:05:58.374793Z  INFO Successfully generated the plonk proof
 2024-08-30T13:05:58.374934Z  INFO Writing the proof to "./agglayer/crates/pessimistic-proof-test-suite/./data/proofs/10-exits-v0x0072d7-4c049331-cde2-4a82-84f9-c720d89b1752.json"
 ```
+
+## Proof output
+
+Use `--proof-dir` to save the proof as a JSON file in the specified directory. If not set, the proof will be logged instead.

--- a/crates/pessimistic-proof-test-suite/src/bin/README.md
+++ b/crates/pessimistic-proof-test-suite/src/bin/README.md
@@ -1,0 +1,49 @@
+# Pessimistic Proof Generator
+
+This utility generates pessimistic proofs on sample data.
+
+```
+cargo run -r -p pessimistic-proof-test-suite --bin ppgen -- --help
+```
+
+## Local mode
+
+The following command will generate one plonk proof for 10 bridge exits, with the default mode which is local.
+
+```
+RUST_LOG=info ./target/release/ppgen --proof-dir ./data/proofs/ --n-exits 10
+```
+
+The local mode requires a large machine with ~128GB RAM.
+
+## Network mode
+
+Necessary environment variables to generate with the succinct infrastructure:
+
+```
+SP1_PROVER=network
+SP1_PRIVATE_KEY=...
+```
+
+Then, the command remains the same:
+
+```
+RUST_LOG=info ./target/release/ppgen --proof-dir ./data/proofs/ --n-exits 10
+```
+
+Expected logs:
+
+```
+2024-08-30T13:02:29.261953Z  INFO Generating the proof for 10 bridge exits
+2024-08-30T13:02:29.261973Z  INFO Client circuit version: v1.1.0
+2024-08-30T13:02:37.100401Z  WARN network_prover: close time.busy=3.75µs time.idle=2.72µs
+2024-08-30T13:02:37.111616Z  INFO execute: clk = 0 pc = 0x209758
+2024-08-30T13:02:37.277199Z  INFO execute: close time.busy=176ms time.idle=1.57µs
+2024-08-30T13:02:37.277218Z  INFO Simulation complete, cycles: 1264128
+2024-08-30T13:02:45.374985Z  INFO Created proofrequest_01j6hp2xm7fpjtc6depe2sfa9s
+2024-08-30T13:02:45.375028Z  INFO View in explorer: https://explorer.succinct.xyz/proofrequest_01j6hp2xm7fpjtc6depe2sfa9s
+2024-08-30T13:02:48.651517Z  INFO Proof request claimed, proving...
+2024-08-30T13:05:57.296735Z  INFO Proof request fulfilled
+2024-08-30T13:05:58.374793Z  INFO Successfully generated the plonk proof
+2024-08-30T13:05:58.374934Z  INFO Writing the proof to "./agglayer/crates/pessimistic-proof-test-suite/./data/proofs/10-exits-v0x0072d7-4c049331-cde2-4a82-84f9-c720d89b1752.json"
+```

--- a/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
+++ b/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use pessimistic_proof::{
+    bridge_exit::{BridgeExit, NetworkId},
+    PessimisticProofOutput,
+};
+use pessimistic_proof_test_suite::{runner::Runner, sample_data as data};
+use serde::{Deserialize, Serialize};
+use sp1_sdk::HashableKey;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+/// The arguments for the pp generator.
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct PPGenArgs {
+    /// The number of bridge exits.
+    #[clap(long, default_value = "10")]
+    n_exits: usize,
+
+    /// The output directory for the generated proofs in json.
+    #[clap(long, default_value = "./data/proofs/")]
+    proof_dir: PathBuf,
+}
+
+pub fn main() {
+    sp1_sdk::utils::setup_logger();
+
+    let args = PPGenArgs::parse();
+
+    let mut state = data::sample_state_01();
+    let bridge_exits = data::sample_bridge_exits_01()
+        .take(args.n_exits)
+        .collect::<Vec<_>>();
+
+    let withdrawals = bridge_exits
+        .iter()
+        .map(|be| (be.token_info, be.amount))
+        .collect::<Vec<_>>();
+
+    let old_state = state.local_state();
+    let batch_header = state.apply_events(&[], &withdrawals);
+
+    info!(
+        "Generating the proof for {} bridge exits",
+        withdrawals.len()
+    );
+
+    let (proof, vk, new_roots) = Runner::new()
+        .generate_plonk_proof(&old_state, &batch_header)
+        .expect("proving failed");
+
+    info!("Successfully generated the plonk proof");
+
+    let vkey = vk.bytes32().to_string();
+    let fixture = PessimisticProofFixture {
+        bridge_exits,
+        pp_inputs: new_roots.into(),
+        vkey: vkey.clone(),
+        public_values: format!("0x{}", hex::encode(proof.public_values.as_slice())),
+        proof: format!("0x{}", hex::encode(proof.bytes())),
+    };
+
+    let id = Uuid::new_v4();
+    // Save the plonk proof to a json file.
+    let proof_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(args.proof_dir);
+    let proof_path = proof_dir.join(format!(
+        "{}-exits-v{}-{}.json",
+        args.n_exits,
+        &vkey[..8],
+        id
+    ));
+    if let Err(e) = std::fs::create_dir_all(&proof_dir) {
+        warn!("Failed to create directory: {e}");
+    }
+    info!("Writing the proof to {:?}", proof_path);
+    std::fs::write(proof_path, serde_json::to_string_pretty(&fixture).unwrap())
+        .expect("failed to write fixture");
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct VerifierInputs {
+    /// The previous local exit root.
+    pub prev_local_exit_root: String,
+    /// The previous pessimistic root.
+    pub prev_pessimistic_root: String,
+    /// The global exit root against which we prove the inclusion of the
+    /// imported bridge exits.
+    pub selected_ger: String,
+    /// The origin network of the pessimistic proof.
+    pub origin_network: NetworkId,
+    /// The consensus hash.
+    pub consensus_hash: String,
+    /// The new local exit root.
+    pub new_local_exit_root: String,
+    /// The new pessimistic root which commits to the balance and nullifier
+    /// tree.
+    pub new_pessimistic_root: String,
+}
+
+impl From<PessimisticProofOutput> for VerifierInputs {
+    fn from(v: PessimisticProofOutput) -> Self {
+        Self {
+            prev_local_exit_root: format!("0x{}", hex::encode(v.prev_local_exit_root)),
+            prev_pessimistic_root: format!("0x{}", hex::encode(v.prev_pessimistic_root)),
+            selected_ger: format!("0x{}", hex::encode(v.selected_ger)),
+            origin_network: v.origin_network,
+            consensus_hash: format!("0x{}", hex::encode(v.consensus_hash)),
+            new_local_exit_root: format!("0x{}", hex::encode(v.new_local_exit_root)),
+            new_pessimistic_root: format!("0x{}", hex::encode(v.new_pessimistic_root)),
+        }
+    }
+}
+
+/// A fixture that can be used to test the verification of SP1 zkVM proofs
+/// inside Solidity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct PessimisticProofFixture {
+    bridge_exits: Vec<BridgeExit>,
+    pp_inputs: VerifierInputs,
+    vkey: String,
+    public_values: String,
+    proof: String,
+}

--- a/crates/pessimistic-proof-test-suite/src/sample_data.rs
+++ b/crates/pessimistic-proof-test-suite/src/sample_data.rs
@@ -1,5 +1,7 @@
 //! Sample data, either synthetic or taken from real traces.
 
+use std::path::PathBuf;
+
 use hex_literal::hex;
 use pessimistic_proof::{
     bridge_exit::{BridgeExit, NetworkId, TokenInfo},
@@ -10,7 +12,7 @@ use pessimistic_proof::{
 use reth_primitives::{address, U256};
 
 use crate::{
-    event_data::{load_json_data_file, DepositEventData},
+    event_data::{load_json_data_file, parse_json_file, DepositEventData},
     forest::Forest,
 };
 
@@ -87,6 +89,12 @@ pub fn sample_state_01() -> Forest {
 
 pub fn sample_bridge_exits_01() -> impl Iterator<Item = BridgeExit> {
     load_json_data_file::<Vec<DepositEventData>>("withdrawals.json")
+        .into_iter()
+        .map(Into::into)
+}
+
+pub fn sample_bridge_exits(sample_path: PathBuf) -> impl Iterator<Item = BridgeExit> {
+    parse_json_file::<Vec<DepositEventData>>(sample_path.as_path())
         .into_iter()
         .map(Into::into)
 }


### PR DESCRIPTION
# Description

Add a basic utility to generate one pp based on sample data, and output the proof along with its metadata to one json file.

Generates it with the succinct infra or locally depending on the proving mode.

Relates to https://github.com/0xPolygonHermez/qa-protocol-kanban/issues/435

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
