### PR TITLE
feat: disable `sendTx` rate limit by default

### DIFF
--- a/crates/agglayer-config/src/rate_limiting.rs
+++ b/crates/agglayer-config/src/rate_limiting.rs
@@ -24,7 +24,7 @@ pub enum TimeRateLimit {
 impl TimeRateLimit {
     /// Default rate limiting for the `sendTx` call.
     pub const fn send_tx_default() -> Self {
-        Self::limited(1, Duration::from_secs(60 * 60))
+        Self::Unlimited
     }
 
     /// Create a time-based rate limiting
@@ -135,10 +135,7 @@ mod test {
 
     #[test]
     fn default_config() {
-        #[rustfmt::skip]
-        let config_str = "[send-tx]\n\
-            max-per-interval = 1\n\
-            time-interval = \"1h\"\n";
+        let config_str = "send-tx = \"unlimited\"";
         let parsed_default_config: RateLimitingConfig = toml::from_str(config_str).unwrap();
         assert_eq!(parsed_default_config, RateLimitingConfig::DEFAULT);
 

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -19,9 +19,8 @@ port = 9090
 host = "0.0.0.0"
 request-timeout = 180
 
-[rate-limiting.send-tx]
-max-per-interval = 1
-time-interval = "1h"
+[rate-limiting]
+send-tx = "unlimited"
 
 [rate-limiting.network]
 


### PR DESCRIPTION
# Description

* related #318
* spec #213

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
