### PR TITLE
build: prevent e2e tests for stack PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,7 @@ jobs:
         run: git diff --exit-code crates/pessimistic-proof-program/elf
 
   pre-e2e:
+    if: github.ref == 'refs/heads/main'
     needs:
       - unit
     name: E2E Tests | Docker


### PR DESCRIPTION
# Description

Disable e2e tests for branches that doesn't target main

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
