### PR TITLE
build: bump `tonic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 0.8.19",
- "tonic 0.12.2",
+ "tonic 0.12.3",
  "tonic-health",
  "tonic-reflection",
  "tower",
@@ -220,7 +220,7 @@ name = "agglayer-prover-types"
 version = "0.1.0"
 dependencies = [
  "prost 0.13.2",
- "tonic 0.12.2",
+ "tonic 0.12.3",
  "tonic-build",
 ]
 
@@ -3995,7 +3995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5479,7 +5479,7 @@ checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -5525,7 +5525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -7975,9 +7975,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8018,28 +8018,28 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0a34e6f706bae26b2b490e1da5c3f6a6ff87cae442bcbc7c881bab9631b5a7"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
 dependencies = [
  "async-stream",
  "prost 0.13.2",
  "tokio",
  "tokio-stream",
- "tonic 0.12.2",
+ "tonic 0.12.3",
 ]
 
 [[package]]
 name = "tonic-reflection"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b56b874eedb04f89907573b408eab1e87c1c1dce43aac6ad63742f57faa99ff"
+checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
 dependencies = [
  "prost 0.13.2",
  "prost-types 0.13.2",
  "tokio",
  "tokio-stream",
- "tonic 0.12.2",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -8688,7 +8688,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7976,8 +7976,7 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+source = "git+https://github.com/hyperium/tonic?tag=v0.12.3#4b8d2c46aa57e40b1e80077f4f7b7d4679027bb5"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1.0.58"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-util = "0.7.11"
 toml = "0.8.15"
-tonic = "0.12.2"
+tonic = "0.12.3"
 tower = "0.4.13"
 tracing = "0.1.40"
 tracing-appender = "0.2.3"
@@ -48,6 +48,15 @@ sp1-recursion-compiler = { git = "https://github.com/succinctlabs/sp1", tag = "v
 sp1-recursion-core = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.8-testnet" }
 sp1-sdk = "2.0.0"
 sp1-prover = "2.0.0"
+
+# Inject a newer `tonic` dependency into `gcloud-sdk` and `ethers-gcp-kms-signer`. This is to
+# address RUSTSEC-2024-0376. A long-term solution would be to avoid `ethers` in favour of `alloy`
+# since `ethers-gcp-kms-signer` seems to be hardly maintained.
+#
+# Note that due to the current limitation in Cargo `patch` feature, we cannot use the same
+# repository for source and target. Hence the use of the git repo URL as a workaround.
+[patch.crates-io]
+tonic = { git = "https://github.com/hyperium/tonic", tag = "v0.12.3" }
 
 # A hack to make the resolver pull in the correct sp1 branch when processing the reth and revm deps.
 # This is intended to be a temporary hotfix while the dependency issue in the upstream packages is

--- a/crates/agglayer-prover/Cargo.toml
+++ b/crates/agglayer-prover/Cargo.toml
@@ -17,7 +17,7 @@ tracing.workspace = true
 agglayer-config = { path = "../agglayer-config" }
 agglayer-prover-types = { path = "../agglayer-prover-types" }
 agglayer-telemetry = { path = "../agglayer-telemetry" }
-tonic = "0.12.2"
+tonic = "0.12.3"
 tower.workspace = true
-tonic-health = "0.12.2"
-tonic-reflection = "0.12.2"
+tonic-health = "0.12.3"
+tonic-reflection = "0.12.3"


### PR DESCRIPTION
# Description

Trying to address the `RUSTSEC-2024-0376` advisory by injecting a newer version of `tonic`.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
