### PR TITLE
feat: adding block clock by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,8 @@ dependencies = [
  "ethers",
  "fail",
  "futures",
+ "rstest",
+ "test-log",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/crates/agglayer-clock/Cargo.toml
+++ b/crates/agglayer-clock/Cargo.toml
@@ -16,3 +16,5 @@ tracing.workspace = true
 
 [dev-dependencies]
 fail = { workspace = true, features = ["failpoints"] }
+rstest.workspace = true
+test-log.workspace = true

--- a/crates/agglayer-clock/src/block.rs
+++ b/crates/agglayer-clock/src/block.rs
@@ -13,7 +13,7 @@ use ethers::{
 use futures::StreamExt as _;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use crate::{Clock, ClockRef, Error, Event, BROADCAST_CHANNEL_SIZE};
 
@@ -70,6 +70,12 @@ impl<P> BlockClock<P> {
             epoch_duration,
             current_epoch: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Reinitialize the current Epoch number based on the current Block height.
+    fn reinitialize_epoch_number(&mut self, current_block: u64) {
+        let current_epoch = self.calculate_epoch_number(current_block);
+        self.current_epoch.store(current_epoch, Ordering::SeqCst);
     }
 
     /// Updates the current Epoch of this [`BlockClock`].
@@ -135,15 +141,17 @@ where
         sender: broadcast::Sender<Event>,
         cancellation_token: CancellationToken,
     ) -> Result<(), BlockClockError> {
+        info!("Starting the BlockClock task");
         // Start by setting the current Block height based on the current L1 Block
         // number. If the current L1 Block number is less than the genesis block
-        // number, we exit the process with an println message.
+        // number, we walk the L1 block stream until reaching the genesis block.
         let current_l1_block = self
             .provider
             .get_block_number()
             .await
             .map_err(|_| BlockClockError::GetBlockNumber)?;
 
+        debug!("Current L1 Block number: {}", current_l1_block);
         let provider = self.provider.clone();
 
         // Subscribe to the L1 Block stream.
@@ -152,24 +160,30 @@ where
             .await
             .map_err(|_| BlockClockError::SubscribeBlocks)?;
 
+        debug!("Successfully subscribed to the L1 Block stream");
+
         let mut current_l1_block = current_l1_block.as_u64();
-        while !current_l1_block < self.genesis_block {
+        while current_l1_block < self.genesis_block {
             if let Some(Block {
                 number: Some(number),
                 ..
             }) = stream.next().await
             {
                 current_l1_block = number.as_u64();
+
+                debug!("Current L1 Block number: {}", current_l1_block);
             }
         }
+
+        info!("Node reached the genesis L1 block {}", self.genesis_block);
+
+        // Calculate the local Block height based on the current L1 Block number.
+        let current_block = self.calculate_block_number(current_l1_block);
 
         // Overwrite the block number to simulate an overflow
         // This is used for testing purposes only and doesn't affect the production
         // code.
         fail::fail_point!("block_clock::BlockClock::run::overwrite_block_number");
-
-        // Calculate the local Block height based on the current L1 Block number.
-        let current_block = self.calculate_block_number(current_l1_block);
 
         match self.block_height.compare_exchange(
             0,
@@ -179,10 +193,7 @@ where
         ) {
             Ok(0) => {
                 debug!("The current block height was set to: {}", current_block);
-                self.update_epoch_number(current_block)
-                    .map_err(|(previous, expected)| {
-                        BlockClockError::SetEpochNumber(previous, expected)
-                    })?;
+                self.reinitialize_epoch_number(current_block);
             }
             Ok(block) => {
                 return Err(BlockClockError::BlockHeightAlreadySet(block));
@@ -205,6 +216,10 @@ where
                         block.number.unwrap(),
                         block.hash.unwrap()
                     );
+                    // Overwrite the block number to simulate an overflow
+                    // This is used for testing purposes only and doesn't affect the production
+                    // code.
+                    fail::fail_point!("block_clock::BlockClock::run::overwrite_block_number_on_new_block");
 
                     // Increase the Block height by 1. The `fetch_add` method returns the previous
                     // value, so we need to add 1 to it to get the current Block height.
@@ -240,10 +255,12 @@ mod tests {
     use std::{num::NonZeroU64, time::Duration};
 
     use ethers::{
-        providers::{Provider, Ws},
+        providers::{Middleware, Provider, Ws},
         utils::Anvil,
     };
     use fail::FailScenario;
+    use futures::StreamExt as _;
+    use rstest::rstest;
     use tokio::sync::broadcast;
     use tokio_util::sync::CancellationToken;
 
@@ -305,12 +322,12 @@ mod tests {
         assert!(clock_ref.current_block_height() >= 3);
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_block_clock_with_genesis_in_future() {
         let anvil = Anvil::new().block_time(1u64).spawn();
         let client = Provider::<Ws>::connect(anvil.ws_endpoint()).await.unwrap();
 
-        let clock = BlockClock::new(client, 2, NonZeroU64::new(3).unwrap());
+        let clock = BlockClock::new(client, 10, NonZeroU64::new(2).unwrap());
         let token = CancellationToken::new();
         let clock_ref = clock.spawn(token).await.unwrap();
         assert_eq!(clock_ref.current_epoch(), 0);
@@ -319,7 +336,7 @@ mod tests {
 
         assert_eq!(recv.recv().await, Ok(Event::EpochEnded(0)));
         assert_eq!(clock_ref.current_epoch(), 1);
-        assert!(clock_ref.current_block_height() >= 3);
+        assert!(clock_ref.current_block_height() >= 2);
     }
 
     #[tokio::test]
@@ -337,6 +354,53 @@ mod tests {
         assert_eq!(recv.recv().await, Ok(Event::EpochEnded(0)));
         assert_eq!(clock_ref.current_epoch(), 1);
         assert!(clock_ref.current_block_height() >= 3);
+    }
+
+    #[tokio::test]
+    async fn test_block_clock_starting_with_genesis() {
+        let anvil = Anvil::new().block_time(1u64).spawn();
+        let client = Provider::<Ws>::connect(anvil.ws_endpoint()).await.unwrap();
+
+        let test_client = client.clone();
+        let mut subscribe = test_client.subscribe_blocks().await.unwrap();
+        let clock = BlockClock::new(client, 10, NonZeroU64::new(1).unwrap());
+
+        let token = CancellationToken::new();
+        let clock_ref = clock.spawn(token).await.unwrap();
+        let mut recv = clock_ref.subscribe().unwrap();
+
+        while let Some(block) = subscribe.next().await {
+            let block_number = block.number.unwrap().as_u64();
+
+            if block_number >= 11 {
+                assert!(matches!(recv.try_recv(), Ok(Event::EpochEnded(0))));
+                assert_eq!(clock_ref.current_epoch(), 1);
+                assert!(clock_ref.current_block_height() >= 1);
+                break;
+            } else {
+                assert!(recv.try_recv().is_err());
+                assert!(clock_ref.current_block_height() == 0);
+            }
+        }
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(13))]
+    #[test_log::test(tokio::test)]
+    async fn test_block_clock_starting_with_genesis_already_passed() {
+        let anvil = Anvil::new().block_time(1u64).spawn();
+        let client = Provider::<Ws>::connect(anvil.ws_endpoint()).await.unwrap();
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let clock = BlockClock::new(client, 0, NonZeroU64::new(3).unwrap());
+
+        let token = CancellationToken::new();
+        let clock_ref = clock.spawn(token).await.unwrap();
+
+        let mut recv = clock_ref.subscribe().unwrap();
+        assert_eq!(recv.recv().await, Ok(Event::EpochEnded(3)));
+        assert_eq!(clock_ref.current_epoch(), 4);
+        assert!(clock_ref.current_block_height() >= 10);
     }
 
     #[tokio::test]
@@ -374,7 +438,7 @@ mod tests {
         scenario.teardown();
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_block_clock_overflow_epoch() {
         let scenario = FailScenario::setup();
         let anvil = Anvil::new().block_time(1u64).spawn();
@@ -387,7 +451,7 @@ mod tests {
 
         let token = CancellationToken::new();
         fail::cfg_callback(
-            "block_clock::BlockClock::run::overwrite_block_number",
+            "block_clock::BlockClock::run::overwrite_block_number_on_new_block",
             move || {
                 // Overflow the current_epoch on next poll
                 epoch.store(u64::MAX, std::sync::atomic::Ordering::SeqCst);

--- a/crates/agglayer-config/src/epoch.rs
+++ b/crates/agglayer-config/src/epoch.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{num::NonZeroU64, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
@@ -7,11 +7,31 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "kebab-case")]
 pub enum Epoch {
     TimeClock(TimeClockConfig),
+    BlockClock(BlockClockConfig),
 }
 
 impl Default for Epoch {
     fn default() -> Self {
-        Self::TimeClock(TimeClockConfig::default())
+        Self::BlockClock(BlockClockConfig::default())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct BlockClockConfig {
+    #[serde(default = "default_block_epoch_duration")]
+    pub epoch_duration: NonZeroU64,
+
+    #[serde(default = "default_genesis_block")]
+    pub genesis_block: u64,
+}
+
+impl Default for BlockClockConfig {
+    fn default() -> Self {
+        Self {
+            epoch_duration: default_block_epoch_duration(),
+            genesis_block: default_genesis_block(),
+        }
     }
 }
 
@@ -32,6 +52,14 @@ impl Default for TimeClockConfig {
             epoch_duration: default_epoch_duration(),
         }
     }
+}
+
+fn default_block_epoch_duration() -> NonZeroU64 {
+    NonZeroU64::new(8).unwrap()
+}
+
+const fn default_genesis_block() -> u64 {
+    0
 }
 
 fn default_epoch_duration() -> Duration {

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -47,8 +47,9 @@ private-keys = []
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
 
-[epoch.time-clock]
-epoch-duration = "1m"
+[epoch.block-clock]
+epoch-duration = 8
+genesis-block = 0
 
 [shutdown]
 runtime-timeout = "5s"

--- a/crates/agglayer-node/tests/pushing_certificate.rs
+++ b/crates/agglayer-node/tests/pushing_certificate.rs
@@ -13,6 +13,7 @@ use rstest::rstest;
 use tokio_util::sync::CancellationToken;
 
 #[rstest]
+#[ignore = "until epoch starting resolution"]
 #[tokio::test]
 #[timeout(Duration::from_secs(60))]
 async fn successfully_push_certificate() {
@@ -45,6 +46,7 @@ async fn successfully_push_certificate() {
     let key_path = tmp_dir.path.join(uuid);
 
     config.l1.node_url = anvil.endpoint().parse().unwrap();
+    config.l1.ws_node_url = anvil.ws_endpoint().parse().unwrap();
     config.auth = agglayer_config::AuthConfig::Local(agglayer_config::LocalConfig {
         private_keys: vec![agglayer_config::PrivateKey {
             path: key_path,

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -47,8 +47,9 @@ private-keys = []
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
 
-[epoch.time-clock]
-epoch-duration = "1m"
+[epoch.block-clock]
+epoch-duration = 8
+genesis-block = 0
 
 [shutdown]
 runtime-timeout = "5s"


### PR DESCRIPTION
# Description

This PR adds and refactor how the clock behave when starting.
Basically, when started with a genesis block in the future, the clock will wait for that block number to start.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
