### PR TITLE
fix: remove stale nodes in smt insertion

### DIFF
--- a/crates/pessimistic-proof/src/utils/smt.rs
+++ b/crates/pessimistic-proof/src/utils/smt.rs
@@ -178,8 +178,8 @@ where
                 Ok(value)
             };
         }
-        let node = self.tree.get(&hash);
-        let mut node = node.copied().unwrap_or(Node {
+        let node = self.tree.remove(&hash);
+        let mut node = node.unwrap_or(Node {
             left: self.empty_hash_at_height[DEPTH - depth - 1],
             right: self.empty_hash_at_height[DEPTH - depth - 1],
         });


### PR DESCRIPTION
Remove stale nodes in the SMT when inserting new nodes.
See https://github.com/agglayer/security/issues/6.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
