### PR TITLE
fix: ARM build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --link Cargo.lock Cargo.lock
 
 RUN cargo chef prepare --recipe-path recipe.json --bin agglayer
 
-FROM golang:1.22 AS go-builder
+FROM --platform=${BUILDPLATFORM} golang:1.22 AS go-builder
 
 FROM chef AS builder
 


### PR DESCRIPTION
# Description

Add the `--platform` parameter so Docker picks up the correct architecture for the `go-builder`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
