### PR TITLE
feat: adding getCertificateHeader RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "serde",
  "sp1-sdk",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -280,10 +281,12 @@ dependencies = [
 name = "agglayer-types"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "hex",
  "pessimistic-proof",
  "reth-primitives",
  "serde",
+ "serde_with",
  "sp1-core-machine",
  "sp1-sdk",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.81"
 arc-swap = "1.7.1"
 async-trait = "0.1.82"
 base64 = "0.22.0"
+bincode = "1.3.3"
 buildstructor = "0.5.4"
 clap = { version = "4.5.13", features = ["derive", "env"] }
 dirs = "5.0.1"

--- a/crates/agglayer-aggregator-notifier/src/sp1/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/sp1/mod.rs
@@ -60,6 +60,8 @@ where
                     )
                     .map_err(|error| {
                         let error_description = error.to_string();
+                        // TODO: Find a better solution than downcasting the error into a
+                        // ProofError.
                         if let Ok(error) = error.downcast::<ProofError>() {
                             error
                         } else {

--- a/crates/agglayer-aggregator-notifier/src/sp1/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/sp1/mod.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 
+use agglayer_types::ProofVerificationError;
 use futures::{future::BoxFuture, FutureExt as _};
-use pessimistic_proof::LocalNetworkState;
+use pessimistic_proof::{LocalNetworkState, ProofError};
 use serde::Serialize;
 use sp1_prover::components::DefaultProverComponents;
 use sp1_sdk::{
     CpuProver, MockProver, NetworkProver, Prover as _, SP1ProvingKey, SP1Stdin, SP1VerifyingKey,
 };
 use tokio::task::spawn_blocking;
+use tracing::error;
 
 use super::Proof;
 
@@ -38,7 +40,7 @@ where
         &self,
         initial_state: LocalNetworkState,
         certificate: I,
-    ) -> BoxFuture<'_, Result<Proof, anyhow::Error>> {
+    ) -> BoxFuture<'_, Result<Proof, ProofError>> {
         let mut stdin = SP1Stdin::new();
         stdin.write(&initial_state);
         stdin.write(&certificate);
@@ -48,21 +50,33 @@ where
 
         async move {
             spawn_blocking(move || {
-                prover.prove(
-                    &proving_key,
-                    stdin,
-                    Default::default(),
-                    Default::default(),
-                    Default::default(),
-                )
+                prover
+                    .prove(
+                        &proving_key,
+                        stdin,
+                        Default::default(),
+                        Default::default(),
+                        Default::default(),
+                    )
+                    .map_err(|error| {
+                        let error_description = error.to_string();
+                        if let Ok(error) = error.downcast::<ProofError>() {
+                            error
+                        } else {
+                            error!("Error while proving: {}", error_description);
+
+                            ProofError::Unknown(error_description)
+                        }
+                    })
             })
-            .await?
+            .await
+            .map_err(|_| ProofError::Unknown("Unable to properly execute Proof task".to_string()))?
             .map(Proof::SP1)
         }
         .boxed()
     }
 
-    fn verify(&self, proof: &Proof) -> Result<(), anyhow::Error> {
+    fn verify(&self, proof: &Proof) -> Result<(), ProofVerificationError> {
         let Proof::SP1(proof) = proof;
 
         Ok(self.prover.verify(proof, &self.verifying_key)?)
@@ -77,7 +91,7 @@ where
         &self,
         initial_state: LocalNetworkState,
         certificate: I,
-    ) -> BoxFuture<'_, Result<Proof, anyhow::Error>> {
+    ) -> BoxFuture<'_, Result<Proof, ProofError>> {
         let mut stdin = SP1Stdin::new();
         stdin.write(&initial_state);
         stdin.write(&certificate);
@@ -94,12 +108,22 @@ where
                     Default::default(),
                 )
                 .await
+                .map_err(|error| {
+                    let error_description = error.to_string();
+                    if let Ok(error) = error.downcast::<ProofError>() {
+                        error
+                    } else {
+                        error!("Error while proving: {}", error_description);
+
+                        ProofError::Unknown(error_description)
+                    }
+                })
                 .map(Proof::SP1)
         }
         .boxed()
     }
 
-    fn verify(&self, proof: &Proof) -> Result<(), anyhow::Error> {
+    fn verify(&self, proof: &Proof) -> Result<(), ProofVerificationError> {
         let Proof::SP1(proof) = proof;
         Ok(self.prover.verify(proof, &self.verifying_key)?)
     }
@@ -113,7 +137,7 @@ where
         &self,
         initial_state: LocalNetworkState,
         certificate: I,
-    ) -> BoxFuture<'_, Result<Proof, anyhow::Error>> {
+    ) -> BoxFuture<'_, Result<Proof, ProofError>> {
         let mut stdin = SP1Stdin::new();
         stdin.write(&initial_state);
         stdin.write(&certificate);
@@ -123,21 +147,33 @@ where
 
         async move {
             spawn_blocking(move || {
-                prover.prove(
-                    &proving_key,
-                    stdin,
-                    Default::default(),
-                    Default::default(),
-                    Default::default(),
-                )
+                prover
+                    .prove(
+                        &proving_key,
+                        stdin,
+                        Default::default(),
+                        Default::default(),
+                        Default::default(),
+                    )
+                    .map_err(|error| {
+                        let error_description = error.to_string();
+                        if let Ok(error) = error.downcast::<ProofError>() {
+                            error
+                        } else {
+                            error!("Error while proving: {}", error_description);
+
+                            ProofError::Unknown(error_description)
+                        }
+                    })
             })
-            .await?
+            .await
+            .map_err(|_| ProofError::Unknown("Unable to properly execute Proof task".to_string()))?
             .map(Proof::SP1)
         }
         .boxed()
     }
 
-    fn verify(&self, proof: &Proof) -> Result<(), anyhow::Error> {
+    fn verify(&self, proof: &Proof) -> Result<(), ProofVerificationError> {
         let Proof::SP1(proof) = proof;
 
         Ok(self.prover.verify(proof, &self.verifying_key)?)

--- a/crates/agglayer-aggregator-notifier/src/tests/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/tests/mod.rs
@@ -33,6 +33,14 @@ mod sp1 {
         > {
             todo!()
         }
+
+        fn get_certificate_header(
+            &self,
+            _certificate_id: &agglayer_types::CertificateId,
+        ) -> Result<Option<agglayer_types::CertificateHeader>, agglayer_storage::error::Error>
+        {
+            todo!()
+        }
     }
     impl PendingCertificateReader for DummyStore {
         fn get_certificate(
@@ -72,8 +80,8 @@ mod sp1 {
 
     #[tokio::test]
     #[rstest::rstest]
-    #[case(ProverConfig::SP1Local {})]
-    #[case(ProverConfig::SP1Mock {})]
+    #[case::sp1_local(ProverConfig::SP1Local {})]
+    #[case::sp1_mock(ProverConfig::SP1Mock {})]
     async fn aggregator_notifier_can_be_implemented(#[case] config: ProverConfig) {
         use std::sync::Arc;
 

--- a/crates/agglayer-certificate-orchestrator/src/tests/certifier_results.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests/certifier_results.rs
@@ -6,6 +6,7 @@ use agglayer_storage::stores::StateReader;
 use agglayer_storage::stores::StateWriter;
 use agglayer_types::Certificate;
 use agglayer_types::CertificateHeader;
+use agglayer_types::CertificateStatus;
 use agglayer_types::LocalNetworkStateData;
 use agglayer_types::Proof;
 use pessimistic_proof::Signature;
@@ -62,7 +63,7 @@ async fn certifier_results_for_unknown_network_with_height_zero() {
 
     orchestrator
         .state_store
-        .insert_certificate_header(&certificate)
+        .insert_certificate_header(&certificate, CertificateStatus::Pending)
         .unwrap();
 
     assert!(orchestrator
@@ -216,7 +217,7 @@ async fn certifier_error_proof_already_exists_with_height_zero() {
 
     orchestrator
         .state_store
-        .insert_certificate_header(&certificate)
+        .insert_certificate_header(&certificate, CertificateStatus::Pending)
         .unwrap();
 
     assert!(orchestrator
@@ -280,7 +281,7 @@ async fn certifier_error_proof_already_exists_with_height_zero_still_pending() {
 
     orchestrator
         .state_store
-        .insert_certificate_header(&certificate)
+        .insert_certificate_header(&certificate, CertificateStatus::Pending)
         .unwrap();
 
     orchestrator

--- a/crates/agglayer-certificate-orchestrator/src/tests/receive_certificates.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests/receive_certificates.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use agglayer_storage::stores::PendingCertificateWriter;
 use agglayer_storage::stores::StateWriter;
 use agglayer_types::Certificate;
+use agglayer_types::CertificateStatus;
 use pessimistic_proof::Signature;
 use pessimistic_proof::U256;
 use rstest::rstest;
@@ -67,7 +68,7 @@ async fn receive_certificate_with_previous_proved() {
 
     orchestrator
         .state_store
-        .insert_certificate_header(&previous)
+        .insert_certificate_header(&previous, CertificateStatus::Pending)
         .unwrap();
 
     let certificate = Certificate {
@@ -91,7 +92,7 @@ async fn receive_certificate_with_previous_proved() {
 
     orchestrator.cursors.insert(1.into(), 0);
 
-    let result = orchestrator.receive_certificates(&[(1.into(), 1, [0; 32])]);
+    let result = orchestrator.receive_certificates(&[(1.into(), 1, [0; 32].into())]);
 
     assert!(result.is_ok());
     assert!(matches!(orchestrator.cursors.get(&1.into()), Some(1)));
@@ -143,7 +144,7 @@ async fn receive_certificate_with_previous_pending() {
         .insert_pending_certificate(1.into(), 1, &certificate)
         .unwrap();
 
-    let result = orchestrator.receive_certificates(&[(1.into(), 1, [0; 32])]);
+    let result = orchestrator.receive_certificates(&[(1.into(), 1, [0; 32].into())]);
 
     assert!(result.is_ok());
     assert!(!orchestrator.cursors.contains_key(&1.into()));

--- a/crates/agglayer-clock/src/time.rs
+++ b/crates/agglayer-clock/src/time.rs
@@ -121,7 +121,9 @@ impl TimeClock {
                         if current_block % self.epoch_duration == 0 {
                             match self.update_epoch_number() {
                                 Ok(epoch_ended) => {
-                                    _ = sender.send(Event::EpochEnded(epoch_ended));
+                                    if let Err(error) = sender.send(Event::EpochEnded(epoch_ended)) {
+                                        error!("Failed to send EpochEnded event to subscribers: {error}");
+                                    }
                                 }
                                 Err((current_epoch, expected)) => {
                                     error!(

--- a/crates/agglayer-node/src/rpc/error.rs
+++ b/crates/agglayer-node/src/rpc/error.rs
@@ -31,6 +31,9 @@ pub mod code {
 
     /// Transaction settlement has been rate limited.
     pub const RATE_LIMITED: i32 = -10007;
+
+    /// Resource not found.
+    pub const RESOURCE_NOT_FOUND: i32 = -10008;
 }
 
 #[derive(PartialEq, Eq, Serialize, Debug, Clone, thiserror::Error)]
@@ -122,9 +125,23 @@ pub enum Error {
         detail: String,
         error: RateLimitedError,
     },
+
+    #[error("Resource not found: {0}")]
+    ResourceNotFound(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
 }
 
 impl Error {
+    pub(crate) fn internal<S: Into<String>>(detail: S) -> Self {
+        Self::Internal(detail.into())
+    }
+
+    pub(crate) fn resource_not_found<S: Into<String>>(resource: S) -> Self {
+        Self::ResourceNotFound(resource.into())
+    }
+
     pub(crate) fn rollup_not_registered(rollup_id: u32) -> Self {
         Self::RollupNotRegistered { rollup_id }
     }
@@ -155,6 +172,8 @@ impl Error {
     /// Get the jsonrpc error code for this error.
     pub fn code(&self) -> i32 {
         match self {
+            Self::Internal(_) => jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+            Self::ResourceNotFound { .. } => code::RESOURCE_NOT_FOUND,
             Self::RollupNotRegistered { .. } => code::ROLLUP_NOT_REGISTERED,
             Self::SignatureMismatch { .. } => code::SIGNATURE_MISMATCH,
             Self::Validation(_) => code::VALIDATION_FAILURE,

--- a/crates/agglayer-node/src/rpc/error.rs
+++ b/crates/agglayer-node/src/rpc/error.rs
@@ -26,7 +26,7 @@ pub mod code {
     /// Transaction status retrieval error.
     pub const STATUS_ERROR: i32 = -10005;
 
-    /// Error submitting a ceritficate.
+    /// Error submitting a certificate.
     pub const SEND_CERTIFICATE: i32 = -10006;
 
     /// Transaction settlement has been rate limited.

--- a/crates/agglayer-node/src/rpc/mod.rs
+++ b/crates/agglayer-node/src/rpc/mod.rs
@@ -277,12 +277,12 @@ where
 
     #[instrument(skip(self), fields(hash, rollup_id = *certificate.network_id), level = "info")]
     async fn send_certificate(&self, certificate: Certificate) -> RpcResult<CertificateId> {
-        let id = format!("{:?}", certificate.hash());
-        tracing::Span::current().record("hash", &id);
+        let hash = certificate.hash();
+        tracing::Span::current().record("hash", hash.to_string());
 
         info!(
-            hash,
-            "Received certificate {id} for rollup {}", *certificate.network_id
+            %hash,
+            "Received certificate {hash} for rollup {}", *certificate.network_id
         );
 
         // TODO: Batch the different queries.
@@ -318,7 +318,7 @@ where
             return Err(Error::send_certificate(error));
         }
 
-        Ok(id)
+        Ok(hash)
     }
 
     async fn get_certificate_header(

--- a/crates/agglayer-node/src/rpc/mod.rs
+++ b/crates/agglayer-node/src/rpc/mod.rs
@@ -2,8 +2,11 @@ use std::sync::Arc;
 
 use agglayer_config::Config;
 use agglayer_storage::stores::PendingCertificateWriter;
+use agglayer_storage::stores::StateReader;
+use agglayer_storage::stores::StateWriter;
 use agglayer_telemetry::KeyValue;
-use agglayer_types::{Certificate, CertificateId, Height, NetworkId};
+use agglayer_types::CertificateStatus;
+use agglayer_types::{Certificate, CertificateHeader, CertificateId, Height, NetworkId};
 use ethers::{
     contract::{ContractError, ContractRevert},
     providers::Middleware,
@@ -40,36 +43,45 @@ trait Agglayer {
     async fn get_tx_status(&self, hash: H256) -> RpcResult<TxStatus>;
 
     #[method(name = "sendCertificate")]
-    async fn send_certificate(&self, certificate: Certificate) -> RpcResult<()>;
+    async fn send_certificate(&self, certificate: Certificate) -> RpcResult<CertificateId>;
+
+    #[method(name = "getCertificateHeader")]
+    async fn get_certificate_header(
+        &self,
+        certificate_id: CertificateId,
+    ) -> RpcResult<CertificateHeader>;
 }
 
 /// The RPC agglayer service implementation.
-pub(crate) struct AgglayerImpl<Rpc, PendingStore> {
+pub(crate) struct AgglayerImpl<Rpc, PendingStore, StateStore> {
     kernel: Kernel<Rpc>,
     certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
-    #[allow(unused)]
     pending_store: Arc<PendingStore>,
+    state: Arc<StateStore>,
 }
 
-impl<Rpc, PendingStore> AgglayerImpl<Rpc, PendingStore> {
+impl<Rpc, PendingStore, StateStore> AgglayerImpl<Rpc, PendingStore, StateStore> {
     /// Create an instance of the RPC agglayer service.
     pub(crate) fn new(
         kernel: Kernel<Rpc>,
         certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
         pending_store: Arc<PendingStore>,
+        state: Arc<StateStore>,
     ) -> Self {
         Self {
             kernel,
             certificate_sender,
             pending_store,
+            state,
         }
     }
 }
 
-impl<Rpc, PendingStore> AgglayerImpl<Rpc, PendingStore>
+impl<Rpc, PendingStore, StateStore> AgglayerImpl<Rpc, PendingStore, StateStore>
 where
     Rpc: Middleware + 'static,
     PendingStore: PendingCertificateWriter + 'static,
+    StateStore: StateReader + StateWriter + 'static,
 {
     pub(crate) async fn start(self, config: Arc<Config>) -> anyhow::Result<ServerHandle> {
         // Create the RPC service
@@ -134,10 +146,11 @@ where
 }
 
 #[async_trait]
-impl<Rpc, PendingStore> AgglayerServer for AgglayerImpl<Rpc, PendingStore>
+impl<Rpc, PendingStore, StateStore> AgglayerServer for AgglayerImpl<Rpc, PendingStore, StateStore>
 where
     Rpc: Middleware + 'static,
     PendingStore: PendingCertificateWriter + 'static,
+    StateStore: StateReader + StateWriter + 'static,
 {
     #[instrument(skip(self, tx), fields(hash, rollup_id = tx.tx.rollup_id), level = "info")]
     async fn send_tx(&self, tx: SignedTx) -> RpcResult<H256> {
@@ -263,20 +276,33 @@ where
     }
 
     #[instrument(skip(self), fields(hash, rollup_id = *certificate.network_id), level = "info")]
-    async fn send_certificate(&self, certificate: Certificate) -> RpcResult<()> {
-        let hash = format!("{:?}", certificate.hash());
-        tracing::Span::current().record("hash", &hash);
+    async fn send_certificate(&self, certificate: Certificate) -> RpcResult<CertificateId> {
+        let id = format!("{:?}", certificate.hash());
+        tracing::Span::current().record("hash", &id);
 
         info!(
             hash,
-            "Received certificate {hash} for rollup {}", *certificate.network_id
+            "Received certificate {id} for rollup {}", *certificate.network_id
         );
 
-        _ = self.pending_store.insert_pending_certificate(
-            certificate.network_id,
-            certificate.height,
-            &certificate,
-        );
+        // TODO: Batch the different queries.
+        // Insert the certificate header into the state store.
+        _ = self
+            .state
+            .insert_certificate_header(&certificate, CertificateStatus::Pending)
+            .map_err(|e| {
+                error!("Failed to insert certificate into state store: {e}");
+                Error::internal(e.to_string())
+            })?;
+
+        // Insert the certificate into the pending store.
+        _ = self
+            .pending_store
+            .insert_pending_certificate(certificate.network_id, certificate.height, &certificate)
+            .map_err(|e| {
+                error!("Failed to insert certificate into pending store: {e}");
+                Error::internal(e.to_string())
+            })?;
 
         if let Err(error) = self
             .certificate_sender
@@ -292,7 +318,26 @@ where
             return Err(Error::send_certificate(error));
         }
 
-        Ok(())
+        Ok(id)
+    }
+
+    async fn get_certificate_header(
+        &self,
+        certificate_id: CertificateId,
+    ) -> RpcResult<CertificateHeader> {
+        info!("Received request to get certificate header for certificate {certificate_id}");
+        match self.state.get_certificate_header(&certificate_id) {
+            Ok(Some(header)) => Ok(header),
+            Ok(None) => Err(Error::resource_not_found(format!(
+                "Certificate({})",
+                certificate_id
+            ))),
+            Err(error) => {
+                error!("Failed to get certificate header: {}", error);
+
+                Err(Error::internal("Unable to get certificate header"))
+            }
+        }
     }
 }
 

--- a/crates/agglayer-node/src/rpc/rpc_middleware/tests.rs
+++ b/crates/agglayer-node/src/rpc/rpc_middleware/tests.rs
@@ -68,7 +68,9 @@ struct ServerGuard(Option<jsonrpsee::server::ServerHandle>);
 
 impl Drop for ServerGuard {
     fn drop(&mut self) {
-        self.0.take().map(|s| s.stop().unwrap());
+        if let Some(s) = self.0.take() {
+            s.stop().unwrap();
+        }
     }
 }
 
@@ -91,8 +93,8 @@ fn log_contains(log: &tracing_capture::SharedStorage, needle: &str) -> bool {
         .any(|e| e.message().is_some_and(|m| m.contains(needle)))
 }
 
-const TIMED_OUT_STR: &'static str = "`do_stuff` timed out";
-const CANCELLED_STR: &'static str = "`do_stuff` was cancelled";
+const TIMED_OUT_STR: &str = "`do_stuff` timed out";
+const CANCELLED_STR: &str = "`do_stuff` was cancelled";
 
 #[tokio::test]
 async fn completed_before_deadline() {

--- a/crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
+++ b/crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
@@ -1,0 +1,165 @@
+use agglayer_types::{Certificate, CertificateHeader, CertificateId, CertificateStatus, Hash};
+use insta::assert_snapshot;
+use jsonrpsee::{
+    core::{client::ClientT, ClientError},
+    rpc_params,
+};
+use rstest::*;
+use serde_json::json;
+
+use super::context;
+use super::raw_rpc;
+use super::TestContext;
+use crate::rpc::{tests::RawRpcContext, AgglayerServer};
+
+#[rstest]
+#[awt]
+#[test_log::test(tokio::test)]
+async fn fetch_unkown_certificate_header(#[future] context: TestContext) {
+    let payload: Result<CertificateHeader, ClientError> = context
+        .client
+        .request("interop_getCertificateHeader", rpc_params![Hash([0; 32])])
+        .await;
+
+    let error = payload.unwrap_err();
+
+    let expected_message = format!("Resource not found: Certificate({:#})", Hash([0; 32]));
+    assert!(matches!(error, ClientError::Call(obj) if obj.message() == expected_message));
+}
+
+#[rstest]
+#[awt]
+#[test_log::test(tokio::test)]
+async fn fetch_kown_certificate_header(#[future] mut context: TestContext) {
+    let certificate = Certificate::new_for_test(1.into(), 0);
+    let id = certificate.hash();
+
+    let res: CertificateId = context
+        .client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    assert_eq!(id, res);
+    assert!(context.certificate_receiver.try_recv().is_ok());
+
+    let payload: CertificateHeader = context
+        .client
+        .request("interop_getCertificateHeader", rpc_params![id])
+        .await
+        .unwrap();
+
+    assert_eq!(payload.certificate_id, id);
+    assert_eq!(payload.status, CertificateStatus::Pending);
+}
+
+#[rstest]
+#[awt]
+#[test_log::test(tokio::test)]
+async fn get_certificate_header_after_sending_the_certificate(#[future] mut context: TestContext) {
+    let certificate = Certificate::new_for_test(1.into(), 0);
+    let id = certificate.hash();
+
+    let res: CertificateId = context
+        .client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    assert_eq!(id, res);
+    assert!(context.certificate_receiver.try_recv().is_ok());
+
+    let payload: CertificateHeader = context
+        .client
+        .request("interop_getCertificateHeader", rpc_params![id])
+        .await
+        .unwrap();
+
+    assert_eq!(payload.certificate_id, id);
+    assert_eq!(payload.status, CertificateStatus::Pending);
+
+    let payload: Result<CertificateHeader, ClientError> = context
+        .client
+        .request("interop_getCertificateHeader", rpc_params![Hash([0; 32])])
+        .await;
+
+    let error = payload.unwrap_err();
+
+    let expected_message = format!("Resource not found: Certificate({:#})", Hash([0; 32]));
+    assert!(matches!(error, ClientError::Call(obj) if obj.message() == expected_message));
+}
+
+#[rstest]
+#[awt]
+#[test_log::test(tokio::test)]
+async fn certificate_error_message(#[future] raw_rpc: RawRpcContext) {
+    let rpc = raw_rpc.rpc.into_rpc();
+    let params = vec![Hash([0; 32])];
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "method": "interop_getCertificateHeader",
+        "params": params,
+        "id": 0
+    });
+    let (response, _) = rpc
+        .raw_json_request(&serde_json::to_string(&payload).unwrap(), 1)
+        .await
+        .unwrap();
+    let json = serde_json::from_str::<serde_json::Value>(&response).unwrap();
+    let json = serde_json::to_string_pretty(&json).unwrap();
+
+    assert_snapshot!(
+        "get_certificate_header::not_found",
+        json,
+        &serde_json::to_string_pretty(&json!({
+            "payload": payload,
+            "raw_response": response
+        }))
+        .unwrap()
+    );
+}
+
+#[rstest]
+#[awt]
+#[test_log::test(tokio::test)]
+async fn certificate_header(#[future] raw_rpc: RawRpcContext) {
+    let rpc = raw_rpc.rpc.into_rpc();
+    let certificate = Certificate::new_for_test(1.into(), 0);
+    let id = certificate.hash();
+
+    let params = vec![certificate];
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "method": "interop_sendCertificate",
+        "params": params,
+        "id": 0
+    });
+    let (_, _) = rpc
+        .raw_json_request(&serde_json::to_string(&payload).unwrap(), 1)
+        .await
+        .unwrap();
+
+    let params = vec![id];
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "method": "interop_getCertificateHeader",
+        "params": params,
+        "id": 0
+    });
+    let (response, _) = rpc
+        .raw_json_request(&serde_json::to_string(&payload).unwrap(), 1)
+        .await
+        .unwrap();
+    let json = serde_json::from_str::<serde_json::Value>(&response).unwrap();
+    let json = serde_json::to_string_pretty(&json).unwrap();
+
+    assert_snapshot!(
+        "get_certificate_header::found",
+        json,
+        &serde_json::to_string_pretty(&json!({
+            "payload": payload,
+            "raw_response": response
+        }))
+        .unwrap()
+    );
+}

--- a/crates/agglayer-node/src/rpc/tests/get_tx_status.rs
+++ b/crates/agglayer-node/src/rpc/tests/get_tx_status.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use agglayer_config::Config;
+use agglayer_storage::storage::{pending_db_cf_definitions, state_db_cf_definitions, DB};
+use agglayer_storage::stores::pending::PendingStore;
+use agglayer_storage::stores::state::StateStore;
+use agglayer_storage::tests::TempDBDir;
+use ethers::providers::{Http, Middleware, Provider, ProviderExt as _};
+use ethers::types::{TransactionRequest, H256};
+use ethers::utils::Anvil;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::core::ClientError;
+use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::rpc_params;
+
+use super::next_available_addr;
+use crate::rpc::tests::DummyStore;
+use crate::rpc::{self, TxStatus};
+use crate::{kernel::Kernel, rpc::AgglayerImpl};
+
+#[test_log::test(tokio::test)]
+async fn check_tx_status() {
+    let anvil = Anvil::new().block_time(1u64).spawn();
+    let client = Provider::<Http>::connect(&anvil.endpoint()).await;
+    let accounts = client.get_accounts().await.unwrap();
+    let from = accounts[0];
+    let to = accounts[1];
+
+    let tx = TransactionRequest::new().to(to).value(1000).from(from);
+
+    let hash = client
+        .send_transaction(tx, None)
+        .await
+        .unwrap()
+        .await
+        .unwrap()
+        .unwrap()
+        .transaction_hash;
+
+    let mut config = Config::new_for_test();
+    let addr = next_available_addr();
+    if let std::net::IpAddr::V4(ip) = addr.ip() {
+        config.rpc.host = ip;
+    }
+    config.rpc.port = addr.port();
+
+    let config = Arc::new(config);
+
+    let kernel = Kernel::new(client, config.clone());
+
+    let (certificate_sender, _certificate_receiver) = tokio::sync::mpsc::channel(1);
+    let _server_handle = AgglayerImpl::new(
+        kernel,
+        certificate_sender,
+        Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
+    )
+    .start(config.clone())
+    .await
+    .unwrap();
+
+    let url = format!("http://{}/", config.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
+
+    let res: TxStatus = client
+        .request("interop_getTxStatus", rpc_params![hash])
+        .await
+        .unwrap();
+
+    // The transaction is not yet mined, so we should get a pending status
+    assert_eq!(res, "pending");
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let res: TxStatus = client
+        .request("interop_getTxStatus", rpc_params![hash])
+        .await
+        .unwrap();
+
+    assert_eq!(res, "done");
+}
+
+#[test_log::test(tokio::test)]
+async fn check_tx_status_fail() {
+    let anvil = Anvil::new().block_time(1u64).spawn();
+    let client = Provider::<Http>::connect(&anvil.endpoint()).await;
+    let (certificate_sender, _certificate_receiver) = tokio::sync::mpsc::channel(1);
+
+    let mut config = Config::new_for_test();
+    let addr = next_available_addr();
+    if let std::net::IpAddr::V4(ip) = addr.ip() {
+        config.rpc.host = ip;
+    }
+    let config = Arc::new(config);
+
+    let kernel = Kernel::new(client, config.clone());
+
+    let tmp = TempDBDir::new();
+    let db = Arc::new(DB::open_cf(tmp.path.as_path(), pending_db_cf_definitions()).unwrap());
+    let tmp = TempDBDir::new();
+    let store_db = Arc::new(DB::open_cf(tmp.path.as_path(), state_db_cf_definitions()).unwrap());
+    let store = Arc::new(PendingStore::new(db));
+    let state = Arc::new(StateStore::new(store_db));
+
+    let _server_handle = AgglayerImpl::new(kernel, certificate_sender, store, state)
+        .start(config.clone())
+        .await
+        .unwrap();
+
+    let url = format!("http://{}/", config.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
+
+    // Try to get status using a non-existent address
+    let fake_tx_hash = H256([0x27; 32]);
+    let result: Result<TxStatus, ClientError> = client
+        .request("interop_getTxStatus", rpc_params![fake_tx_hash])
+        .await;
+
+    match result.unwrap_err() {
+        ClientError::Call(err) => {
+            assert_eq!(err.code(), rpc::error::code::STATUS_ERROR);
+
+            let data_expected = serde_json::json! {
+                { "status": { "tx-not-found": { "hash":  fake_tx_hash} } }
+            };
+            let data = serde_json::to_value(err.data().expect("data should not be empty")).unwrap();
+            assert_eq!(data_expected, data);
+        }
+        _ => panic!("Unexpected error returned"),
+    }
+}

--- a/crates/agglayer-node/src/rpc/tests/mod.rs
+++ b/crates/agglayer-node/src/rpc/tests/mod.rs
@@ -286,7 +286,7 @@ async fn check_tx_status_fail() {
 }
 
 #[tokio::test]
-async fn get_certificate_header_after_sending_the_certif() {
+async fn get_certificate_header_after_sending_the_certificate() {
     let _ = tracing_subscriber::FmtSubscriber::builder()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init();

--- a/crates/agglayer-node/src/rpc/tests/mod.rs
+++ b/crates/agglayer-node/src/rpc/tests/mod.rs
@@ -3,11 +3,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use agglayer_config::Config;
-use agglayer_storage::storage::{pending_db_cf_definitions, DB};
+use agglayer_storage::storage::{pending_db_cf_definitions, state_db_cf_definitions, DB};
 use agglayer_storage::stores::pending::PendingStore;
-use agglayer_storage::stores::PendingCertificateWriter;
+use agglayer_storage::stores::state::StateStore;
+use agglayer_storage::stores::{PendingCertificateWriter, StateReader, StateWriter};
 use agglayer_storage::tests::TempDBDir;
-use agglayer_types::{Certificate, NetworkId};
+use agglayer_types::{
+    Certificate, CertificateHeader, CertificateId, CertificateStatus, Hash, NetworkId,
+};
 use ethers::providers::{self, Http, Middleware, Provider, ProviderExt as _};
 use ethers::types::{TransactionRequest, H256};
 use ethers::utils::Anvil;
@@ -44,10 +47,15 @@ async fn healthcheck_method_can_be_called() {
 
     let kernel = Kernel::new(provider, config.clone());
 
-    let _server_handle = AgglayerImpl::new(kernel, certificate_sender, Arc::new(DummyStore {}))
-        .start(config.clone())
-        .await
-        .unwrap();
+    let _server_handle = AgglayerImpl::new(
+        kernel,
+        certificate_sender,
+        Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
+    )
+    .start(config.clone())
+    .await
+    .unwrap();
 
     let http_client = Client::builder(TokioExecutor::new()).build_http();
     let uri = format!("http://{}/health", config.rpc_addr());
@@ -103,10 +111,15 @@ async fn check_tx_status() {
     let kernel = Kernel::new(client, config.clone());
 
     let (certificate_sender, _certificate_receiver) = tokio::sync::mpsc::channel(1);
-    let _server_handle = AgglayerImpl::new(kernel, certificate_sender, Arc::new(DummyStore {}))
-        .start(config.clone())
-        .await
-        .unwrap();
+    let _server_handle = AgglayerImpl::new(
+        kernel,
+        certificate_sender,
+        Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
+    )
+    .start(config.clone())
+    .await
+    .unwrap();
 
     let url = format!("http://{}/", config.rpc_addr());
     let client = HttpClientBuilder::default().build(url).unwrap();
@@ -149,15 +162,20 @@ async fn send_certificate_method_can_be_called() {
 
     let kernel = Kernel::new(provider, config.clone());
 
-    let _server_handle = AgglayerImpl::new(kernel, certificate_sender, Arc::new(DummyStore {}))
-        .start(config.clone())
-        .await
-        .unwrap();
+    let _server_handle = AgglayerImpl::new(
+        kernel,
+        certificate_sender,
+        Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
+    )
+    .start(config.clone())
+    .await
+    .unwrap();
 
     let url = format!("http://{}/", config.rpc_addr());
     let client = HttpClientBuilder::default().build(url).unwrap();
 
-    let _: () = client
+    let _: CertificateId = client
         .request(
             "interop_sendCertificate",
             rpc_params![Certificate::new_for_test(1.into(), 0)],
@@ -188,10 +206,15 @@ async fn send_certificate_method_can_be_called_and_fail() {
 
     let kernel = Kernel::new(provider, config.clone());
 
-    let _server_handle = AgglayerImpl::new(kernel, certificate_sender, Arc::new(DummyStore {}))
-        .start(config.clone())
-        .await
-        .unwrap();
+    let _server_handle = AgglayerImpl::new(
+        kernel,
+        certificate_sender,
+        Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
+    )
+    .start(config.clone())
+    .await
+    .unwrap();
 
     let url = format!("http://{}/", config.rpc_addr());
     let client = HttpClientBuilder::default().build(url).unwrap();
@@ -229,9 +252,12 @@ async fn check_tx_status_fail() {
 
     let tmp = TempDBDir::new();
     let db = Arc::new(DB::open_cf(tmp.path.as_path(), pending_db_cf_definitions()).unwrap());
+    let tmp = TempDBDir::new();
+    let store_db = Arc::new(DB::open_cf(tmp.path.as_path(), state_db_cf_definitions()).unwrap());
     let store = Arc::new(PendingStore::new(db));
+    let state = Arc::new(StateStore::new(store_db));
 
-    let _server_handle = AgglayerImpl::new(kernel, certificate_sender, store)
+    let _server_handle = AgglayerImpl::new(kernel, certificate_sender, store, state)
         .start(config.clone())
         .await
         .unwrap();
@@ -259,6 +285,73 @@ async fn check_tx_status_fail() {
     }
 }
 
+#[tokio::test]
+async fn get_certificate_header_after_sending_the_certif() {
+    let _ = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let tmp = TempDBDir::new();
+    let mut config = Config::new(&tmp.path);
+    let state_db =
+        Arc::new(DB::open_cf(&config.storage.state_db_path, state_db_cf_definitions()).unwrap());
+    let pending_db = Arc::new(
+        DB::open_cf(&config.storage.pending_db_path, pending_db_cf_definitions()).unwrap(),
+    );
+
+    let state_store = Arc::new(StateStore::new(state_db));
+    let pending_store = Arc::new(PendingStore::new(pending_db));
+
+    let addr = next_available_addr();
+    if let IpAddr::V4(ip) = addr.ip() {
+        config.rpc.host = ip;
+    }
+    config.rpc.port = addr.port();
+
+    let config = Arc::new(config);
+
+    let (provider, _mock) = providers::Provider::mocked();
+    let (certificate_sender, mut certificate_receiver) = tokio::sync::mpsc::channel(1);
+
+    let kernel = Kernel::new(provider, config.clone());
+
+    let _server_handle = AgglayerImpl::new(kernel, certificate_sender, pending_store, state_store)
+        .start(config.clone())
+        .await
+        .unwrap();
+
+    let url = format!("http://{}/", config.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
+
+    let certificate = Certificate::new_for_test(1.into(), 0);
+    let id = certificate.hash();
+
+    let res: CertificateId = client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    assert_eq!(id, res);
+    assert!(certificate_receiver.try_recv().is_ok());
+
+    let payload: CertificateHeader = client
+        .request("interop_getCertificateHeader", rpc_params![id])
+        .await
+        .unwrap();
+
+    assert_eq!(payload.certificate_id, id);
+    assert_eq!(payload.status, CertificateStatus::Pending);
+
+    let payload: Result<CertificateHeader, ClientError> = client
+        .request("interop_getCertificateHeader", rpc_params![Hash([0; 32])])
+        .await;
+
+    let error = payload.unwrap_err();
+
+    let expected_message = format!("Resource not found: Certificate({:#})", Hash([0; 32]));
+    assert!(matches!(error, ClientError::Call(obj) if obj.message() == expected_message));
+}
+
 fn next_available_addr() -> std::net::SocketAddr {
     use std::net::{TcpListener, TcpStream};
 
@@ -284,6 +377,56 @@ fn next_available_addr() -> std::net::SocketAddr {
 
 struct DummyStore {}
 
+impl StateWriter for DummyStore {
+    fn insert_certificate_header(
+        &self,
+        _certificate: &Certificate,
+        _status: agglayer_types::CertificateStatus,
+    ) -> Result<(), agglayer_storage::error::Error> {
+        Ok(())
+    }
+    fn update_certificate_header_status(
+        &self,
+        _certificate_id: &agglayer_types::CertificateId,
+        _status: &CertificateStatus,
+    ) -> Result<(), agglayer_storage::error::Error> {
+        Ok(())
+    }
+}
+
+impl StateReader for DummyStore {
+    fn get_active_networks(&self) -> Result<Vec<NetworkId>, agglayer_storage::error::Error> {
+        todo!()
+    }
+
+    fn get_certificate_header(
+        &self,
+        _certificate_id: &agglayer_types::CertificateId,
+    ) -> Result<Option<agglayer_types::CertificateHeader>, agglayer_storage::error::Error> {
+        Ok(None)
+    }
+
+    fn get_certificate_header_by_cursor(
+        &self,
+        _network_id: NetworkId,
+        _height: agglayer_types::Height,
+    ) -> Result<Option<agglayer_types::CertificateHeader>, agglayer_storage::error::Error> {
+        todo!()
+    }
+
+    fn get_current_settled_height(
+        &self,
+    ) -> Result<
+        Vec<(
+            NetworkId,
+            agglayer_types::Height,
+            agglayer_types::CertificateId,
+        )>,
+        agglayer_storage::error::Error,
+    > {
+        todo!()
+    }
+}
 impl PendingCertificateWriter for DummyStore {
     fn insert_pending_certificate(
         &self,

--- a/crates/agglayer-node/src/rpc/tests/send_certificate.rs
+++ b/crates/agglayer-node/src/rpc/tests/send_certificate.rs
@@ -1,0 +1,97 @@
+use std::{net::IpAddr, sync::Arc};
+
+use agglayer_config::Config;
+use agglayer_types::{Certificate, CertificateId};
+use ethers::providers;
+use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
+
+use super::next_available_addr;
+use crate::{
+    kernel::Kernel,
+    rpc::{tests::DummyStore, AgglayerImpl},
+};
+
+#[test_log::test(tokio::test)]
+async fn send_certificate_method_can_be_called() {
+    let _ = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let mut config = Config::new_for_test();
+    let addr = next_available_addr();
+    if let IpAddr::V4(ip) = addr.ip() {
+        config.rpc.host = ip;
+    }
+    config.rpc.port = addr.port();
+
+    let config = Arc::new(config);
+
+    let (provider, _mock) = providers::Provider::mocked();
+    let (certificate_sender, mut certificate_receiver) = tokio::sync::mpsc::channel(1);
+
+    let kernel = Kernel::new(provider, config.clone());
+
+    let _server_handle = AgglayerImpl::new(
+        kernel,
+        certificate_sender,
+        Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
+    )
+    .start(config.clone())
+    .await
+    .unwrap();
+
+    let url = format!("http://{}/", config.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
+
+    let _: CertificateId = client
+        .request(
+            "interop_sendCertificate",
+            rpc_params![Certificate::new_for_test(1.into(), 0)],
+        )
+        .await
+        .unwrap();
+
+    assert!(certificate_receiver.try_recv().is_ok());
+}
+
+#[test_log::test(tokio::test)]
+async fn send_certificate_method_can_be_called_and_fail() {
+    let mut config = Config::new_for_test();
+    let addr = next_available_addr();
+    if let IpAddr::V4(ip) = addr.ip() {
+        config.rpc.host = ip;
+    }
+    config.rpc.port = addr.port();
+
+    let config = Arc::new(config);
+
+    let (provider, _mock) = providers::Provider::mocked();
+    let (certificate_sender, certificate_receiver) = tokio::sync::mpsc::channel(1);
+
+    let kernel = Kernel::new(provider, config.clone());
+
+    let _server_handle = AgglayerImpl::new(
+        kernel,
+        certificate_sender,
+        Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
+    )
+    .start(config.clone())
+    .await
+    .unwrap();
+
+    let url = format!("http://{}/", config.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
+
+    drop(certificate_receiver);
+
+    let res: Result<(), _> = client
+        .request(
+            "interop_sendCertificate",
+            rpc_params![Certificate::default()],
+        )
+        .await;
+
+    assert!(res.is_err());
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__get_certificate_header__get_certificate_header::found.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__get_certificate_header__get_certificate_header::found.snap
@@ -1,0 +1,17 @@
+---
+source: crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
+expression: "{\n  \"payload\": {\n    \"id\": 0,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"interop_getCertificateHeader\",\n    \"params\": [\n      \"0x5063586f6efc738b82ab2b3a4acfe5b4cd52b16bd8ba11c3553da34bf7af4f1a\"\n    ]\n  },\n  \"raw_response\": \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":0,\\\"result\\\":{\\\"network_id\\\":1,\\\"height\\\":0,\\\"epoch_number\\\":null,\\\"certificate_index\\\":null,\\\"certificate_id\\\":\\\"0x5063586f6efc738b82ab2b3a4acfe5b4cd52b16bd8ba11c3553da34bf7af4f1a\\\",\\\"new_local_exit_root\\\":\\\"0x0000000000000000000000000000000000000000000000000000000000000000\\\",\\\"status\\\":\\\"Pending\\\"}}\"\n}"
+---
+{
+  "id": 0,
+  "jsonrpc": "2.0",
+  "result": {
+    "certificate_id": "0x5063586f6efc738b82ab2b3a4acfe5b4cd52b16bd8ba11c3553da34bf7af4f1a",
+    "certificate_index": null,
+    "epoch_number": null,
+    "height": 0,
+    "network_id": 1,
+    "new_local_exit_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "status": "Pending"
+  }
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__get_certificate_header__get_certificate_header::not_found.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__get_certificate_header__get_certificate_header::not_found.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
+expression: "{\n  \"payload\": {\n    \"id\": 0,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"interop_getCertificateHeader\",\n    \"params\": [\n      \"0x0000000000000000000000000000000000000000000000000000000000000000\"\n    ]\n  },\n  \"response\": \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":0,\\\"error\\\":{\\\"code\\\":-10007,\\\"message\\\":\\\"Resource not found: Certificate(0x0000000000000000000000000000000000000000000000000000000000000000)\\\",\\\"data\\\":{\\\"resource-not-found\\\":\\\"Certificate(0x0000000000000000000000000000000000000000000000000000000000000000)\\\"}}}\"\n}"
+---
+{
+  "error": {
+    "code": -10007,
+    "data": {
+      "resource-not-found": "Certificate(0x0000000000000000000000000000000000000000000000000000000000000000)"
+    },
+    "message": "Resource not found: Certificate(0x0000000000000000000000000000000000000000000000000000000000000000)"
+  },
+  "id": 0,
+  "jsonrpc": "2.0"
+}

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -13,6 +13,7 @@ rand = { version = "0.8.5", optional = true }
 rocksdb = "0.22.0"
 serde.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 agglayer-config = { path = "../agglayer-config" }
 agglayer-types = { path = "../agglayer-types" }

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 arc-swap.workspace = true
-bincode = "1.3.3"
+bincode.workspace = true
 hex.workspace = true
 parking_lot = "0.12.3"
 rand = { version = "0.8.5", optional = true }

--- a/crates/agglayer-storage/benches/latest_certificate_bench.rs
+++ b/crates/agglayer-storage/benches/latest_certificate_bench.rs
@@ -43,7 +43,7 @@ fn bench_latest_certificate(c: &mut Criterion) {
         for i in 1..=expected {
             db.put::<LatestSettledCertificatePerNetworkColumn>(
                 &i.into(),
-                &SettledCertificate([0; 32], 0, 0),
+                &SettledCertificate([0; 32].into(), 0, 0),
             )
             .expect("Unable to put certificate into storage");
         }

--- a/crates/agglayer-storage/src/columns/balance_tree_per_network/tests.rs
+++ b/crates/agglayer-storage/src/columns/balance_tree_per_network/tests.rs
@@ -1,3 +1,5 @@
+use agglayer_types::Hash;
+
 use super::{Key, KeyType};
 use crate::columns::Codec as _;
 
@@ -22,7 +24,7 @@ fn can_serialize_a_root_key() {
 fn can_serialize_a_node_key() {
     let key = Key {
         network_id: 1,
-        key_type: KeyType::Node([1; 32]),
+        key_type: KeyType::Node(Hash([1; 32])),
     };
 
     //                  -> [  network ][ key type ]
@@ -41,7 +43,7 @@ fn can_serialize_a_node_key() {
 fn can_serialize_a_leaf_key() {
     let key = Key {
         network_id: 1,
-        key_type: KeyType::Leaf([1; 32]),
+        key_type: KeyType::Leaf(Hash([1; 32])),
     };
 
     //                  -> [  network ][ key type ]

--- a/crates/agglayer-storage/src/columns/certificate_header/tests.rs
+++ b/crates/agglayer-storage/src/columns/certificate_header/tests.rs
@@ -5,7 +5,7 @@ use crate::columns::Codec as _;
 
 #[test]
 fn can_parse_key() {
-    let key: CertificateId = [1; 32];
+    let key: CertificateId = [1; 32].into();
 
     let encoded = key.encode().expect("Unable to encode key");
 
@@ -18,11 +18,12 @@ fn can_parse_key() {
 fn can_parse_value() {
     let value = Value {
         network_id: 1.into(),
-        certificate_id: [1; 32],
+        certificate_id: [1; 32].into(),
         height: 2,
         epoch_number: Some(3),
         certificate_index: Some(4),
-        new_local_exit_root: [5; 32],
+        new_local_exit_root: [5; 32].into(),
+        status: agglayer_types::CertificateStatus::Pending,
     };
 
     let encoded = value.encode().expect("Unable to encode value");
@@ -56,5 +57,6 @@ fn can_parse_value() {
         ]
     );
 
-    assert!(encoded[94..].is_empty());
+    assert_eq!(encoded[94..98], [0, 0, 0, 0]);
+    assert!(encoded[98..].is_empty());
 }

--- a/crates/agglayer-storage/src/columns/certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/certificate_per_network/mod.rs
@@ -1,4 +1,4 @@
-use agglayer_types::CertificateHeader;
+use agglayer_types::CertificateId;
 use serde::{Deserialize, Serialize};
 
 use super::{Codec, ColumnSchema, CERTIFICATE_PER_NETWORK_CF};
@@ -10,9 +10,9 @@ mod tests;
 ///
 /// ## Column definition
 ///
-/// | key                     | value               |
-/// | --                      | --                  |
-/// | (`NetworkId`, `Height`) | `CertificateHeader` |
+/// | key                     | value           |
+/// | --                      | --              |
+/// | (`NetworkId`, `Height`) | `CertificateId` |
 pub struct CertificatePerNetworkColumn;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -25,7 +25,7 @@ impl Codec for Key {}
 
 impl ColumnSchema for CertificatePerNetworkColumn {
     type Key = Key;
-    type Value = CertificateHeader;
+    type Value = CertificateId;
 
     const COLUMN_FAMILY_NAME: &'static str = CERTIFICATE_PER_NETWORK_CF;
 }

--- a/crates/agglayer-storage/src/columns/certificate_per_network/tests.rs
+++ b/crates/agglayer-storage/src/columns/certificate_per_network/tests.rs
@@ -21,11 +21,12 @@ fn can_parse_key() {
 fn can_parse_value() {
     let value = CertificateHeader {
         network_id: 1.into(),
-        certificate_id: [1; 32],
+        certificate_id: [1; 32].into(),
         epoch_number: Some(3),
         certificate_index: Some(4),
         height: 0,
-        new_local_exit_root: [0; 32],
+        new_local_exit_root: [0; 32].into(),
+        status: agglayer_types::CertificateStatus::Pending,
     };
 
     let encoded = value.encode().expect("Unable to encode value");
@@ -59,5 +60,6 @@ fn can_parse_value() {
         ]
     );
 
-    assert!(encoded[94..].is_empty());
+    assert_eq!(encoded[94..98], [0, 0, 0, 0]);
+    assert!(encoded[98..].is_empty());
 }

--- a/crates/agglayer-storage/src/columns/latest_certificate_per_network/tests.rs
+++ b/crates/agglayer-storage/src/columns/latest_certificate_per_network/tests.rs
@@ -16,7 +16,7 @@ fn can_parse_key() {
 
 #[test]
 fn can_parse_value() {
-    let value = SettledCertificate([1; 32], 10, 21);
+    let value = SettledCertificate([1; 32].into(), 10, 21);
 
     let encoded = value.encode().expect("Unable to encode value");
 

--- a/crates/agglayer-storage/src/columns/nullifier_tree_per_network/tests.rs
+++ b/crates/agglayer-storage/src/columns/nullifier_tree_per_network/tests.rs
@@ -22,7 +22,7 @@ fn can_serialize_a_root_key() {
 fn can_serialize_a_node_key() {
     let key = Key {
         network_id: 1,
-        key_type: KeyType::Node([1; 32]),
+        key_type: KeyType::Node([1; 32].into()),
     };
 
     //                  -> [  network ][ key type ]
@@ -41,7 +41,7 @@ fn can_serialize_a_node_key() {
 fn can_serialize_a_leaf_key() {
     let key = Key {
         network_id: 1,
-        key_type: KeyType::Leaf([1; 32]),
+        key_type: KeyType::Leaf([1; 32].into()),
     };
 
     //                  -> [  network ][ key type ]

--- a/crates/agglayer-storage/src/columns/proof_per_certificate/tests.rs
+++ b/crates/agglayer-storage/src/columns/proof_per_certificate/tests.rs
@@ -5,7 +5,7 @@ use crate::columns::{
 
 #[test]
 fn can_parse_key() {
-    let key: CertificateId = [1; 32];
+    let key: CertificateId = [1; 32].into();
 
     let encoded = key.encode().expect("Unable to encode key");
 

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -39,7 +39,7 @@ impl DB {
             .ok_or(Error::ColumnFamilyNotFound)?;
 
         self.rocksdb
-            .get_cf(&cf, key)?
+            .get_cf(&cf, &key)?
             .map(|v| C::Value::decode(&v[..]))
             // If the value is not found, return None.
             // If the value is found, decode it and wrap it in Some to propagate decode error.
@@ -169,6 +169,7 @@ pub fn state_db_cf_definitions() -> Vec<ColumnFamilyDescriptor> {
     [
         crate::columns::LATEST_SETTLED_CERTIFICATE_PER_NETWORK_CF,
         crate::columns::CERTIFICATE_PER_NETWORK_CF,
+        crate::columns::CERTIFICATE_HEADER_CF,
     ]
     .iter_mut()
     .map(|cf| {

--- a/crates/agglayer-storage/src/stores/interfaces/reader.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/reader.rs
@@ -36,6 +36,12 @@ pub trait MetadataReader: Send + Sync {
 pub trait StateReader: Send + Sync {
     /// Get the active networks.
     fn get_active_networks(&self) -> Result<Vec<NetworkId>, Error>;
+
+    fn get_certificate_header(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<CertificateHeader>, Error>;
+
     fn get_certificate_header_by_cursor(
         &self,
         network_id: NetworkId,

--- a/crates/agglayer-storage/src/stores/interfaces/writer.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/writer.rs
@@ -1,4 +1,4 @@
-use agglayer_types::{Certificate, CertificateId, Height, NetworkId, Proof};
+use agglayer_types::{Certificate, CertificateId, CertificateStatus, Height, NetworkId, Proof};
 
 use crate::error::Error;
 
@@ -18,7 +18,17 @@ pub trait MetadataWriter: Send + Sync {
 }
 
 pub trait StateWriter: Send + Sync {
-    fn insert_certificate_header(&self, certificate: &Certificate) -> Result<(), Error>;
+    fn insert_certificate_header(
+        &self,
+        certificate: &Certificate,
+        status: CertificateStatus,
+    ) -> Result<(), Error>;
+
+    fn update_certificate_header_status(
+        &self,
+        certificate_id: &CertificateId,
+        status: &CertificateStatus,
+    ) -> Result<(), Error>;
 }
 
 pub trait PendingCertificateWriter: Send + Sync {
@@ -27,6 +37,7 @@ pub trait PendingCertificateWriter: Send + Sync {
         network_id: NetworkId,
         height: Height,
     ) -> Result<(), Error>;
+
     fn insert_pending_certificate(
         &self,
         network_id: NetworkId,

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -4,6 +4,7 @@ use agglayer_types::{
     Certificate, CertificateHeader, CertificateId, CertificateStatus, Height, NetworkId,
 };
 use rocksdb::{Direction, ReadOptions};
+use tracing::warn;
 
 use super::{StateReader, StateWriter};
 use crate::{
@@ -121,7 +122,17 @@ impl StateReader for StateStore {
                 height,
             })?
             .map_or(Ok(None), |certificate_id| {
-                self.get_certificate_header(&certificate_id)
+                let result = self.get_certificate_header(&certificate_id);
+
+                if let Ok(None) = result {
+                    warn!(
+                        "Certificate header not found for certificate_id: {} while having a \
+                         reference in the CertificatePerNetworkColumn",
+                        certificate_id
+                    );
+                }
+
+                result
             })
     }
 

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -1,11 +1,14 @@
 use std::sync::Arc;
 
-use agglayer_types::{Certificate, CertificateHeader, CertificateId, Height, NetworkId};
+use agglayer_types::{
+    Certificate, CertificateHeader, CertificateId, CertificateStatus, Height, NetworkId,
+};
 use rocksdb::{Direction, ReadOptions};
 
 use super::{StateReader, StateWriter};
 use crate::{
     columns::{
+        certificate_header::CertificateHeaderColumn,
         certificate_per_network::{self, CertificatePerNetworkColumn},
         latest_certificate_per_network::{
             LatestSettledCertificatePerNetworkColumn, SettledCertificate,
@@ -30,21 +33,54 @@ impl StateStore {
 }
 
 impl StateWriter for StateStore {
-    fn insert_certificate_header(&self, certificate: &Certificate) -> Result<(), Error> {
-        self.db.put::<CertificatePerNetworkColumn>(
-            &certificate_per_network::Key {
-                network_id: *certificate.network_id,
-                height: certificate.height,
-            },
+    fn insert_certificate_header(
+        &self,
+        certificate: &Certificate,
+        status: CertificateStatus,
+    ) -> Result<(), Error> {
+        // TODO: make it a batch write
+        self.db.put::<CertificateHeaderColumn>(
+            &certificate.hash(),
             &CertificateHeader {
                 certificate_id: certificate.hash(),
                 network_id: certificate.network_id,
                 height: certificate.height,
                 epoch_number: None,
                 certificate_index: None,
-                new_local_exit_root: certificate.new_local_exit_root,
+                new_local_exit_root: certificate.new_local_exit_root.into(),
+                status: status.clone(),
             },
-        )
+        )?;
+
+        if let CertificateStatus::Settled = status {
+            // TODO: Check certificate conflict during insert (if conflict it's too late)
+            self.db.put::<CertificatePerNetworkColumn>(
+                &certificate_per_network::Key {
+                    network_id: *certificate.network_id,
+                    height: certificate.height,
+                },
+                &certificate.hash(),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn update_certificate_header_status(
+        &self,
+        certificate_id: &CertificateId,
+        status: &CertificateStatus,
+    ) -> Result<(), Error> {
+        // TODO: make lockguard for certificate_id
+        let certificate_header = self.db.get::<CertificateHeaderColumn>(certificate_id)?;
+
+        if let Some(mut certificate_header) = certificate_header {
+            certificate_header.status = status.clone();
+            self.db
+                .put::<CertificateHeaderColumn>(certificate_id, &certificate_header)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -65,6 +101,15 @@ impl StateReader for StateStore {
             .filter_map(|v| v.ok())
             .collect())
     }
+
+    fn get_certificate_header(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<CertificateHeader>, Error> {
+        tracing::info!("get_certificate_header: {}", certificate_id);
+        self.db.get::<CertificateHeaderColumn>(certificate_id)
+    }
+
     fn get_certificate_header_by_cursor(
         &self,
         network_id: NetworkId,
@@ -74,6 +119,9 @@ impl StateReader for StateStore {
             .get::<CertificatePerNetworkColumn>(&certificate_per_network::Key {
                 network_id: *network_id,
                 height,
+            })?
+            .map_or(Ok(None), |certificate_id| {
+                self.get_certificate_header(&certificate_id)
             })
     }
 

--- a/crates/agglayer-storage/src/stores/state/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/tests.rs
@@ -18,7 +18,7 @@ fn can_retrieve_list_of_network() {
 
     db.put::<LatestSettledCertificatePerNetworkColumn>(
         &1.into(),
-        &SettledCertificate([0; 32], 0, 0),
+        &SettledCertificate([0; 32].into(), 0, 0),
     )
     .expect("Unable to put certificate into storage");
     assert!(store.get_active_networks().unwrap().len() == 1);

--- a/crates/agglayer-types/Cargo.toml
+++ b/crates/agglayer-types/Cargo.toml
@@ -15,7 +15,7 @@ sp1-core-machine.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-bincode = "1.3.3"
+bincode.workspace = true
 
 [features]
 default = []

--- a/crates/agglayer-types/Cargo.toml
+++ b/crates/agglayer-types/Cargo.toml
@@ -9,9 +9,13 @@ hex.workspace = true
 pessimistic-proof = { path = "../pessimistic-proof" }
 reth-primitives = { git = "https://github.com/sp1-patches/reth", default-features = false, branch = "sp1-reth" }
 serde.workspace = true
+serde_with.workspace = true
 sp1-sdk.workspace = true
 sp1-core-machine.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+bincode = "1.3.3"
 
 [features]
 default = []

--- a/crates/pessimistic-proof-program/Cargo.lock
+++ b/crates/pessimistic-proof-program/Cargo.lock
@@ -3740,6 +3740,7 @@ name = "pessimistic-proof"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "hex",
  "reth-primitives",
  "serde",
  "serde_json",

--- a/crates/pessimistic-proof-program/Cargo.lock
+++ b/crates/pessimistic-proof-program/Cargo.lock
@@ -5807,18 +5807,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/pessimistic-proof-test-suite/Cargo.toml
+++ b/crates/pessimistic-proof-test-suite/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/bin/ppgen.rs"
 [dependencies]
 agglayer-types = { path = "../agglayer-types" }
 base64.workspace = true
-bincode = "1.3.3"
+bincode.workspace = true
 clap.workspace = true
 ethers-signers.workspace = true
 reth-primitives = { git = "https://github.com/sp1-patches/reth", default-features = false, branch = "sp1-reth" }

--- a/crates/pessimistic-proof/Cargo.toml
+++ b/crates/pessimistic-proof/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3.3"
+hex.workspace = true
 reth-primitives = { git = "https://github.com/sp1-patches/reth", default-features = false, branch = "sp1-reth" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }

--- a/crates/pessimistic-proof/Cargo.toml
+++ b/crates/pessimistic-proof/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bincode = "1.3.3"
+bincode.workspace = true
 hex.workspace = true
 reth-primitives = { git = "https://github.com/sp1-patches/reth", default-features = false, branch = "sp1-reth" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/pessimistic-proof/src/imported_bridge_exit.rs
+++ b/crates/pessimistic-proof/src/imported_bridge_exit.rs
@@ -42,7 +42,7 @@ impl L1InfoTreeLeaf {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Error {
     #[error("Mismatch between the global index and the inclusion proof.")]
     MismatchGlobalIndexInclusionProof,

--- a/crates/pessimistic-proof/src/local_state.rs
+++ b/crates/pessimistic-proof/src/local_state.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     bridge_exit::{LeafType, L1_ETH, L1_NETWORK_ID},
     imported_bridge_exit::commit_imported_bridge_exits,
-    keccak::Digest,
+    keccak::{Digest, Hash},
     local_balance_tree::LocalBalanceTree,
     local_exit_tree::{hasher::Keccak256Hasher, LocalExitTree},
     multi_batch_header::{signature_commitment, MultiBatchHeader},
@@ -70,8 +70,8 @@ impl LocalNetworkState {
         let computed_root = self.exit_tree.get_root();
         if computed_root != multi_batch_header.prev_local_exit_root {
             return Err(ProofError::InvalidInitialLocalExitRoot {
-                got: computed_root,
-                expected: multi_batch_header.prev_local_exit_root,
+                got: Hash(computed_root),
+                expected: Hash(multi_batch_header.prev_local_exit_root),
             });
         }
         if self.balance_tree.root != multi_batch_header.prev_balance_root {

--- a/crates/pessimistic-proof/src/proof.rs
+++ b/crates/pessimistic-proof/src/proof.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use crate::{
     bridge_exit::{NetworkId, TokenInfo},
     imported_bridge_exit,
+    keccak::Hash,
     keccak::{keccak256_combine, Digest},
     local_exit_tree::hasher::Keccak256Hasher,
     local_state::{LocalNetworkState, StateCommitment},
@@ -13,10 +14,10 @@ use crate::{
 };
 
 /// Represents all errors that can occur while generating the proof.
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ProofError {
-    #[error("Invalid initial local exit root. Got: {got:?}, Expected: {expected:?}")]
-    InvalidInitialLocalExitRoot { got: Digest, expected: Digest },
+    #[error("Invalid initial local exit root. Got: {got}, Expected: {expected}")]
+    InvalidInitialLocalExitRoot { got: Hash, expected: Hash },
     #[error("Invalid final local exit root.")]
     InvalidFinalLocalExitRoot,
     #[error("Invalid initial balance root.")]
@@ -58,6 +59,8 @@ pub enum ProofError {
     InvalidImportedBridgeExitNetwork,
     #[error("Duplicate token {0:?} in balance proofs")]
     DuplicateTokenBalanceProof(TokenInfo),
+    #[error("Unknown error: {0}")]
+    Unknown(String),
 }
 
 /// Outputs of the pessimistic proof.

--- a/crates/pessimistic-proof/src/utils/smt.rs
+++ b/crates/pessimistic-proof/src/utils/smt.rs
@@ -11,7 +11,7 @@ pub trait ToBits<const NUM_BITS: usize> {
     fn to_bits(&self) -> [bool; NUM_BITS];
 }
 
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Error, Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub enum SmtError {
     #[error("trying to insert a key already in the SMT")]
     KeyAlreadyPresent,


### PR DESCRIPTION
# Description

This PR adds a new RPC that provide access to the `CertificateHeader`.

The goal is to provide a way to monitor and check the status of a particular `CertificateId`.

The definition is:

```
path: getCertificateHeader (interop_getCertificateHeader)
params: [ CertificateId ]
response: CertificateHeader
```

The `CertificateHeader` contains multiple things:

- `epoch_number` which is null until the certificate is settled in an epoch
- `certificate_index` which is null until the certificate is settled in an epoch, it represents the index of the certificate in the epoch
- `status` which represent the status of the certificate, it can be `Pending`, `InError` or `Settled`


An example of a `CertificateHeader` of a failed certificate with the reason:

```json
{
  "network_id": 1,
  "height": 0,
  "epoch_number": null,
  "certificate_index": null,
  "certificate_id": "0x548faaa7bd84fdd200e56791f0d88f97bc11f897b1bdc1f75704d9b99610b9e8",
  "new_local_exit_root": "0x030b33b7ce8e655ee40bf325c31d7f0ec29854f73c73f9e054bd820c79ea726e",
  "status": {
    "InError": {
      "error": {
        "ProofGenerationError": {
          "generation_type": "Native",
          "source": {
            "InvalidInitialLocalExitRoot": {
              "got": "0x27ae5ba08d7291c96c8cbddcc148bf48a6d68c7974b94356f53754ef6171d757",
              "expected": "0xf99fbc86af88be1a031b1d3aa12352bbc35c660f84f127100d98c722980dd5d7"
            }
          }
        }
      }
    }
  }
}
```


## Additions and Changes

- `sendCertificate` RPC now returns a `CertificateId`

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
