### PR TITLE
feat: use `humantime` for `Duration` in config

### DIFF
--- a/crates/agglayer-config/src/epoch.rs
+++ b/crates/agglayer-config/src/epoch.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 /// The Epoch configuration.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -20,8 +20,7 @@ impl Default for Epoch {
 pub struct TimeClockConfig {
     #[serde(
         default = "default_epoch_duration",
-        serialize_with = "serialize_duration",
-        deserialize_with = "deserialize_duration",
+        with = "crate::with::HumanDuration",
         alias = "EpochDuration"
     )]
     pub epoch_duration: Duration,
@@ -39,22 +38,6 @@ fn default_epoch_duration() -> Duration {
     Duration::from_secs(60)
 }
 
-fn serialize_duration<S>(value: &Duration, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    s.serialize_u64(value.as_secs())
-}
-
-fn deserialize_duration<'de, D>(d: D) -> Result<Duration, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let seconds = u64::deserialize(d)?;
-
-    Ok(Duration::from_secs(seconds))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,7 +47,7 @@ mod tests {
         let epoch = Epoch::TimeClock(TimeClockConfig::default());
         let serialized = serde_json::to_string(&epoch).unwrap();
 
-        assert_eq!(serialized, r#"{"time-clock":{"epoch-duration":60}}"#);
+        assert_eq!(serialized, r#"{"time-clock":{"epoch-duration":"1m"}}"#);
     }
 
     #[test]

--- a/crates/agglayer-config/src/l1.rs
+++ b/crates/agglayer-config/src/l1.rs
@@ -2,11 +2,9 @@ use std::time::Duration;
 
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DurationSeconds};
 use url::Url;
 
 /// The L1 configuration.
-#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct L1 {
@@ -17,7 +15,7 @@ pub struct L1 {
     #[serde(alias = "RollupManagerContract")]
     pub rollup_manager_contract: Address,
     #[serde(default = "L1::default_rpc_timeout")]
-    #[serde_as(as = "DurationSeconds")]
+    #[serde(with = "crate::with::HumanDuration")]
     pub rpc_timeout: Duration,
 }
 

--- a/crates/agglayer-config/src/l2.rs
+++ b/crates/agglayer-config/src/l2.rs
@@ -1,15 +1,13 @@
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DurationSeconds};
 
 /// Configuration of the communication with the L2 nodes.
-#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct L2 {
+    #[serde(with = "crate::with::HumanDuration")]
     #[serde(default = "L2::default_rpc_timeout")]
-    #[serde_as(as = "DurationSeconds")]
     pub rpc_timeout: Duration,
 }
 

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -30,6 +30,7 @@ pub(crate) mod rpc;
 pub mod shutdown;
 pub mod storage;
 pub(crate) mod telemetry;
+mod with;
 
 pub use auth::{AuthConfig, GcpKmsConfig, LocalConfig, PrivateKey};
 pub use epoch::Epoch;

--- a/crates/agglayer-config/src/outbound.rs
+++ b/crates/agglayer-config/src/outbound.rs
@@ -2,8 +2,6 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use serde::Serialize;
-use serde_with::serde_as;
-use serde_with::DurationSeconds;
 
 /// Outbound configuration.
 #[derive(Serialize, Default, Debug, Deserialize, PartialEq, Eq)]
@@ -23,7 +21,6 @@ pub struct OutboundRpcConfig {
 
 /// Outbound RPC settle configuration that is used to configure the outbound
 /// RPC settle function call.
-#[serde_as]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename = "settle", rename_all = "kebab-case")]
 pub struct OutboundRpcSettleConfig {
@@ -33,7 +30,7 @@ pub struct OutboundRpcSettleConfig {
 
     /// Interval for the polling of the transaction.
     #[serde(default = "default_rpc_retry_interval")]
-    #[serde_as(as = "DurationSeconds")]
+    #[serde(with = "crate::with::HumanDuration")]
     pub retry_interval: Duration,
 
     /// Number of confirmations required for the transaction to resolve a
@@ -44,7 +41,7 @@ pub struct OutboundRpcSettleConfig {
     /// Timeout for the submission of the settlement transaction to L1,
     /// including the required number of confirmations.
     #[serde(default = "default_settlement_timeout")]
-    #[serde_as(as = "DurationSeconds")]
+    #[serde(with = "crate::with::HumanDuration")]
     pub settlement_timeout: Duration,
 }
 

--- a/crates/agglayer-config/src/prover.rs
+++ b/crates/agglayer-config/src/prover.rs
@@ -5,12 +5,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use serde_with::DurationSeconds;
 
 use crate::{shutdown::ShutdownConfig, telemetry::TelemetryConfig, Log};
 
 /// The Agglayer Prover configuration.
-#[serde_as]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct ProverConfig {
@@ -36,7 +34,7 @@ pub struct ProverConfig {
 
     /// The maximum duration of a request.
     #[serde(default = "default_max_request_duration")]
-    #[serde_as(as = "DurationSeconds")]
+    #[serde(with = "crate::with::HumanDuration")]
     pub max_request_duration: Duration,
 
     /// The maximum number of buffered queries.
@@ -75,11 +73,11 @@ pub struct CpuProverConfig {
     #[serde(default = "default_max_concurrency_limit")]
     pub max_concurrency_limit: usize,
 
-    #[serde_as(as = "Option<DurationSeconds>")]
+    #[serde_as(as = "Option<crate::with::HumanDuration>")]
     pub proving_request_timeout: Option<Duration>,
 
     #[serde(default = "default_cpu_proving_timeout")]
-    #[serde_as(as = "DurationSeconds")]
+    #[serde(with = "crate::with::HumanDuration")]
     pub proving_timeout: Duration,
 }
 
@@ -111,11 +109,11 @@ pub struct NetworkProverConfig {
     #[serde(default = "default_activation_network_prover")]
     pub enabled: bool,
 
-    #[serde_as(as = "Option<DurationSeconds>")]
+    #[serde_as(as = "Option<crate::with::HumanDuration>")]
     pub proving_request_timeout: Option<Duration>,
 
     #[serde(default = "default_network_proving_timeout")]
-    #[serde_as(as = "DurationSeconds")]
+    #[serde(with = "crate::with::HumanDuration")]
     pub proving_timeout: Duration,
 }
 

--- a/crates/agglayer-config/src/rate_limiting.rs
+++ b/crates/agglayer-config/src/rate_limiting.rs
@@ -16,7 +16,8 @@ pub enum TimeRateLimit {
     #[serde(untagged, rename_all = "kebab-case")]
     Limited {
         max_per_interval: u32,
-        #[serde(with = "humantime_serde")]
+
+        #[serde(with = "crate::with::HumanDuration")]
         time_interval: Duration,
     },
 }

--- a/crates/agglayer-config/src/rpc.rs
+++ b/crates/agglayer-config/src/rpc.rs
@@ -2,7 +2,7 @@ use std::{net::Ipv4Addr, str::FromStr, time::Duration};
 
 use jsonrpsee::core::TEN_MB_SIZE_BYTES;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_with::{serde_as, DurationSeconds};
+use serde_with::serde_as;
 
 /// The default port for the local RPC server.
 const DEFAULT_PORT: u16 = 9090;
@@ -36,9 +36,10 @@ pub struct RpcConfig {
     pub batch_request_limit: Option<u32>,
     /// The interval at which to send ping messages
     #[serde(skip)]
+    #[serde_as(as = "Option<crate::with::HumanDuration>")]
     pub ping_interval: Option<Duration>,
     /// Timeout for completion of an RPC request to the AggLayer node.
-    #[serde_as(as = "DurationSeconds")]
+    #[serde_as(as = "crate::with::HumanDuration")]
     #[serde(default = "default_request_timeout")]
     pub request_timeout: Duration,
 }

--- a/crates/agglayer-config/src/shutdown.rs
+++ b/crates/agglayer-config/src/shutdown.rs
@@ -2,15 +2,12 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use serde::Serialize;
-use serde_with::serde_as;
-use serde_with::DurationSeconds;
 
-#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct ShutdownConfig {
     #[serde(default = "default_shutdown_runtime_timeout")]
-    #[serde_as(as = "DurationSeconds")]
+    #[serde(with = "crate::with::HumanDuration")]
     pub runtime_timeout: Duration,
 }
 

--- a/crates/agglayer-config/src/with/human_duration.rs
+++ b/crates/agglayer-config/src/with/human_duration.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+
+use serde_with::serde_conv;
+
+serde_conv!(pub HumanDuration, Duration, HumanDurationImpl::new, HumanDurationImpl::get);
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy)]
+#[serde(untagged)]
+enum HumanDurationImpl {
+    Secs(u64),
+    Human(#[serde(with = "humantime_serde")] Duration),
+}
+
+impl HumanDurationImpl {
+    fn new(value: &Duration) -> Self {
+        Self::Human(*value)
+    }
+
+    pub fn get(self) -> Result<Duration, std::convert::Infallible> {
+        match self {
+            Self::Secs(secs) => Ok(Duration::from_secs(secs)),
+            Self::Human(duration) => Ok(duration),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use toml::toml;
+
+    #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+    struct TestConfig {
+        #[serde(with = "super::HumanDuration")]
+        time: Duration,
+    }
+
+    impl TestConfig {
+        fn from_secs(secs: u64) -> Self {
+            let time = Duration::from_secs(secs);
+            Self { time }
+        }
+
+        fn from_toml(value: toml::Value) -> Result<Self, toml::de::Error> {
+            value.try_into()
+        }
+
+        fn to_toml(&self) -> toml::Value {
+            toml::Value::try_from(self).unwrap()
+        }
+    }
+
+    #[test]
+    fn serialize() {
+        assert_eq!(
+            (TestConfig::from_secs(10)).to_toml(),
+            toml!(time = "10s").into(),
+        );
+        assert_eq!(
+            (TestConfig::from_secs(60)).to_toml(),
+            toml!(time = "1m").into(),
+        );
+        assert_eq!(
+            (TestConfig::from_secs(600)).to_toml(),
+            toml!(time = "10m").into(),
+        );
+        assert_eq!(
+            (TestConfig::from_secs(601)).to_toml(),
+            toml!(time = "10m 1s").into(),
+        );
+        assert_eq!(
+            (TestConfig::from_secs(3600)).to_toml(),
+            toml!(time = "1h").into(),
+        );
+    }
+
+    #[test]
+    fn deserialize() {
+        assert_eq!(
+            TestConfig::from_secs(10),
+            TestConfig::from_toml(toml!(time = 10).into()).unwrap(),
+        );
+        assert_eq!(
+            TestConfig::from_secs(10),
+            TestConfig::from_toml(toml!(time = "10s").into()).unwrap(),
+        );
+        assert_eq!(
+            TestConfig::from_toml(toml!(time = 70).into()).unwrap(),
+            TestConfig::from_toml(toml!(time = "1min 10s").into()).unwrap(),
+        );
+        assert!(TestConfig::from_toml("10s".into()).is_err());
+        assert!(TestConfig::from_toml(10.into()).is_err());
+    }
+}

--- a/crates/agglayer-config/src/with/mod.rs
+++ b/crates/agglayer-config/src/with/mod.rs
@@ -1,0 +1,9 @@
+//! Helper (de)serializers to be used with `#[serde(with)]` and `#[serde_as]`.
+
+mod human_duration;
+
+/// A config-friendly [std::time::Duration].
+///
+/// Can be specified as either human-readable string, such as `"1h"` or
+/// `"15min"`, or as an integer interpreted as the number of seconds.
+pub use human_duration::HumanDuration;

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -1,13 +1,15 @@
 ---
 source: crates/agglayer-config/tests/validate_deserialize.rs
+assertion_line: 12
 expression: config
+snapshot_kind: text
 ---
 prover-entrypoint = "http://127.0.0.1:8080"
 
 [full-node-rpcs]
 
 [l2]
-rpc-timeout = 45
+rpc-timeout = "45s"
 
 [proof-signers]
 
@@ -19,7 +21,7 @@ format = "pretty"
 [rpc]
 port = 9090
 host = "0.0.0.0"
-request-timeout = 180
+request-timeout = "3m"
 
 [rate-limiting]
 send-tx = "unlimited"
@@ -28,16 +30,16 @@ send-tx = "unlimited"
 
 [outbound.rpc.settle]
 max-retries = 3
-retry-interval = 7
+retry-interval = "7s"
 confirmations = 1
-settlement-timeout = 1200
+settlement-timeout = "20m"
 
 [l1]
 chain-id = 1337
 node-url = "http://zkevm-mock-l1-network:8545/"
 ws-node-url = "ws://zkevm-mock-l1-network:8546/"
 rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
-rpc-timeout = 45
+rpc-timeout = "45s"
 
 [auth.local]
 private-keys = []
@@ -46,10 +48,10 @@ private-keys = []
 prometheus-addr = "0.0.0.0:3000"
 
 [epoch.time-clock]
-epoch-duration = 60
+epoch-duration = "1m"
 
 [shutdown]
-runtime-timeout = 5
+runtime-timeout = "5s"
 
 [certificate-orchestrator]
 input-backpressure-buffer-size = 1000

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -1,13 +1,15 @@
 ---
 source: crates/agglayer/tests/config.rs
+assertion_line: 12
 expression: sanitize_config_folder_path(result)
+snapshot_kind: text
 ---
 prover-entrypoint = "http://127.0.0.1:8080"
 
 [full-node-rpcs]
 
 [l2]
-rpc-timeout = 45
+rpc-timeout = "45s"
 
 [proof-signers]
 
@@ -19,7 +21,7 @@ format = "pretty"
 [rpc]
 port = 9090
 host = "0.0.0.0"
-request-timeout = 180
+request-timeout = "3m"
 
 [rate-limiting]
 send-tx = "unlimited"
@@ -28,16 +30,16 @@ send-tx = "unlimited"
 
 [outbound.rpc.settle]
 max-retries = 3
-retry-interval = 7
+retry-interval = "7s"
 confirmations = 1
-settlement-timeout = 1200
+settlement-timeout = "20m"
 
 [l1]
 chain-id = 1337
 node-url = "http://zkevm-mock-l1-network:8545/"
 ws-node-url = "ws://zkevm-mock-l1-network:8546/"
 rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
-rpc-timeout = 45
+rpc-timeout = "45s"
 
 [auth.local]
 private-keys = []
@@ -46,10 +48,10 @@ private-keys = []
 prometheus-addr = "0.0.0.0:3000"
 
 [epoch.time-clock]
-epoch-duration = 60
+epoch-duration = "1m"
 
 [shutdown]
-runtime-timeout = 5
+runtime-timeout = "5s"
 
 [certificate-orchestrator]
 input-backpressure-buffer-size = 1000

--- a/crates/agglayer/tests/snapshots/config__prover_config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__prover_config_display.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/agglayer/tests/config.rs
+assertion_line: 26
 expression: sanitize_config_folder_path(result)
 ---
 grpc-endpoint = "127.0.0.1:8080"
 max-concurrency-limit = 100
-max-request-duration = 300
+max-request-duration = "5m"
 max-buffered-queries = 100
 
 [log]
@@ -16,12 +17,12 @@ format = "pretty"
 prometheus-addr = "0.0.0.0:3000"
 
 [shutdown]
-runtime-timeout = 5
+runtime-timeout = "5s"
 
 [cpu-prover]
 max-concurrency-limit = 100
-proving-timeout = 300
+proving-timeout = "5m"
 
 [network-prover]
 enabled = false
-proving-timeout = 300
+proving-timeout = "5m"


### PR DESCRIPTION
# Description

There is an inconsistency in time format used in the config. The rate limiter uses human readable strings like "1h" or "15min" while all other components use a plain number interpreted as seconds.

Let's address the inconsistency while improving the UX and maintaining backwards compatibility. Make the config parser to accept both human strings and number of seconds, at user discretion.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
