### PR TITLE
chore: port RPC error test changes from main to v0.1.7

### DIFF
--- a/crates/agglayer-node/src/rpc/tests/errors.rs
+++ b/crates/agglayer-node/src/rpc/tests/errors.rs
@@ -79,7 +79,13 @@ type SettlementError = kernel::SettlementError<RpcProvider>;
 )]
 fn rpc_error_rendering(#[case] name: &str, #[case] err: Error) {
     let debug_str = format!("{err:?}");
-    let err_obj = serde_json::to_value(ErrorObjectOwned::from(err)).expect("json ok");
+    let err_obj = ErrorObjectOwned::from(err);
+    let err_json_string = {
+        // Going through an extra encode/decode here helps normalize the output.
+        let json_string = serde_json::to_string(&err_obj).unwrap();
+        let json = serde_json::from_str::<serde_json::Value>(&json_string).unwrap();
+        serde_json::to_string_pretty(&json).unwrap()
+    };
 
-    insta::assert_json_snapshot!(name, err_obj, &debug_str);
+    insta::assert_snapshot!(name, err_json_string, &debug_str);
 }


### PR DESCRIPTION
# Description

This makes the test snapshot generation more stable. Was originally introduced when porting the code to `main`, to address an issue resulting from different `insta` versions. This is mainly to minimize the unnecessary differences between the two branches.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
