### PR TITLE
feat: inclusion proof of sub-local exit tree

### DIFF
--- a/crates/pessimistic-proof/src/local_exit_tree/data.rs
+++ b/crates/pessimistic-proof/src/local_exit_tree/data.rs
@@ -32,7 +32,7 @@ where
     H::Digest: Serialize + DeserializeOwned,
 {
     #[serde_as(as = "[_; TREE_DEPTH]")]
-    siblings: [H::Digest; TREE_DEPTH],
+    pub(crate) siblings: [H::Digest; TREE_DEPTH],
 }
 
 impl<H, const TREE_DEPTH: usize> Default for LocalExitTreeData<H, TREE_DEPTH>

--- a/crates/pessimistic-proof/src/local_exit_tree/tests.rs
+++ b/crates/pessimistic-proof/src/local_exit_tree/tests.rs
@@ -1,3 +1,4 @@
+use rand::random;
 use rs_merkle::{Hasher as MerkleHasher, MerkleTree};
 use tiny_keccak::{Hasher as _, Keccak};
 
@@ -23,6 +24,32 @@ fn test_local_exit_tree_basic() {
         ground_truth_tree.root().unwrap(),
         local_exit_tree.get_root()
     );
+}
+
+fn local_exit_tree_is_subtree(leaf_count_a: usize, leaf_count_b: usize) {
+    assert!(leaf_count_a <= leaf_count_b);
+    let mut let_a = LocalExitTreeData::<Keccak256Hasher>::new();
+    for _ in 0..leaf_count_a {
+        let_a.add_leaf(random());
+    }
+    let mut let_b = let_a.clone();
+    for _ in 0..leaf_count_b - leaf_count_a {
+        let_b.add_leaf(random());
+    }
+
+    let let_a_frontier = LocalExitTree::from(&let_a);
+    let proof = let_b.get_proof(leaf_count_a as u32);
+    assert!(let_a_frontier.is_subtree(let_b.get_root(), let_b.get(0, leaf_count_a), proof));
+}
+
+#[test]
+fn test_local_exit_tree_is_subtree_different_sizes() {
+    local_exit_tree_is_subtree(100, 200);
+}
+
+#[test]
+fn test_local_exit_tree_is_subtree_empty() {
+    local_exit_tree_is_subtree(0, 100);
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Implement a function `LocalExitTree::is_subtree()` to check if a local exit tree is a sub-tree of another one.
See #119 for discussions.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
