### PR TITLE
refactor: updating tests setup to rely on mocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "agglayer-storage",
  "agglayer-types",
  "anyhow",
+ "arc-swap",
  "bincode",
  "futures",
  "pessimistic-proof",
@@ -102,6 +103,7 @@ dependencies = [
  "bincode",
  "buildstructor",
  "futures-util",
+ "mockall",
  "pessimistic-proof",
  "rstest",
  "test-log",
@@ -177,6 +179,7 @@ dependencies = [
  "agglayer-clock",
  "agglayer-config",
  "agglayer-contracts",
+ "agglayer-prover",
  "agglayer-signer",
  "agglayer-storage",
  "agglayer-telemetry",
@@ -195,6 +198,7 @@ dependencies = [
  "parking_lot",
  "pessimistic-proof",
  "pin-project 1.1.6",
+ "rand",
  "reqwest 0.12.8",
  "rstest",
  "serde",
@@ -278,9 +282,11 @@ dependencies = [
  "bincode",
  "criterion",
  "hex",
+ "mockall",
  "parking_lot",
  "rand",
  "rocksdb",
+ "rstest",
  "serde",
  "sp1-sdk",
  "thiserror",
@@ -2156,6 +2162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,6 +2829,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs2"
@@ -4281,6 +4299,32 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates 3.1.2",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ futures = "0.3.31"
 hex = "0.4.3"
 jsonrpsee = { version = "0.24.6", features = ["full"] }
 lazy_static = "1.5.0"
+mockall = "0.13.0"
 rand = "0.8.5"
 rstest = "0.22.0"
 serde = { version = "1.0.209", features = ["derive"] }

--- a/crates/agglayer-aggregator-notifier/Cargo.toml
+++ b/crates/agglayer-aggregator-notifier/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+arc-swap.workspace = true
 bincode.workspace = true
 futures.workspace = true
 serde.workspace = true

--- a/crates/agglayer-certificate-orchestrator/Cargo.toml
+++ b/crates/agglayer-certificate-orchestrator/Cargo.toml
@@ -24,5 +24,6 @@ futures-util = "0.3.30"
 agglayer-storage = { path = "../agglayer-storage", features = ["testutils"] }
 agglayer-config = { path = "../agglayer-config", features = ["testutils"] }
 agglayer-types = { path = "../agglayer-types", features = ["testutils"] }
+mockall.workspace = true
 rstest.workspace = true
 test-log.workspace = true

--- a/crates/agglayer-certificate-orchestrator/src/tests/mocks.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests/mocks.rs
@@ -1,0 +1,24 @@
+use agglayer_types::{Height, NetworkId};
+use futures_util::future::BoxFuture;
+use mockall::mock;
+
+use crate::{Certifier, CertifierOutput, EpochPacker, Error};
+
+mock! {
+    pub Certifier {}
+    impl Certifier for Certifier {
+        fn certify(
+            &self,
+            state: agglayer_types::LocalNetworkStateData,
+            network_id: NetworkId,
+            height: Height,
+        ) -> Result<BoxFuture<'static, Result<CertifierOutput, Error>>, Error>;
+    }
+}
+
+mock! {
+    pub EpochPacker {}
+    impl EpochPacker for EpochPacker {
+        fn pack(&self, epoch: u64) -> Result<BoxFuture<'static, Result<(), Error>>, Error>;
+    }
+}

--- a/crates/agglayer-certificate-orchestrator/src/tests/receive_certificates.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests/receive_certificates.rs
@@ -41,7 +41,10 @@ async fn receive_certificate_with_height_zero() {
     let result = orchestrator.receive_certificates(&[(1.into(), 0, certificate_id)]);
 
     assert!(result.is_ok());
-    assert!(matches!(orchestrator.cursors.get(&1.into()), Some(0)));
+    assert!(matches!(
+        orchestrator.proving_cursors.get(&1.into()),
+        Some(0)
+    ));
     assert!(orchestrator.global_state.contains_key(&1.into()));
     assert!(receiver.recv().await.is_some());
 }
@@ -90,12 +93,15 @@ async fn receive_certificate_with_previous_proven() {
         .insert_pending_certificate(1.into(), 1, &certificate)
         .unwrap();
 
-    orchestrator.cursors.insert(1.into(), 0);
+    orchestrator.proving_cursors.insert(1.into(), 0);
 
     let result = orchestrator.receive_certificates(&[(1.into(), 1, [0; 32].into())]);
 
     assert!(result.is_ok());
-    assert!(matches!(orchestrator.cursors.get(&1.into()), Some(1)));
+    assert!(matches!(
+        orchestrator.proving_cursors.get(&1.into()),
+        Some(1)
+    ));
     assert!(orchestrator.global_state.contains_key(&1.into()));
     assert!(receiver.recv().await.is_some());
 }
@@ -147,7 +153,7 @@ async fn receive_certificate_with_previous_pending() {
     let result = orchestrator.receive_certificates(&[(1.into(), 1, [0; 32].into())]);
 
     assert!(result.is_ok());
-    assert!(!orchestrator.cursors.contains_key(&1.into()));
+    assert!(!orchestrator.proving_cursors.contains_key(&1.into()));
     sleep(Duration::from_millis(10)).await;
 
     assert!(receiver.try_recv().is_err());

--- a/crates/agglayer-config/src/epoch.rs
+++ b/crates/agglayer-config/src/epoch.rs
@@ -65,7 +65,7 @@ mod tests {
         let epoch = Epoch::TimeClock(TimeClockConfig::default());
         let serialized = serde_json::to_string(&epoch).unwrap();
 
-        assert_eq!(serialized, r#"{"time-clock":{"epoch-duration":5}}"#);
+        assert_eq!(serialized, r#"{"time-clock":{"epoch-duration":60}}"#);
     }
 
     #[test]

--- a/crates/agglayer-config/src/epoch.rs
+++ b/crates/agglayer-config/src/epoch.rs
@@ -37,7 +37,7 @@ impl Default for TimeClockConfig {
 }
 
 fn default_epoch_duration() -> Duration {
-    Duration::from_secs(5)
+    Duration::from_secs(60)
 }
 
 fn serialize_duration<S>(value: &Duration, s: S) -> Result<S::Ok, S::Error>

--- a/crates/agglayer-config/src/prover.rs
+++ b/crates/agglayer-config/src/prover.rs
@@ -148,7 +148,7 @@ const fn default_activation_network_prover() -> bool {
 }
 
 pub(crate) fn default_prover_entrypoint() -> String {
-    default_socket_addr().to_string()
+    format!("http://{}", default_socket_addr())
 }
 
 const fn default_max_concurrency_limit() -> usize {

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -39,12 +39,14 @@ pessimistic-proof = { path = "../pessimistic-proof" }
 agglayer-aggregator-notifier = { path = "../agglayer-aggregator-notifier" }
 
 [dev-dependencies]
+ethers.workspace = true
 insta = { version = "1.39.0", features = ["json"] }
 jsonrpsee-test-utils = { git = "https://github.com/paritytech/jsonrpsee.git", tag = "v0.24.6" }
 rstest.workspace = true
 serde_json.workspace = true
 hyper-util = { version = "0.1.6", features = ["client"] }
 http-body-util = "0.1.2"
+rand.workspace = true
 test-log.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-capture = "0.1.0"
@@ -52,6 +54,7 @@ tracing-capture = "0.1.0"
 agglayer-config = { path = "../agglayer-config", features = ["testutils"] }
 agglayer-storage = { path = "../agglayer-storage", features = ["testutils"] }
 agglayer-types = { path = "../agglayer-types", features = ["testutils"] }
+agglayer-prover = { path = "../agglayer-prover", features = ["testutils"] }
 
 [features]
 default = ["sp1"]

--- a/crates/agglayer-node/tests/pushing_certificate.rs
+++ b/crates/agglayer-node/tests/pushing_certificate.rs
@@ -1,0 +1,124 @@
+use std::time::Duration;
+
+use agglayer_prover::fake::FakeProver;
+use agglayer_storage::tests::TempDBDir;
+use agglayer_types::{
+    Certificate, CertificateHeader, CertificateId, CertificateStatusError, GenerationType,
+    LocalNetworkStateData,
+};
+use ethers::{signers::LocalWallet, utils::Anvil};
+use jsonrpsee::{core::client::ClientT, rpc_params, ws_client::WsClientBuilder};
+use pessimistic_proof::ProofError;
+use rstest::rstest;
+use tokio_util::sync::CancellationToken;
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(60))]
+async fn successfully_push_certificate() {
+    let anvil = Anvil::new().block_time(1u64).spawn();
+    let tmp_dir = TempDBDir::new();
+    let mut config = agglayer_config::Config::new(&tmp_dir.path);
+    let prover_config = agglayer_config::prover::ProverConfig::default();
+
+    // spawning fake prover as we don't want to hit SP1
+    let fake_prover = FakeProver::default();
+    let endpoint = prover_config.grpc_endpoint;
+    let cancellation = CancellationToken::new();
+
+    FakeProver::spawn_at(fake_prover, endpoint, cancellation.clone())
+        .await
+        .unwrap();
+
+    let account = anvil.keys().first().cloned().unwrap();
+
+    let mut rng = rand::thread_rng();
+    let (_key, uuid) = LocalWallet::encrypt_keystore(
+        &tmp_dir.path,
+        &mut rng,
+        account.to_bytes(),
+        "randpsswd",
+        None,
+    )
+    .unwrap();
+
+    let key_path = tmp_dir.path.join(uuid);
+
+    config.l1.node_url = anvil.endpoint().parse().unwrap();
+    config.auth = agglayer_config::AuthConfig::Local(agglayer_config::LocalConfig {
+        private_keys: vec![agglayer_config::PrivateKey {
+            path: key_path,
+            password: "randpsswd".into(),
+        }],
+    });
+
+    let config_file = tmp_dir.path.join("config.toml");
+    let toml = toml::to_string_pretty(&config).unwrap();
+    std::fs::write(&config_file, toml).unwrap();
+
+    let handle = std::thread::spawn(move || agglayer_node::main(config_file));
+    let url = format!("ws://{}/", config.rpc_addr());
+
+    let mut interval = tokio::time::interval(Duration::from_secs(10));
+    let mut max_attempts = 20;
+    let client = loop {
+        if max_attempts == 0 {
+            panic!("Failed to connect to the server");
+        }
+        interval.tick().await;
+        if let Ok(client) = WsClientBuilder::default().build(&url).await {
+            break client;
+        }
+
+        if handle.is_finished() {
+            let result = handle.join();
+            println!("{:?}", result);
+            panic!("Server has finished");
+        }
+
+        max_attempts -= 1;
+    };
+
+    assert!(!handle.is_finished());
+
+    let mut certificate = Certificate::new_for_test(1.into(), 0);
+    let state = LocalNetworkStateData::default();
+    certificate.prev_local_exit_root = state.exit_tree.get_root();
+    certificate.new_local_exit_root = state.exit_tree.get_root();
+
+    let certificate_id: CertificateId = client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    loop {
+        let response: CertificateHeader = client
+            .request("interop_getCertificateHeader", rpc_params![certificate_id])
+            .await
+            .unwrap();
+
+        match response.status {
+            agglayer_types::CertificateStatus::Pending => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            // In success the test is valid
+            agglayer_types::CertificateStatus::Proven => {
+                break;
+            }
+
+            // We can't go further than that with the current test setup
+            // TODO: Add a way to generate valide certificate here
+            agglayer_types::CertificateStatus::InError {
+                error:
+                    CertificateStatusError::ProofGenerationError {
+                        generation_type: GenerationType::Native,
+                        source: ProofError::InvalidSignature,
+                    },
+            } => break,
+            agglayer_types::CertificateStatus::InError { error } => {
+                panic!("{}", error)
+            }
+            _ => break,
+        }
+    }
+}

--- a/crates/agglayer-prover/Cargo.toml
+++ b/crates/agglayer-prover/Cargo.toml
@@ -24,9 +24,14 @@ agglayer-config = { path = "../agglayer-config" }
 agglayer-prover-types = { path = "../agglayer-prover-types" }
 agglayer-telemetry = { path = "../agglayer-telemetry" }
 pessimistic-proof = { path = "../pessimistic-proof" }
+agglayer-types = { path = "../agglayer-types", optional = true }
 
 sp1-sdk.workspace = true
 sp1-prover.workspace = true
 
 [dev-dependencies]
 agglayer-types = { path = "../agglayer-types" }
+
+[features]
+default = []
+testutils = ["agglayer-types"]

--- a/crates/agglayer-prover/src/fake.rs
+++ b/crates/agglayer-prover/src/fake.rs
@@ -1,0 +1,76 @@
+use std::net::SocketAddr;
+
+use agglayer_prover_types::v1::proof_generation_service_server::{
+    ProofGenerationService, ProofGenerationServiceServer,
+};
+use agglayer_types::Proof;
+use bincode::Options;
+use tonic::transport::Server;
+use tracing::error;
+use tracing::info;
+
+#[derive(Default)]
+pub struct FakeProver {}
+
+impl FakeProver {
+    pub async fn spawn_at(
+        fake_prover: Self,
+        endpoint: SocketAddr,
+        cancellation_token: tokio_util::sync::CancellationToken,
+    ) -> Result<tokio::task::JoinHandle<Result<(), tonic::transport::Error>>, ()> {
+        let svc = ProofGenerationServiceServer::new(fake_prover);
+
+        let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+
+        health_reporter
+            .set_serving::<ProofGenerationServiceServer<FakeProver>>()
+            .await;
+
+        health_reporter
+            .set_serving::<ProofGenerationServiceServer<FakeProver>>()
+            .await;
+
+        let reflection = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(agglayer_prover_types::FILE_DESCRIPTOR_SET)
+            .build_v1alpha()
+            .expect("Cannot build gRPC because of FILE_DESCRIPTOR_SET error");
+        let layer = tower::ServiceBuilder::new().into_inner();
+
+        info!("Starting Agglayer Prover on {}", endpoint);
+        let handle = tokio::spawn(async move {
+            if let Err(error) = Server::builder()
+                .layer(layer)
+                .add_service(reflection)
+                .add_service(health_service)
+                .add_service(svc)
+                .serve_with_shutdown(endpoint, cancellation_token.cancelled())
+                .await
+            {
+                error!("Failed to start Agglayer Prover: {}", error);
+
+                return Err(error);
+            }
+
+            Ok(())
+        });
+
+        Ok(handle)
+    }
+}
+
+#[tonic::async_trait]
+impl ProofGenerationService for FakeProver {
+    async fn generate_proof(
+        &self,
+        _request: tonic::Request<agglayer_prover_types::v1::ProofGenerationRequest>,
+    ) -> Result<tonic::Response<agglayer_prover_types::v1::ProofGenerationResponse>, tonic::Status>
+    {
+        Ok(tonic::Response::new(
+            agglayer_prover_types::v1::ProofGenerationResponse {
+                proof: agglayer_prover_types::default_bincode_options()
+                    .serialize(&Proof::new_for_test())
+                    .unwrap(),
+            },
+        ))
+    }
+}

--- a/crates/agglayer-prover/src/lib.rs
+++ b/crates/agglayer-prover/src/lib.rs
@@ -11,6 +11,8 @@ use tracing::info;
 mod logging;
 
 mod executor;
+#[cfg(feature = "testutils")]
+pub mod fake;
 mod prover;
 mod rpc;
 

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -18,9 +18,12 @@ tracing.workspace = true
 agglayer-config = { path = "../agglayer-config" }
 agglayer-types = { path = "../agglayer-types" }
 
+mockall = { workspace = true, optional = true }
+
 [dev-dependencies]
 criterion = "0.5.1"
 rand.workspace = true
+rstest.workspace = true
 sp1-sdk.workspace = true
 
 [[bench]]
@@ -30,4 +33,4 @@ required-features = ["testutils"]
 
 [features]
 default = []
-testutils = ["rand"]
+testutils = ["rand", "mockall"]

--- a/crates/agglayer-storage/src/columns/epochs/end_checkpoint/mod.rs
+++ b/crates/agglayer-storage/src/columns/epochs/end_checkpoint/mod.rs
@@ -1,0 +1,19 @@
+use agglayer_types::{Height, NetworkId};
+
+use crate::columns::PER_EPOCH_END_CHECKPOINT_CF;
+
+/// Column family for the end checkpoint in an epoch.
+///
+/// ## Column definition
+///
+/// | key         | value    |
+/// | --          | --       |
+/// | `NetworkId` | `Height` |
+pub struct EndCheckpointColumn;
+
+impl crate::columns::ColumnSchema for EndCheckpointColumn {
+    type Key = NetworkId;
+    type Value = Height;
+
+    const COLUMN_FAMILY_NAME: &'static str = PER_EPOCH_END_CHECKPOINT_CF;
+}

--- a/crates/agglayer-storage/src/columns/epochs/metadata/mod.rs
+++ b/crates/agglayer-storage/src/columns/epochs/metadata/mod.rs
@@ -7,9 +7,9 @@ use crate::columns::PER_EPOCH_METADATA_CF;
 /// | key                   | value                   |
 /// | --                    | --                      |
 /// | `PerEpochMetadataKey` | `PerEpochMetadataValue` |
-pub struct ProofPerIndex;
+pub struct PerEpochMetadataColumn;
 
-impl crate::columns::ColumnSchema for ProofPerIndex {
+impl crate::columns::ColumnSchema for PerEpochMetadataColumn {
     type Key = crate::types::PerEpochMetadataKey;
     type Value = crate::types::PerEpochMetadataValue;
 

--- a/crates/agglayer-storage/src/columns/epochs/start_checkpoint/mod.rs
+++ b/crates/agglayer-storage/src/columns/epochs/start_checkpoint/mod.rs
@@ -1,0 +1,19 @@
+use agglayer_types::{Height, NetworkId};
+
+use crate::columns::PER_EPOCH_START_CHECKPOINT_CF;
+
+/// Column family for the start checkpoint in an epoch.
+///
+/// ## Column definition
+///
+/// | key         | value    |
+/// | --          | --       |
+/// | `NetworkId` | `Height` |
+pub struct StartCheckpointColumn;
+
+impl crate::columns::ColumnSchema for StartCheckpointColumn {
+    type Key = NetworkId;
+    type Value = Height;
+
+    const COLUMN_FAMILY_NAME: &'static str = PER_EPOCH_START_CHECKPOINT_CF;
+}

--- a/crates/agglayer-storage/src/columns/mod.rs
+++ b/crates/agglayer-storage/src/columns/mod.rs
@@ -31,6 +31,8 @@ pub const METADATA_CF: &str = "metadata_cf";
 pub const PER_EPOCH_CERTIFICATES_CF: &str = "per_epoch_certificates_cf";
 pub const PER_EPOCH_METADATA_CF: &str = "per_epoch_metadata_cf";
 pub const PER_EPOCH_PROOFS_CF: &str = "per_epoch_proofs_cf";
+pub const PER_EPOCH_END_CHECKPOINT_CF: &str = "per_epoch_end_checkpoint_cf";
+pub const PER_EPOCH_START_CHECKPOINT_CF: &str = "per_epoch_start_checkpoint_cf";
 
 // Pending related CFs
 pub const PENDING_QUEUE_CF: &str = "pending_queue_cf";
@@ -72,6 +74,8 @@ pub(crate) mod metadata;
 // PerEpoch
 pub mod epochs {
     pub(crate) mod certificates;
+    pub(crate) mod end_checkpoint;
     pub(crate) mod metadata;
     pub(crate) mod proofs;
+    pub(crate) mod start_checkpoint;
 }

--- a/crates/agglayer-storage/src/error.rs
+++ b/crates/agglayer-storage/src/error.rs
@@ -1,3 +1,5 @@
+use agglayer_types::{Height, NetworkId};
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("RocksDB error: {0}")]
@@ -19,4 +21,21 @@ pub enum Error {
 
     #[error("No proof found")]
     NoProof,
+
+    #[error("The store is already in packing mode")]
+    AlreadyInPackingMode,
+
+    #[error(transparent)]
+    CertificateCandidateError(#[from] CertificateCandidateError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CertificateCandidateError {
+    #[error("Invalid certificate candidate for network {0} at height {1} for current epoch")]
+    Invalid(NetworkId, Height),
+
+    #[error(
+        "Invalid certificate candidate for network {0}: {1} wasn't expected, current height {2}"
+    )]
+    UnexpectedHeight(NetworkId, Height, Height),
 }

--- a/crates/agglayer-storage/src/storage/cf_definitions/epochs.rs
+++ b/crates/agglayer-storage/src/storage/cf_definitions/epochs.rs
@@ -1,9 +1,11 @@
 use rocksdb::ColumnFamilyDescriptor;
 
-pub const CFS: [&str; 3] = [
+pub const CFS: [&str; 5] = [
     crate::columns::PER_EPOCH_CERTIFICATES_CF,
+    crate::columns::PER_EPOCH_END_CHECKPOINT_CF,
     crate::columns::PER_EPOCH_METADATA_CF,
     crate::columns::PER_EPOCH_PROOFS_CF,
+    crate::columns::PER_EPOCH_START_CHECKPOINT_CF,
 ];
 
 /// Definitions for the column families in the epochs storage.

--- a/crates/agglayer-storage/src/stores/epochs.rs
+++ b/crates/agglayer-storage/src/stores/epochs.rs
@@ -20,7 +20,7 @@ impl EpochsStore {
         epoch_number: u64,
         pending_db: Arc<DB>,
     ) -> Result<Self, Error> {
-        let current_epoch = Arc::new(ArcSwap::new(Arc::new(PerEpochStore::open(
+        let current_epoch = Arc::new(ArcSwap::new(Arc::new(PerEpochStore::try_open(
             config.clone(),
             epoch_number,
             pending_db.clone(),
@@ -41,7 +41,7 @@ impl EpochStoreWriter for EpochsStore {
     type PerEpochStore = PerEpochStore;
 
     fn open(&self, epoch_number: u64) -> Result<PerEpochStore, Error> {
-        PerEpochStore::open(self.config.clone(), epoch_number, self.pending_db.clone())
+        PerEpochStore::try_open(self.config.clone(), epoch_number, self.pending_db.clone())
     }
 }
 

--- a/crates/agglayer-storage/src/stores/interfaces/writer.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/writer.rs
@@ -4,6 +4,7 @@ use crate::error::Error;
 
 pub trait PerEpochWriter: Send + Sync {
     fn add_certificate(&self, network_id: NetworkId, height: Height) -> Result<(), Error>;
+    fn start_packing(&self) -> Result<(), Error>;
 }
 
 pub trait EpochStoreWriter: Send + Sync {

--- a/crates/agglayer-storage/src/stores/mod.rs
+++ b/crates/agglayer-storage/src/stores/mod.rs
@@ -1,7 +1,9 @@
 mod interfaces;
 
 pub use interfaces::{
-    reader::{EpochStoreReader, MetadataReader, PendingCertificateReader, StateReader},
+    reader::{
+        EpochStoreReader, MetadataReader, PendingCertificateReader, PerEpochReader, StateReader,
+    },
     writer::{
         EpochStoreWriter, MetadataWriter, PendingCertificateWriter, PerEpochWriter, StateWriter,
     },

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -1,27 +1,45 @@
-use std::sync::{atomic::AtomicU64, Arc};
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use agglayer_types::{Height, NetworkId};
+use parking_lot::RwLock;
+use rocksdb::ReadOptions;
+use tracing::{debug, warn};
 
-use super::PerEpochWriter;
+use super::{interfaces::reader::PerEpochReader, PerEpochWriter};
 use crate::{
     columns::{
-        epochs::{certificates::CertificatePerIndexColumn, proofs::ProofPerIndexColumn},
+        epochs::{
+            certificates::CertificatePerIndexColumn, end_checkpoint::EndCheckpointColumn,
+            proofs::ProofPerIndexColumn, start_checkpoint::StartCheckpointColumn,
+        },
         pending_queue::{PendingQueueColumn, PendingQueueKey},
         proof_per_certificate::ProofPerCertificateColumn,
     },
-    error::Error,
+    error::{CertificateCandidateError, Error},
     storage::{epochs_db_cf_definitions, DB},
 };
+
+#[cfg(test)]
+mod tests;
 
 /// A logical store for an Epoch.
 pub struct PerEpochStore {
     db: Arc<DB>,
     pending_db: Arc<DB>,
     next_certificate_index: AtomicU64,
+    start_checkpoint: BTreeMap<NetworkId, Height>,
+    end_checkpoint: RwLock<BTreeMap<NetworkId, Height>>,
+    in_packing: AtomicBool,
 }
 
 impl PerEpochStore {
-    pub fn open(
+    pub fn try_open(
         config: Arc<agglayer_config::Config>,
         epoch_number: u64,
         pending_db: Arc<DB>,
@@ -34,16 +52,126 @@ impl PerEpochStore {
 
         let db = Arc::new(DB::open_cf(&path, epochs_db_cf_definitions())?);
 
+        let start_checkpoint = if epoch_number == 0 {
+            BTreeMap::new()
+        } else {
+            let checkpoint = db
+                .iter_with_direction::<StartCheckpointColumn>(
+                    ReadOptions::default(),
+                    rocksdb::Direction::Forward,
+                )?
+                .filter_map(|v| v.ok())
+                .collect::<BTreeMap<NetworkId, Height>>();
+
+            if checkpoint.is_empty() {
+                return Err(Error::Unexpected(format!(
+                    "Epoch {} doesn't seem to have a start checkpoint...",
+                    epoch_number
+                )))?;
+            }
+
+            checkpoint
+        };
+
+        let mut in_packing = false;
+
+        let end_checkpoint = {
+            let checkpoint = db
+                .iter_with_direction::<EndCheckpointColumn>(
+                    ReadOptions::default(),
+                    rocksdb::Direction::Forward,
+                )?
+                .filter_map(|v| v.ok())
+                .collect::<BTreeMap<NetworkId, Height>>();
+
+            if checkpoint.is_empty() {
+                start_checkpoint.clone()
+            } else {
+                in_packing = true;
+
+                checkpoint
+            }
+        };
+
         Ok(Self {
             db,
             pending_db,
             next_certificate_index: AtomicU64::new(0),
+            start_checkpoint,
+            end_checkpoint: RwLock::new(end_checkpoint),
+            in_packing: AtomicBool::new(in_packing),
         })
     }
 }
 
 impl PerEpochWriter for PerEpochStore {
     fn add_certificate(&self, network_id: NetworkId, height: Height) -> Result<(), Error> {
+        // Check for network rate limiting
+        let start_checkpoint = self.start_checkpoint.get(&network_id);
+        let mut end_checkpoint = self.end_checkpoint.write();
+
+        debug!(
+            "Try adding certificate for network {} at height {}",
+            network_id, height
+        );
+
+        // Fetch the network current point for this epoch
+        match (start_checkpoint, end_checkpoint.entry(network_id)) {
+            // If the network is not found in the end checkpoint, but is present in
+            // the start checkpoint, this is an invalid state.
+            (Some(_), Entry::Vacant(_)) => {
+                warn!(
+                    "Network {} is present in the start checkpoint but not in the end checkpoint",
+                    network_id
+                );
+                return Err(Error::Unexpected(format!(
+                    "Network {} is present in the start checkpoint but not in the end checkpoint",
+                    network_id
+                )));
+            }
+            // If the network is not found in the end checkpoint and the height is 0,
+            // this is the first certificate for this network.
+            (None, Entry::Vacant(entry)) if height == 0 => {
+                debug!("First certificate for network {}", network_id);
+                // Adding the network to the end checkpoint.
+                entry.insert(0);
+
+                // Adding the certificate to the DB
+            }
+            // If the network is not found in the end checkpoint and the height is not 0,
+            // this is an invalid certificate candidate and the operation should fail.
+            (None, Entry::Vacant(_)) => {
+                return Err(CertificateCandidateError::Invalid(network_id, height))?
+            }
+            // If the network is found in the end checkpoint and the height is 0,
+            // this is an invalid certificate candidate and the operation should fail.
+            (Some(_start_height), Entry::Occupied(ref current_height)) if height == 0 => {
+                return Err(CertificateCandidateError::UnexpectedHeight(
+                    network_id,
+                    height,
+                    *current_height.get(),
+                ))?
+            }
+            // If the network is found in the end checkpoint and the height minus one is equal to
+            // the current network height. We can add the certificate.
+            (Some(_start_height), Entry::Occupied(current_height))
+                if *current_height.get() == height - 1 =>
+            {
+                debug!(
+                    "Certificate candidate for network {} at height {} accepted",
+                    network_id, height
+                );
+            }
+
+            (_, Entry::Occupied(current_height)) => {
+                return Err(CertificateCandidateError::UnexpectedHeight(
+                    network_id,
+                    height,
+                    *current_height.get(),
+                ))?
+            }
+        }
+
         let certificate = self
             .pending_db
             .get::<PendingQueueColumn>(&PendingQueueKey(network_id, height))?
@@ -56,9 +184,7 @@ impl PerEpochWriter for PerEpochStore {
             .get::<ProofPerCertificateColumn>(&certificate_id)?
             .ok_or(Error::NoProof)?;
 
-        let certificate_index = self
-            .next_certificate_index
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let certificate_index = self.next_certificate_index.fetch_add(1, Ordering::SeqCst);
 
         // TODO: all of this need to be batched
 
@@ -77,5 +203,26 @@ impl PerEpochWriter for PerEpochStore {
             .delete::<PendingQueueColumn>(&PendingQueueKey(network_id, height))?;
 
         Ok(())
+    }
+
+    fn start_packing(&self) -> Result<(), Error> {
+        self.in_packing
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::Acquire)
+            .map_err(|_| Error::AlreadyInPackingMode)?;
+
+        Ok(())
+    }
+}
+
+impl PerEpochReader for PerEpochStore {
+    fn get_start_checkpoint(&self) -> &BTreeMap<NetworkId, Height> {
+        &self.start_checkpoint
+    }
+
+    fn get_end_checkpoint_height_per_network(
+        &self,
+        network_id: NetworkId,
+    ) -> Result<Option<Height>, Error> {
+        Ok(self.end_checkpoint.read().get(&network_id).copied())
     }
 }

--- a/crates/agglayer-storage/src/stores/per_epoch/tests.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/tests.rs
@@ -1,0 +1,121 @@
+use std::{
+    collections::BTreeMap,
+    sync::{atomic::Ordering, Arc},
+};
+
+use agglayer_config::Config;
+use agglayer_types::{Height, NetworkId, Proof};
+use rstest::rstest;
+
+use crate::{
+    error::Error,
+    storage::{pending_db_cf_definitions, DB},
+    stores::{pending::PendingStore, per_epoch::PerEpochStore, PerEpochWriter as _},
+    tests::TempDBDir,
+};
+
+#[test]
+fn can_start_packing_an_unpacked_epoch() {
+    let tmp = TempDBDir::new();
+    let pending_db =
+        Arc::new(DB::open_cf(tmp.path.as_path(), pending_db_cf_definitions()).unwrap());
+    let config = Arc::new(Config::new_for_test());
+
+    let store = PerEpochStore::try_open(config, 0, pending_db.clone()).unwrap();
+
+    assert!(store.start_packing().is_ok());
+}
+
+#[test]
+fn cant_start_packing_a_packed_epoch() {
+    let tmp = TempDBDir::new();
+    let pending_db =
+        Arc::new(DB::open_cf(tmp.path.as_path(), pending_db_cf_definitions()).unwrap());
+    let config = Arc::new(Config::new(&tmp.path));
+
+    let store = PerEpochStore::try_open(config, 0, pending_db.clone()).unwrap();
+
+    store.in_packing.store(true, Ordering::Relaxed);
+
+    assert!(store.start_packing().is_err());
+}
+
+enum CheckpointState {
+    Empty,
+    WithCheckpoint(Vec<(NetworkId, Height)>),
+}
+
+impl From<CheckpointState> for BTreeMap<NetworkId, Height> {
+    fn from(value: CheckpointState) -> Self {
+        match value {
+            CheckpointState::Empty => BTreeMap::new(),
+            CheckpointState::WithCheckpoint(checkpoint) => checkpoint.into_iter().collect(),
+        }
+    }
+}
+
+type StartCheckpointState = CheckpointState;
+type EndCheckpointState = CheckpointState;
+
+#[rstest]
+#[case::when_state_are_empty(
+    StartCheckpointState::Empty,
+    EndCheckpointState::Empty,
+    |result: Result<(), Error>| result.is_ok(),
+    0)]
+#[case::when_state_is_incorrect(
+    StartCheckpointState::WithCheckpoint(vec![(NetworkId::new(0), 0)]),
+    EndCheckpointState::Empty,
+    |result: Result<(), Error>| matches!(result, Err(Error::Unexpected(_))),
+    0)]
+#[case::when_certificate_is_unexpected(
+    StartCheckpointState::WithCheckpoint(vec![(NetworkId::new(0), 1)]),
+    EndCheckpointState::WithCheckpoint(vec![(NetworkId::new(0), 1)]),
+    |result: Result<(), Error>| {
+        matches!(result, Err(Error::CertificateCandidateError(crate::error::CertificateCandidateError::UnexpectedHeight(_, 0, 1))))
+    }, 0)]
+#[case::when_certificate_is_already_present(
+    StartCheckpointState::WithCheckpoint(vec![(NetworkId::new(0), 1)]),
+    EndCheckpointState::WithCheckpoint(vec![(NetworkId::new(0), 1)]),
+    |result: Result<(), Error>| {
+        matches!(result, Err(Error::CertificateCandidateError(crate::error::CertificateCandidateError::UnexpectedHeight(_, 1, 1))))
+    }, 1)]
+#[case::when_there_is_a_gap(
+    StartCheckpointState::WithCheckpoint(vec![(NetworkId::new(0), 1)]),
+    EndCheckpointState::WithCheckpoint(vec![(NetworkId::new(0), 1)]),
+    |result: Result<(), Error>| {
+        matches!(result, Err(Error::CertificateCandidateError(crate::error::CertificateCandidateError::UnexpectedHeight(_, 3, 1))))
+    }, 3)]
+fn adding_a_certificate(
+    #[case] start_checkpoint: StartCheckpointState,
+    #[case] end_checkpoint: EndCheckpointState,
+    #[case] expected_result: impl FnOnce(Result<(), Error>) -> bool,
+    #[case] height: Height,
+) {
+    use agglayer_types::Certificate;
+    use parking_lot::RwLock;
+
+    use crate::stores::PendingCertificateWriter as _;
+
+    let tmp = TempDBDir::new();
+    let pending_db =
+        Arc::new(DB::open_cf(tmp.path.as_path(), pending_db_cf_definitions()).unwrap());
+    let config = Arc::new(Config::new(&tmp.path));
+
+    let certificate = Certificate::new_for_test(0.into(), height);
+    let pending_store = PendingStore::new(pending_db.clone());
+    pending_store
+        .insert_pending_certificate(0.into(), height, &certificate)
+        .unwrap();
+
+    pending_store
+        .insert_generated_proof(&certificate.hash(), &Proof::new_for_test())
+        .unwrap();
+
+    let mut store = PerEpochStore::try_open(config, 0, pending_db.clone()).unwrap();
+
+    store.start_checkpoint = start_checkpoint.into();
+    store.end_checkpoint = RwLock::new(end_checkpoint.into());
+
+    assert!(expected_result(store.add_certificate(0.into(), height)));
+}

--- a/crates/agglayer-storage/src/tests.rs
+++ b/crates/agglayer-storage/src/tests.rs
@@ -7,6 +7,8 @@ use std::{
 
 use rand::Rng as _;
 
+pub mod mocks;
+
 pub struct TempDBDir {
     pub path: PathBuf,
 }

--- a/crates/agglayer-storage/src/tests/mocks.rs
+++ b/crates/agglayer-storage/src/tests/mocks.rs
@@ -1,0 +1,9 @@
+mod epochs_store;
+mod pending_store;
+mod per_epoch_store;
+mod state_store;
+
+pub use epochs_store::MockEpochsStore;
+pub use pending_store::MockPendingStore;
+pub use per_epoch_store::MockPerEpochStore;
+pub use state_store::MockStateStore;

--- a/crates/agglayer-storage/src/tests/mocks/epochs_store.rs
+++ b/crates/agglayer-storage/src/tests/mocks/epochs_store.rs
@@ -1,0 +1,17 @@
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use mockall::mock;
+
+use super::MockPerEpochStore;
+use crate::stores::EpochStoreReader;
+
+mock! {
+    pub EpochsStore {}
+
+    impl EpochStoreReader for EpochsStore {
+        type PerEpochStore = MockPerEpochStore;
+
+        fn get_current_epoch(&self) -> Arc<ArcSwap<MockPerEpochStore>>;
+    }
+}

--- a/crates/agglayer-storage/src/tests/mocks/pending_store.rs
+++ b/crates/agglayer-storage/src/tests/mocks/pending_store.rs
@@ -1,0 +1,61 @@
+use agglayer_types::{Certificate, CertificateId, Height, NetworkId, Proof};
+use mockall::mock;
+
+use crate::{
+    columns::latest_proven_certificate_per_network::ProvenCertificate,
+    error::Error,
+    stores::{PendingCertificateReader, PendingCertificateWriter},
+};
+
+mock! {
+    pub PendingStore {}
+    impl PendingCertificateReader for PendingStore {
+        fn get_certificate(
+            &self,
+            network_id: NetworkId,
+            height: Height,
+        ) -> Result<Option<Certificate>, Error>;
+
+        fn get_proof(&self, certificate_id: CertificateId) -> Result<Option<Proof>, Error>;
+
+        fn multi_get_certificate(
+            &self,
+            keys: &[(NetworkId, Height)],
+        ) -> Result<Vec<Option<Certificate>>, Error>;
+
+        fn multi_get_proof(&self, keys: &[CertificateId]) -> Result<Vec<Option<Proof>>, Error>;
+
+        fn get_current_proven_height(&self) -> Result<Vec<ProvenCertificate>, Error>;
+    }
+
+    impl PendingCertificateWriter for PendingStore {
+        fn remove_pending_certificate(
+            &self,
+            network_id: NetworkId,
+            height: Height,
+        ) -> Result<(), Error>;
+
+        fn remove_generated_proof(&self, certificate_id: &CertificateId) -> Result<(), Error>;
+
+        fn insert_pending_certificate(
+            &self,
+            network_id: NetworkId,
+            height: Height,
+            certificate: &Certificate,
+        ) -> Result<(), Error>;
+
+        fn insert_generated_proof(
+            &self,
+            certificate_id: &CertificateId,
+            proof: &Proof,
+        ) -> Result<(), Error>;
+
+        fn set_latest_proven_certificate_per_network(
+            &self,
+            network_id: &NetworkId,
+            height: &Height,
+            certificate_id: &CertificateId,
+        ) -> Result<(), Error>;
+
+    }
+}

--- a/crates/agglayer-storage/src/tests/mocks/per_epoch_store.rs
+++ b/crates/agglayer-storage/src/tests/mocks/per_epoch_store.rs
@@ -1,0 +1,27 @@
+use std::collections::BTreeMap;
+
+use agglayer_types::{Height, NetworkId};
+use mockall::mock;
+
+use crate::{
+    error::Error,
+    stores::{PerEpochReader, PerEpochWriter},
+};
+
+mock! {
+    pub PerEpochStore {}
+
+    impl PerEpochReader for PerEpochStore {
+        fn get_start_checkpoint(&self) -> &BTreeMap<NetworkId, Height>;
+
+        fn get_end_checkpoint_height_per_network(
+            &self,
+            network_id: NetworkId,
+        ) -> Result<Option<Height>, Error>;
+    }
+
+    impl PerEpochWriter for PerEpochStore {
+        fn add_certificate(&self, network_id: NetworkId, height: Height) -> Result<(), Error>;
+        fn start_packing(&self) -> Result<(), Error>;
+    }
+}

--- a/crates/agglayer-storage/src/tests/mocks/state_store.rs
+++ b/crates/agglayer-storage/src/tests/mocks/state_store.rs
@@ -1,0 +1,41 @@
+use agglayer_types::{
+    Certificate, CertificateHeader, CertificateId, CertificateStatus, Height, NetworkId,
+};
+use mockall::mock;
+
+use crate::{
+    error::Error,
+    stores::{StateReader, StateWriter},
+};
+mock! {
+    pub StateStore {}
+    impl StateWriter for StateStore {
+        fn insert_certificate_header(
+            &self,
+            certificate: &Certificate,
+            status: CertificateStatus,
+        ) -> Result<(), Error>;
+
+        fn update_certificate_header_status(
+            &self,
+            certificate_id: &CertificateId,
+            status: &CertificateStatus,
+        ) -> Result<(), Error>;
+    }
+
+    impl StateReader for StateStore {
+        fn get_active_networks(&self) -> Result<Vec<NetworkId>, Error>;
+
+        fn get_certificate_header(
+            &self,
+            certificate_id: &CertificateId,
+        ) -> Result<Option<CertificateHeader>, Error>;
+
+        fn get_certificate_header_by_cursor(
+            &self,
+            network_id: NetworkId,
+            height: Height,
+        ) -> Result<Option<CertificateHeader>, Error>;
+        fn get_current_settled_height(&self) -> Result<Vec<(NetworkId, Height, CertificateId)>, Error>;
+    }
+}

--- a/crates/agglayer-storage/src/types.rs
+++ b/crates/agglayer-storage/src/types.rs
@@ -1,4 +1,6 @@
-use agglayer_types::{Certificate, CertificateHeader, CertificateId, NetworkId, Proof};
+use std::collections::BTreeMap;
+
+use agglayer_types::{Certificate, CertificateHeader, CertificateId, Height, NetworkId, Proof};
 use serde::{Deserialize, Serialize};
 
 macro_rules! default_codec_impl {
@@ -22,11 +24,15 @@ pub enum MetadataValue {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum PerEpochMetadataKey {
     SettlementTxHash,
+    StartCheckpoint,
+    EndCheckpoint,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum PerEpochMetadataValue {
     SettlementTxHash([u8; 32]),
+    StartCheckpoint(BTreeMap<NetworkId, Height>),
+    EndCheckpoint(BTreeMap<NetworkId, Height>),
 }
 
 default_codec_impl!(

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer/tests/config.rs
 expression: sanitize_config_folder_path(result)
 ---
-prover-entrypoint = "127.0.0.1:8080"
+prover-entrypoint = "http://127.0.0.1:8080"
 
 [full-node-rpcs]
 
@@ -45,7 +45,7 @@ private-keys = []
 prometheus-addr = "0.0.0.0:3000"
 
 [epoch.time-clock]
-epoch-duration = 5
+epoch-duration = 60
 
 [shutdown]
 runtime-timeout = 5


### PR DESCRIPTION
# Description

This PR replaces the `DummyStorage` by proper `mocks` using `mockall`

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
