### PR TITLE
build: fix `testutils` feature propagation

### DIFF
--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -41,11 +41,14 @@ insta = { version = "1.39.0", features = ["json"] }
 jsonrpsee-test-utils = { git = "https://github.com/paritytech/jsonrpsee.git", tag = "v0.24.3" }
 rstest.workspace = true
 serde_json.workspace = true
-agglayer-config = { path = "../agglayer-config", features = ["testutils"] }
 hyper-util = { version = "0.1.6", features = ["client"] }
 http-body-util = "0.1.2"
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-capture = "0.1.0"
+
+agglayer-config = { path = "../agglayer-config", features = ["testutils"] }
+agglayer-storage = { path = "../agglayer-storage", features = ["testutils"] }
+agglayer-types = { path = "../agglayer-types", features = ["testutils"] }
 
 [features]
 default = ["sp1"]


### PR DESCRIPTION
This fixes the build so the `testutils` feature is properly propagated to crate dependencies in testing mode.

Commands such as the following do not work without this:

```sh
cargo nextest run -p agglayer-node
```

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
