### PR TITLE
feat: retrieve the l1 info tree leaf count from certificate

### DIFF
--- a/crates/pessimistic-proof/src/imported_bridge_exit.rs
+++ b/crates/pessimistic-proof/src/imported_bridge_exit.rs
@@ -235,10 +235,20 @@ impl ImportedBridgeExit {
         }
     }
 
-    pub fn l1_root(&self) -> Digest {
+    /// Returns the considered L1 Info Root against which the claim is done.
+    pub fn l1_info_root(&self) -> Digest {
         match &self.claim_data {
             Claim::Mainnet(claim) => claim.proof_ger_l1root.root,
             Claim::Rollup(claim) => claim.proof_ger_l1root.root,
+        }
+    }
+
+    /// Returns the considered L1 Info Tree leaf index against which the claim
+    /// is done.
+    pub fn l1_leaf_index(&self) -> u32 {
+        match &self.claim_data {
+            Claim::Mainnet(claim) => claim.l1_leaf.l1_info_tree_index,
+            Claim::Rollup(claim) => claim.l1_leaf.l1_info_tree_index,
         }
     }
 


### PR DESCRIPTION
# Description

Add one function to retrieve the L1 Info Tree leaf count considered for a given Certificate.

It corresponds to the highest leaf index considered among the imported bridge exits of a given Certificate.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
