### PR TITLE
feat: orchestrator response + height checks

### DIFF
--- a/crates/agglayer-certificate-orchestrator/src/error.rs
+++ b/crates/agglayer-certificate-orchestrator/src/error.rs
@@ -21,6 +21,9 @@ pub enum InitialCheckError {
     #[error("Cannot replace an existing {status} certificate")]
     IllegalReplacement { status: CertificateStatus },
 
+    #[error("Certificate processing task for network {network_id} is busy, try again later")]
+    Busy { network_id: NetworkId },
+
     #[error("Internal error")]
     Internal,
 }

--- a/crates/agglayer-certificate-orchestrator/src/error.rs
+++ b/crates/agglayer-certificate-orchestrator/src/error.rs
@@ -1,7 +1,29 @@
 use agglayer_types::{
-    CertificateId, CertificateStatusError, Height, NetworkId, ProofVerificationError,
+    CertificateId, CertificateStatus, CertificateStatusError, Height, NetworkId,
+    ProofVerificationError,
 };
 use pessimistic_proof::ProofError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum InitialCheckError {
+    #[error("Storage error: {0}")]
+    Storage(#[from] agglayer_storage::error::Error),
+
+    #[error("Certificate submission failed")]
+    CertificateSubmission,
+
+    #[error("Certificate is in the past (height {height}, expecting {next_height})")]
+    InPast { height: u64, next_height: u64 },
+
+    #[error("Certificate is too far in the future (height {height}, max allowed {max_height})")]
+    FarFuture { height: u64, max_height: u64 },
+
+    #[error("Cannot replace an existing {status} certificate")]
+    IllegalReplacement { status: CertificateStatus },
+
+    #[error("Internal error")]
+    Internal,
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum PreCertificationError {

--- a/crates/agglayer-certificate-orchestrator/src/error.rs
+++ b/crates/agglayer-certificate-orchestrator/src/error.rs
@@ -1,3 +1,5 @@
+use std::ops::RangeInclusive;
+
 use agglayer_types::{
     CertificateId, CertificateStatus, CertificateStatusError, Height, NetworkId,
     ProofVerificationError,
@@ -12,11 +14,11 @@ pub enum InitialCheckError {
     #[error("Certificate submission failed")]
     CertificateSubmission,
 
-    #[error("Certificate is in the past (height {height}, expecting {next_height})")]
-    InPast { height: u64, next_height: u64 },
-
-    #[error("Certificate is too far in the future (height {height}, max allowed {max_height})")]
-    FarFuture { height: u64, max_height: u64 },
+    #[error("Certificate height ({height}) outside of acceptable range ({accepting:?})")]
+    IllegalHeight {
+        height: u64,
+        accepting: RangeInclusive<u64>,
+    },
 
     #[error("Cannot replace an existing {status} certificate")]
     IllegalReplacement { status: CertificateStatus },

--- a/crates/agglayer-certificate-orchestrator/src/lib.rs
+++ b/crates/agglayer-certificate-orchestrator/src/lib.rs
@@ -17,12 +17,12 @@ use agglayer_storage::{
         PerEpochReader, PerEpochWriter, StateReader, StateWriter,
     },
 };
-use agglayer_types::{CertificateId, Height, NetworkId};
+use agglayer_types::{Certificate, CertificateId, NetworkId};
 use arc_swap::ArcSwap;
 use futures_util::{stream::FuturesUnordered, FutureExt, Stream, StreamExt};
-use network_task::{NetworkTask, NewCertificate};
+use network_task::NetworkTask;
 use tokio::{
-    sync::mpsc::{self, Receiver},
+    sync::{mpsc, oneshot},
     task::JoinHandle,
 };
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
@@ -33,12 +33,15 @@ mod epoch_packer;
 mod error;
 mod network_task;
 
+mod submitter;
+
 #[cfg(test)]
 mod tests;
 
 pub use certifier::{CertificateInput, Certifier, CertifierOutput, CertifierResult};
 pub use epoch_packer::EpochPacker;
-pub use error::{CertificationError, Error, PreCertificationError};
+pub use error::{CertificationError, Error, InitialCheckError, PreCertificationError};
+pub use submitter::Submitter as CertificateSubmitter;
 
 const MAX_POLL_READS: usize = 1_000;
 
@@ -64,6 +67,12 @@ pub type SettlementTasks = FuturesUnordered<
     >,
 >;
 
+/// A response to the certificate submission.
+pub type CertResponse = Result<(), InitialCheckError>;
+
+/// A certificate response sender.
+pub type CertResponseSender = oneshot::Sender<CertResponse>;
+
 /// The Certificate orchestrator receives the certificates from CDKs.
 ///
 /// Each certificate reception triggers the generation of a pessimistic proof.
@@ -87,7 +96,7 @@ pub struct CertificateOrchestrator<
     clock: Pin<Box<dyn Stream<Item = Event> + Send>>,
     clock_ref: ClockRef,
     /// Receiver for certificates coming from CDKs.
-    data_receiver: Receiver<(NetworkId, Height, CertificateId)>,
+    data_receiver: mpsc::Receiver<(Certificate, CertResponseSender)>,
     /// Cancellation token future for graceful shutdown.
     cancellation_token_future: Pin<Box<WaitForCancellationFutureOwned>>,
 
@@ -105,7 +114,7 @@ pub struct CertificateOrchestrator<
 
     /// Network tasks that are currently running, with their associated
     /// notifier.
-    spawned_network_tasks: BTreeMap<NetworkId, mpsc::Sender<NewCertificate>>,
+    spawned_network_tasks: BTreeMap<NetworkId, mpsc::Sender<(Certificate, CertResponseSender)>>,
 
     /// Network task future resolver.
     network_tasks: NetworkTasks,
@@ -129,7 +138,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn try_new(
         clock: ClockRef,
-        data_receiver: Receiver<(NetworkId, Height, CertificateId)>,
+        data_receiver: mpsc::Receiver<(Certificate, CertResponseSender)>,
         cancellation_token: CancellationToken,
         epoch_packing_task_builder: E,
         certifier_task_builder: CertifierClient,
@@ -199,7 +208,7 @@ where
     #[builder(entry = "builder", exit = "start", visibility = "pub")]
     pub async fn start(
         clock: ClockRef,
-        data_receiver: Receiver<(NetworkId, Height, CertificateId)>,
+        data_receiver: mpsc::Receiver<(Certificate, CertResponseSender)>,
         cancellation_token: CancellationToken,
         epoch_packing_task_builder: E,
         certifier_task_builder: CertifierClient,
@@ -283,22 +292,22 @@ where
     /// - Spawning the certifier task for the next height of the network.
     fn receive_certificates(
         &mut self,
-        cursors: impl IntoIterator<Item = (NetworkId, Height, CertificateId)>,
+        cursors: impl IntoIterator<Item = (Certificate, CertResponseSender)>,
     ) -> Result<(), Error> {
-        for (network_id, height, certificate_id) in cursors {
+        for (certificate, reply_sender) in cursors {
+            let network_id = certificate.network_id;
             self.spawn_network_task(network_id)?;
 
             if let Some(sender) = self.spawned_network_tasks.get(&network_id) {
                 if let Ok(sender) = sender.try_reserve() {
-                    sender.send(NewCertificate {
-                        certificate_id,
-                        height,
-                    })
+                    sender.send((certificate, reply_sender));
                 } else {
+                    let certificate_id = certificate.hash();
                     error!(
                         "Failed to send the certificate {certificate_id} to the network task for \
                          network {network_id}",
                     );
+                    let _ = reply_sender.send(Err(InitialCheckError::Internal));
                 }
             } else {
                 warn!("Unable to find the network task for network {}", network_id);

--- a/crates/agglayer-certificate-orchestrator/src/network_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task.rs
@@ -203,7 +203,6 @@ where
                 );
 
                 let response = self.run_prechecks(&certificate, *next_expected_height);
-                warn!("============== PRECHECKS FINISHED");
 
                 if let Err(err) = &response {
                     let cert_id = certificate.hash();

--- a/crates/agglayer-certificate-orchestrator/src/network_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task.rs
@@ -318,22 +318,15 @@ where
 
         if let Some(SettledCertificate(settled_id, _, _, _)) = &self.latest_settled {
             if settled_id == &certificate.hash() {
-                warn!("=============== ALREADY SETTLED");
                 // TODO Return status from the RPC in case of success
                 return Ok(());
             }
         }
 
-        if height < next_height {
-            return Err(InitialCheckError::InPast {
-                height,
-                next_height,
-            });
-        }
-
-        let max_height = next_height + MAX_FUTURE_HEIGHT_DISTANCE;
-        if height > max_height {
-            return Err(InitialCheckError::FarFuture { height, max_height });
+        // Range of certificate heights we are currently accepting.
+        let accepting = next_height..=(next_height + MAX_FUTURE_HEIGHT_DISTANCE);
+        if !accepting.contains(&height) {
+            return Err(InitialCheckError::IllegalHeight { height, accepting });
         }
 
         // TODO signature check + rate limit

--- a/crates/agglayer-certificate-orchestrator/src/network_task/tests/prechecks.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task/tests/prechecks.rs
@@ -1,0 +1,159 @@
+use std::{sync::Arc, time::Duration};
+
+use agglayer_storage::tests::mocks::{MockPendingStore, MockStateStore};
+use agglayer_types::{
+    Certificate, CertificateHeader, CertificateStatus, CertificateStatusError, Digest, NetworkId,
+};
+use mockall::predicate::eq;
+use rstest::rstest;
+use tokio::sync::mpsc;
+
+use crate::{
+    epoch_packer::MockEpochPacker,
+    network_task::NetworkTask,
+    tests::{clock, mocks::MockCertifier},
+    InitialCheckError,
+};
+
+const fn dummy_cert_header(
+    network_id: NetworkId,
+    height: u64,
+    status: CertificateStatus,
+) -> CertificateHeader {
+    CertificateHeader {
+        network_id,
+        height,
+        epoch_number: None,
+        certificate_index: None,
+        certificate_id: Digest([0xab; 32]),
+        prev_local_exit_root: Digest([0xbc; 32]),
+        new_local_exit_root: Digest([0xcd; 32]),
+        metadata: Digest([0xef; 32]),
+        settlement_tx_hash: None,
+        status,
+    }
+}
+
+#[rstest]
+#[case(None)]
+#[case(Some(dummy_cert_header(1.into(), 0, CertificateStatus::InError {
+        error: CertificateStatusError::TrustedSequencerNotFound(1.into())
+    })))]
+#[case(Some(dummy_cert_header(1.into(), 0, CertificateStatus::InError {
+        error: CertificateStatusError::ProofVerificationFailed(
+            agglayer_types::ProofVerificationError::InvalidPublicValues
+        )
+    })))]
+#[tokio::test]
+#[timeout(Duration::from_secs(1))]
+async fn process_certificate_ok(#[case] existing_cert_header: Option<CertificateHeader>) {
+    let mut pending = MockPendingStore::new();
+    let mut state = MockStateStore::new();
+    let certifier = MockCertifier::new();
+    let packer = MockEpochPacker::new();
+    let clock_ref = clock();
+    let network_id = 1.into();
+    let (_sender, certificate_stream) = mpsc::channel(100);
+
+    state
+        .expect_get_latest_settled_certificate_per_network()
+        .once()
+        .with(eq(network_id))
+        .returning(|_| Ok(None));
+
+    state
+        .expect_get_certificate_header_by_cursor()
+        .once()
+        .with(eq(network_id), eq(0))
+        .returning(move |_network_id, _height| Ok(existing_cert_header.clone()));
+
+    state
+        .expect_read_local_network_state()
+        .returning(|_| Ok(Default::default()));
+
+    state
+        .expect_insert_certificate_header()
+        .once()
+        .returning(|_cert, _status| Ok(()));
+
+    pending
+        .expect_insert_pending_certificate()
+        .once()
+        .returning(|_net, _ht, _cert| Ok(()));
+
+    state
+        .expect_write_local_network_state()
+        .returning(|_, _, _| Ok(()));
+
+    let mut task = NetworkTask::new(
+        Arc::new(pending),
+        Arc::new(state),
+        Arc::new(certifier),
+        Arc::new(packer),
+        clock_ref.clone(),
+        network_id,
+        certificate_stream,
+    )
+    .expect("Failed to create a new network task");
+
+    let certificate = Certificate::new_for_test(network_id, 0);
+    let result = task.run_prechecks(&certificate, 0);
+    assert!(result.is_ok());
+}
+
+#[rstest]
+#[case(CertificateStatus::Proven)]
+#[case(CertificateStatus::Pending)]
+#[case(CertificateStatus::Candidate)]
+#[case(CertificateStatus::Settled)]
+#[tokio::test]
+#[timeout(Duration::from_secs(1))]
+async fn replace_certificate_illegally(#[case] cur_cert_status: CertificateStatus) {
+    let pending = MockPendingStore::new();
+    let mut state = MockStateStore::new();
+    let certifier = MockCertifier::new();
+    let packer = MockEpochPacker::new();
+    let clock_ref = clock();
+    let network_id = 1.into();
+    let (_sender, certificate_stream) = mpsc::channel(100);
+
+    state
+        .expect_get_latest_settled_certificate_per_network()
+        .once()
+        .with(eq(network_id))
+        .returning(|_| Ok(None));
+
+    state
+        .expect_get_certificate_header_by_cursor()
+        .once()
+        .with(eq(network_id), eq(0))
+        .returning(move |network_id, height| {
+            Ok(Some(dummy_cert_header(
+                network_id,
+                height,
+                cur_cert_status.clone(),
+            )))
+        });
+
+    state
+        .expect_read_local_network_state()
+        .returning(|_| Ok(Default::default()));
+
+    let mut task = NetworkTask::new(
+        Arc::new(pending),
+        Arc::new(state),
+        Arc::new(certifier),
+        Arc::new(packer),
+        clock_ref.clone(),
+        network_id,
+        certificate_stream,
+    )
+    .expect("Failed to create a new network task");
+
+    let certificate = Certificate::new_for_test(network_id, 0);
+    let result = task.run_prechecks(&certificate, 0);
+    assert!(matches!(
+        result.unwrap_err(),
+        InitialCheckError::IllegalReplacement { .. }
+    ));
+}

--- a/crates/agglayer-certificate-orchestrator/src/network_task/tests/status.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task/tests/status.rs
@@ -104,10 +104,8 @@ async fn from_pending_to_settle() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = 0;
-    let mut first_run = true;
-    task.make_progress(&mut epochs, &mut next_expected_height, &mut first_run)
+    task.process_next_pending_certificate(&mut next_expected_height)
         .await
         .unwrap();
 
@@ -210,10 +208,8 @@ async fn from_proven_to_settle() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = 0;
-    let mut first_run = true;
-    task.make_progress(&mut epochs, &mut next_expected_height, &mut first_run)
+    task.process_next_pending_certificate(&mut next_expected_height)
         .await
         .unwrap();
 
@@ -308,10 +304,8 @@ async fn from_candidate_to_settle() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = 0;
-    let mut first_run = true;
-    task.make_progress(&mut epochs, &mut next_expected_height, &mut first_run)
+    task.process_next_pending_certificate(&mut next_expected_height)
         .await
         .unwrap();
 
@@ -369,10 +363,8 @@ async fn from_settle_to_settle() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = 1;
-    let mut first_run = true;
-    task.make_progress(&mut epochs, &mut next_expected_height, &mut first_run)
+    task.process_next_pending_certificate(&mut next_expected_height)
         .await
         .unwrap();
 

--- a/crates/agglayer-certificate-orchestrator/src/network_task/tests/status.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task/tests/status.rs
@@ -104,8 +104,9 @@ async fn from_pending_to_settle() {
     )
     .expect("Failed to create a new network task");
 
+    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = 0;
-    task.process_next_pending_certificate(&mut next_expected_height)
+    task.make_progress(&mut epochs, &mut next_expected_height)
         .await
         .unwrap();
 
@@ -208,8 +209,9 @@ async fn from_proven_to_settle() {
     )
     .expect("Failed to create a new network task");
 
+    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = 0;
-    task.process_next_pending_certificate(&mut next_expected_height)
+    task.make_progress(&mut epochs, &mut next_expected_height)
         .await
         .unwrap();
 
@@ -304,8 +306,9 @@ async fn from_candidate_to_settle() {
     )
     .expect("Failed to create a new network task");
 
+    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = 0;
-    task.process_next_pending_certificate(&mut next_expected_height)
+    task.make_progress(&mut epochs, &mut next_expected_height)
         .await
         .unwrap();
 
@@ -343,6 +346,10 @@ async fn from_settle_to_settle() {
         .state
         .insert_certificate_header(&certificate, CertificateStatus::Settled)
         .expect("Failed to insert certificate header");
+    storage
+        .pending
+        .insert_pending_certificate(network_id, 1, &certificate)
+        .expect("unable to insert certificate in pending");
 
     certifier.expect_certify().never();
     certifier.expect_witness_execution().never();
@@ -363,8 +370,9 @@ async fn from_settle_to_settle() {
     )
     .expect("Failed to create a new network task");
 
+    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = 1;
-    task.process_next_pending_certificate(&mut next_expected_height)
+    task.make_progress(&mut epochs, &mut next_expected_height)
         .await
         .unwrap();
 

--- a/crates/agglayer-certificate-orchestrator/src/submitter.rs
+++ b/crates/agglayer-certificate-orchestrator/src/submitter.rs
@@ -1,0 +1,26 @@
+use tokio::sync::{mpsc, oneshot};
+
+use crate::{CertResponseSender, Certificate, InitialCheckError as Error};
+
+/// An entry point to submit certificates to the orchestrator.
+#[derive(Debug, Clone)]
+pub struct Submitter(mpsc::Sender<(Certificate, CertResponseSender)>);
+
+impl Submitter {
+    pub fn new(cert_sender: mpsc::Sender<(Certificate, CertResponseSender)>) -> Self {
+        Self(cert_sender)
+    }
+}
+
+impl Submitter {
+    pub async fn submit(&self, certificate: Certificate) -> Result<(), Error> {
+        let (resp_send, resp_recv) = oneshot::channel();
+
+        self.0
+            .send((certificate, resp_send))
+            .await
+            .map_err(|_| Error::CertificateSubmission)?;
+
+        resp_recv.await.map_err(|_| Error::Internal)?
+    }
+}

--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -40,12 +40,12 @@ use pessimistic_proof::{
     LocalNetworkState,
 };
 use rstest::fixture;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    epoch_packer::MockEpochPacker, CertificateInput, CertificateOrchestrator, CertificationError,
-    Certifier, CertifierOutput, CertifierResult, EpochPacker, Error,
+    epoch_packer::MockEpochPacker, CertResponseSender, CertificateInput, CertificateOrchestrator,
+    CertificationError, Certifier, CertifierOutput, CertifierResult, EpochPacker, Error,
 };
 
 pub(crate) mod mocks;
@@ -546,7 +546,10 @@ async fn test_collect_certificates() {
     )
     .expect("Unable to create orchestrator");
 
-    _ = data_sender.send((1.into(), 1, [0; 32].into())).await;
+    let cert = Certificate::new_for_test(1.into(), 1);
+    let res_send = oneshot::channel().0;
+    _ = data_sender.send((cert, res_send)).await;
+
     let current_epoch = orchestrator.current_epoch.load().clone();
     _ = clock_sender.send(agglayer_clock::Event::EpochEnded(1));
 
@@ -615,7 +618,9 @@ async fn test_collect_certificates_after_epoch() {
     _ = clock_sender.send(agglayer_clock::Event::EpochEnded(1));
     let _poll = poll!(&mut orchestrator);
 
-    _ = data_sender.send((1.into(), 1, [0; 32].into())).await;
+    let cert = Certificate::new_for_test(1.into(), 1);
+    let res_send = oneshot::channel().0;
+    _ = data_sender.send((cert, res_send)).await;
 
     let _poll = poll!(&mut orchestrator);
 
@@ -756,7 +761,7 @@ struct MockOrchestrator {
     current_epoch: Option<MockPerEpochStore>,
 }
 
-type SenderAndClockRef = (mpsc::Sender<(NetworkId, Height, CertificateId)>, ClockRef);
+type SenderAndClockRef = (mpsc::Sender<(Certificate, CertResponseSender)>, ClockRef);
 
 #[fixture]
 pub(crate) fn create_orchestrator_mock(

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -218,13 +218,17 @@ impl Node {
             .await?;
 
         info!("Certificate orchestrator started.");
+
+        let cert_submitter =
+            agglayer_certificate_orchestrator::CertificateSubmitter::new(data_sender);
+
         // Bind the core to the RPC server.
         let server_handle = AgglayerImpl::new(
             core,
-            data_sender,
             pending_store.clone(),
-            state_store.clone(),
+            state_store,
             debug_store,
+            cert_submitter,
             config.clone(),
         )
         .start()

--- a/crates/agglayer-node/src/rpc/error.rs
+++ b/crates/agglayer-node/src/rpc/error.rs
@@ -116,7 +116,7 @@ pub enum Error {
     #[error("Status retrieval error: {0}")]
     Status(#[from] StatusError),
 
-    #[error("Cannot send certificate: {detail}")]
+    #[error("Cannot send certificate")]
     SendCertificate { detail: String },
 
     #[error("Rate limited")]
@@ -164,7 +164,9 @@ impl Error {
         err.into()
     }
 
-    pub(crate) fn send_certificate<T>(err: tokio::sync::mpsc::error::SendError<T>) -> Self {
+    pub(crate) fn send_certificate(
+        err: agglayer_certificate_orchestrator::InitialCheckError,
+    ) -> Self {
         let detail = err.to_string();
         Self::SendCertificate { detail }
     }

--- a/crates/agglayer-node/src/rpc/mod.rs
+++ b/crates/agglayer-node/src/rpc/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use agglayer_certificate_orchestrator::CertificateSubmitter;
 use agglayer_config::epoch::BlockClockConfig;
 use agglayer_config::Config;
 use agglayer_config::Epoch;
@@ -11,9 +12,9 @@ use agglayer_storage::stores::PendingCertificateWriter;
 use agglayer_storage::stores::StateReader;
 use agglayer_storage::stores::StateWriter;
 use agglayer_telemetry::KeyValue;
-use agglayer_types::CertificateStatus;
-use agglayer_types::EpochConfiguration;
-use agglayer_types::{Certificate, CertificateHeader, CertificateId, Height, NetworkId};
+use agglayer_types::{
+    Certificate, CertificateHeader, CertificateId, CertificateStatus, EpochConfiguration, NetworkId,
+};
 use ethers::{
     contract::{ContractError, ContractRevert},
     providers::Middleware,
@@ -25,11 +26,9 @@ use jsonrpsee::{
     proc_macros::rpc,
     server::{middleware::http::ProxyGetRequestLayer, PingConfig, ServerBuilder, ServerHandle},
 };
-use tokio::{sync::mpsc, try_join};
-use tower_http::compression::CompressionLayer;
-use tower_http::cors::CorsLayer;
-use tracing::trace;
-use tracing::{debug, error, info, instrument};
+use tokio::try_join;
+use tower_http::{compression::CompressionLayer, cors::CorsLayer};
+use tracing::{debug, error, info, instrument, trace};
 
 use crate::{
     kernel::Kernel,
@@ -91,10 +90,10 @@ trait Agglayer {
 /// The RPC agglayer service implementation.
 pub(crate) struct AgglayerImpl<Rpc, PendingStore, StateStore, DebugStore> {
     kernel: Kernel<Rpc>,
-    certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
     pending_store: Arc<PendingStore>,
-    state: Arc<StateStore>,
+    state_store: Arc<StateStore>,
     debug_store: Arc<DebugStore>,
+    certificate_submitter: CertificateSubmitter,
     config: Arc<Config>,
 }
 
@@ -104,18 +103,18 @@ impl<Rpc, PendingStore, StateStore, DebugStore>
     /// Create an instance of the RPC agglayer service.
     pub(crate) fn new(
         kernel: Kernel<Rpc>,
-        certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
         pending_store: Arc<PendingStore>,
-        state: Arc<StateStore>,
+        state_store: Arc<StateStore>,
         debug_store: Arc<DebugStore>,
+        certificate_submitter: CertificateSubmitter,
         config: Arc<Config>,
     ) -> Self {
         Self {
             kernel,
-            certificate_sender,
             pending_store,
-            state,
+            state_store,
             debug_store,
+            certificate_submitter,
             config,
         }
     }
@@ -343,43 +342,15 @@ where
             "Received certificate {hash} for rollup {} at height {}", *certificate.network_id, certificate.height
         );
 
-        // TODO: Batch the different queries.
-        // Insert the certificate header into the state store.
-        _ = self
-            .state
-            .insert_certificate_header(&certificate, CertificateStatus::Pending)
-            .map_err(|e| {
-                error!("Failed to insert certificate into state store: {e}");
-                Error::internal(e.to_string())
-            })?;
-
-        // Insert the certificate into the pending store.
-        _ = self
-            .pending_store
-            .insert_pending_certificate(certificate.network_id, certificate.height, &certificate)
-            .map_err(|e| {
-                error!("Failed to insert certificate into pending store: {e}");
-                Error::internal(e.to_string())
-            })?;
-
         _ = self.debug_store.add_certificate(&certificate).map_err(|e| {
             error!("Failed to insert certificate into debug store: {e}");
             Error::internal(e.to_string())
         });
 
-        if let Err(error) = self
-            .certificate_sender
-            .send((
-                certificate.network_id,
-                certificate.height,
-                certificate.hash(),
-            ))
+        self.certificate_submitter
+            .submit(certificate)
             .await
-        {
-            error!("Failed to send certificate: {error}");
-
-            return Err(Error::send_certificate(error));
-        }
+            .map_err(Error::send_certificate)?;
 
         Ok(hash)
     }
@@ -389,7 +360,7 @@ where
         certificate_id: CertificateId,
     ) -> RpcResult<CertificateHeader> {
         trace!("Received request to get certificate header for certificate {certificate_id}");
-        match self.state.get_certificate_header(&certificate_id) {
+        match self.state_store.get_certificate_header(&certificate_id) {
             Ok(Some(header)) => Ok(header),
             Ok(None) => Err(Error::resource_not_found(format!(
                 "Certificate({})",
@@ -433,7 +404,7 @@ where
         );
 
         let settled_certificate_id_and_height = self
-            .state
+            .state_store
             .get_latest_settled_certificate_per_network(&network_id)
             .map_err(|e| {
                 error!("Failed to get latest settled certificate: {e}");
@@ -470,7 +441,7 @@ where
         .map(|v| v.0);
 
         if let Some(certificate_id) = certificate_id {
-            match self.state.get_certificate_header(&certificate_id) {
+            match self.state_store.get_certificate_header(&certificate_id) {
                 Ok(Some(header)) => Ok(Some(header)),
                 Ok(None) => Err(Error::resource_not_found(format!(
                     "Certificate({})",
@@ -496,7 +467,7 @@ where
     ) -> RpcResult<(Certificate, Option<CertificateHeader>)> {
         match self.debug_store.get_certificate(&certificate_id) {
             Ok(Some(cert)) => match self
-                .state
+                .state_store
                 .get_certificate_header(&certificate_id)
                 .map(|header| (cert, header))
             {
@@ -523,7 +494,7 @@ where
         network_id: NetworkId,
     ) -> RpcResult<Option<CertificateHeader>> {
         let id = match self
-            .state
+            .state_store
             .get_latest_settled_certificate_per_network(&network_id)
         {
             Ok(Some((_, SettledCertificate(id, _, _, _)))) => id,
@@ -536,7 +507,7 @@ where
             }
         };
 
-        match self.state.get_certificate_header(&id) {
+        match self.state_store.get_certificate_header(&id) {
             Ok(Some(header)) => Ok(Some(header)),
             Ok(None) => Err(Error::resource_not_found(format!("Certificate({})", id))),
             Err(e) => {
@@ -564,7 +535,7 @@ where
             }
         };
 
-        match self.state.get_certificate_header(&id) {
+        match self.state_store.get_certificate_header(&id) {
             Ok(Some(CertificateHeader {
                 status: CertificateStatus::Settled,
                 ..

--- a/crates/agglayer-node/src/rpc/tests/errors.rs
+++ b/crates/agglayer-node/src/rpc/tests/errors.rs
@@ -111,6 +111,7 @@ type CertError = agglayer_certificate_orchestrator::InitialCheckError;
     "cert_submission",
     Error::send_certificate(CertError::CertificateSubmission)
 )]
+#[case("cert_busy", Error::send_certificate(CertError::Busy { network_id: 42.into() }))]
 #[case(
     "cert_past",
     Error::send_certificate(CertError::InPast {

--- a/crates/agglayer-node/src/rpc/tests/errors.rs
+++ b/crates/agglayer-node/src/rpc/tests/errors.rs
@@ -114,16 +114,16 @@ type CertError = agglayer_certificate_orchestrator::InitialCheckError;
 #[case("cert_busy", Error::send_certificate(CertError::Busy { network_id: 42.into() }))]
 #[case(
     "cert_past",
-    Error::send_certificate(CertError::InPast {
+    Error::send_certificate(CertError::IllegalHeight {
         height: 55,
-        next_height: 57,
+        accepting: 57..=67,
     })
 )]
 #[case(
     "cert_future",
-    Error::send_certificate(CertError::FarFuture {
+    Error::send_certificate(CertError::IllegalHeight {
         height: 153,
-        max_height: 95,
+        accepting: 95..=105,
     })
 )]
 #[case(

--- a/crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
+++ b/crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
@@ -30,7 +30,7 @@ async fn fetch_unknown_certificate_header(#[future] context: TestContext) {
 #[rstest]
 #[awt]
 #[test_log::test(tokio::test)]
-async fn fetch_known_certificate_header(#[future] mut context: TestContext) {
+async fn fetch_kown_certificate_header(#[future] context: TestContext) {
     let certificate = Certificate::new_for_test(1.into(), 0);
     let id = certificate.hash();
 
@@ -41,7 +41,6 @@ async fn fetch_known_certificate_header(#[future] mut context: TestContext) {
         .unwrap();
 
     assert_eq!(id, res);
-    assert!(context.certificate_receiver.try_recv().is_ok());
 
     let payload: CertificateHeader = context
         .client
@@ -56,7 +55,7 @@ async fn fetch_known_certificate_header(#[future] mut context: TestContext) {
 #[rstest]
 #[awt]
 #[test_log::test(tokio::test)]
-async fn get_certificate_header_after_sending_the_certificate(#[future] mut context: TestContext) {
+async fn get_certificate_header_after_sending_the_certificate(#[future] context: TestContext) {
     let certificate = Certificate::new_for_test(1.into(), 0);
     let id = certificate.hash();
 
@@ -67,7 +66,6 @@ async fn get_certificate_header_after_sending_the_certificate(#[future] mut cont
         .unwrap();
 
     assert_eq!(id, res);
-    assert!(context.certificate_receiver.try_recv().is_ok());
 
     let payload: CertificateHeader = context
         .client
@@ -163,6 +161,7 @@ async fn certificate_header(#[future] raw_rpc: RawRpcContext) {
         .unwrap()
     );
 }
+
 #[rstest]
 #[test_log::test(tokio::test)]
 async fn debug_fetch_unknown_certificate() {
@@ -188,7 +187,7 @@ async fn debug_fetch_known_certificate() {
     let mut config = TestContext::get_default_config();
     config.debug_mode = true;
 
-    let mut context = TestContext::new_with_config(config).await;
+    let context = TestContext::new_with_config(config).await;
 
     let certificate = Certificate::new_for_test(1.into(), 0);
     let id = certificate.hash();
@@ -200,7 +199,6 @@ async fn debug_fetch_known_certificate() {
         .unwrap();
 
     assert_eq!(id, res);
-    assert!(context.certificate_receiver.try_recv().is_ok());
 
     let (recv_cert, header): (Certificate, Option<CertificateHeader>) = context
         .client
@@ -221,7 +219,7 @@ async fn debug_get_certificate_after_sending_the_certificate() {
     let mut config = TestContext::get_default_config();
     config.debug_mode = true;
 
-    let mut context = TestContext::new_with_config(config).await;
+    let context = TestContext::new_with_config(config).await;
 
     let certificate = Certificate::new_for_test(1.into(), 0);
     let id = certificate.hash();
@@ -233,7 +231,6 @@ async fn debug_get_certificate_after_sending_the_certificate() {
         .unwrap();
 
     assert_eq!(id, res);
-    assert!(context.certificate_receiver.try_recv().is_ok());
 
     let (recv_cert, header): (Certificate, Option<CertificateHeader>) = context
         .client
@@ -264,7 +261,7 @@ async fn debug_get_certificate_after_overwrite() {
     let mut config = TestContext::get_default_config();
     config.debug_mode = true;
 
-    let mut context = TestContext::new_with_config(config).await;
+    let context = TestContext::new_with_config(config).await;
 
     let certificate = Certificate::new_for_test(1.into(), 0);
     let id = certificate.hash();
@@ -276,7 +273,6 @@ async fn debug_get_certificate_after_overwrite() {
         .unwrap();
 
     assert_eq!(id, res);
-    assert!(context.certificate_receiver.try_recv().is_ok());
 
     let (recv_cert, header): (Certificate, Option<CertificateHeader>) = context
         .client
@@ -301,7 +297,6 @@ async fn debug_get_certificate_after_overwrite() {
         .unwrap();
 
     assert_eq!(id2, res);
-    assert!(context.certificate_receiver.try_recv().is_ok());
 
     // Retrieve 1
     let (recv_cert, header): (Certificate, Option<CertificateHeader>) = context
@@ -336,7 +331,7 @@ async fn debug_get_certificate_after_overwrite_with_debug_false() {
     let mut config = TestContext::get_default_config();
     config.debug_mode = false;
 
-    let mut context = TestContext::new_with_config(config).await;
+    let context = TestContext::new_with_config(config).await;
 
     let certificate = Certificate::new_for_test(1.into(), 0);
     let id = certificate.hash();
@@ -348,7 +343,6 @@ async fn debug_get_certificate_after_overwrite_with_debug_false() {
         .unwrap();
 
     assert_eq!(id, res);
-    assert!(context.certificate_receiver.try_recv().is_ok());
 
     let payload: Result<(Certificate, Option<CertificateHeader>), ClientError> = context
         .client
@@ -371,7 +365,6 @@ async fn debug_get_certificate_after_overwrite_with_debug_false() {
         .unwrap();
 
     assert_eq!(id2, res);
-    assert!(context.certificate_receiver.try_recv().is_ok());
 
     let payload: Result<(Certificate, Option<CertificateHeader>), ClientError> = context
         .client

--- a/crates/agglayer-node/src/rpc/tests/mod.rs
+++ b/crates/agglayer-node/src/rpc/tests/mod.rs
@@ -1,15 +1,15 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use agglayer_certificate_orchestrator::{CertResponseSender, CertificateSubmitter};
 use agglayer_config::Config;
-use agglayer_storage::columns::latest_settled_certificate_per_network::SettledCertificate;
-use agglayer_storage::storage::{pending_db_cf_definitions, state_db_cf_definitions, DB};
-use agglayer_storage::stores::debug::DebugStore;
-use agglayer_storage::stores::pending::PendingStore;
-use agglayer_storage::stores::state::StateStore;
-use agglayer_storage::stores::{DebugReader, DebugWriter, PendingCertificateReader};
 use agglayer_storage::{
-    stores::{PendingCertificateWriter, StateReader, StateWriter},
+    columns::latest_settled_certificate_per_network::SettledCertificate,
+    storage::{pending_db_cf_definitions, state_db_cf_definitions, DB},
+    stores::{
+        debug::DebugStore, pending::PendingStore, state::StateStore, DebugReader, DebugWriter,
+        PendingCertificateReader, PendingCertificateWriter, StateReader, StateWriter,
+    },
     tests::TempDBDir,
 };
 use agglayer_types::{Certificate, CertificateId, CertificateStatus, Digest, Height, NetworkId};
@@ -20,6 +20,7 @@ use hyper_util::rt::TokioExecutor;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::server::ServerHandle;
 use rstest::*;
+use tokio::{sync::mpsc, task::JoinHandle};
 
 use crate::{kernel::Kernel, rpc::AgglayerImpl};
 
@@ -47,12 +48,14 @@ async fn healthcheck_method_can_be_called() {
 
     let kernel = Kernel::new(Arc::new(provider), config.clone());
 
+    let cert_submitter = CertificateSubmitter::new(certificate_sender);
+
     let _server_handle = AgglayerImpl::new(
         kernel,
-        certificate_sender,
         Arc::new(DummyStore {}),
         Arc::new(DummyStore {}),
         Arc::new(DummyStore {}),
+        cert_submitter,
         config.clone(),
     )
     .start()
@@ -78,18 +81,41 @@ async fn healthcheck_method_can_be_called() {
     assert_eq!(out.as_str(), "{\"health\":true}");
 }
 
+struct DummyOrchestrator(JoinHandle<()>);
+
+impl DummyOrchestrator {
+    fn start(
+        mut certificate_receiver: mpsc::Receiver<(Certificate, CertResponseSender)>,
+        state_store: Arc<StateStore>,
+    ) -> Self {
+        let handle = tokio::task::spawn(async move {
+            while let Some((cert, reply_sender)) = certificate_receiver.recv().await {
+                state_store
+                    .insert_certificate_header(&cert, CertificateStatus::Pending)
+                    .unwrap();
+                let _ = reply_sender.send(Ok(()));
+            }
+        });
+        Self(handle)
+    }
+}
+
+impl Drop for DummyOrchestrator {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 pub(crate) struct RawRpcContext {
-    pub(crate) rpc: AgglayerImpl<Provider<MockProvider>, PendingStore, StateStore, DebugStore>,
+    rpc: AgglayerImpl<Provider<MockProvider>, PendingStore, StateStore, DebugStore>,
     config: Arc<Config>,
-    pub(crate) certificate_receiver:
-        tokio::sync::mpsc::Receiver<(NetworkId, Height, CertificateId)>,
+    dummy_orchestrator: DummyOrchestrator,
 }
 
 pub(crate) struct TestContext {
-    pub(crate) server_handle: ServerHandle,
-    pub(crate) client: jsonrpsee::http_client::HttpClient,
-    pub(crate) certificate_receiver:
-        tokio::sync::mpsc::Receiver<(NetworkId, Height, CertificateId)>,
+    server_handle: ServerHandle,
+    client: jsonrpsee::http_client::HttpClient,
+    _dummy_orchestrator: DummyOrchestrator,
 }
 
 impl TestContext {
@@ -108,7 +134,7 @@ impl TestContext {
         Self {
             server_handle,
             client,
-            certificate_receiver: raw_rpc.certificate_receiver,
+            _dummy_orchestrator: raw_rpc.dummy_orchestrator,
         }
     }
 
@@ -150,19 +176,23 @@ impl TestContext {
 
         let kernel = Kernel::new(Arc::new(provider), config.clone());
 
+        let cert_submitter = CertificateSubmitter::new(certificate_sender);
+
         let rpc = AgglayerImpl::new(
             kernel,
-            certificate_sender,
             pending_store,
-            state_store,
+            state_store.clone(),
             debug_store,
+            cert_submitter,
             config.clone(),
         );
+
+        let dummy_orchestrator = DummyOrchestrator::start(certificate_receiver, state_store);
 
         RawRpcContext {
             rpc,
             config,
-            certificate_receiver,
+            dummy_orchestrator,
         }
     }
 }

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_busy.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_busy.snap
@@ -1,0 +1,14 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "SendCertificate { detail: \"Certificate processing task for network 42 is busy, try again later\" }"
+snapshot_kind: text
+---
+{
+  "code": -10006,
+  "data": {
+    "send-certificate": {
+      "detail": "Certificate processing task for network 42 is busy, try again later"
+    }
+  },
+  "message": "Cannot send certificate"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_future.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_future.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+assertion_line: 144
+expression: "SendCertificate { detail: \"Certificate is too far in the future (height 153, max allowed 95)\" }"
+snapshot_kind: text
+---
+{
+  "code": -10006,
+  "data": {
+    "send-certificate": {
+      "detail": "Certificate is too far in the future (height 153, max allowed 95)"
+    }
+  },
+  "message": "Cannot send certificate"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_future.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_future.snap
@@ -1,14 +1,13 @@
 ---
 source: crates/agglayer-node/src/rpc/tests/errors.rs
-assertion_line: 144
-expression: "SendCertificate { detail: \"Certificate is too far in the future (height 153, max allowed 95)\" }"
+expression: "SendCertificate { detail: \"Certificate height (153) outside of acceptable range (95..=105)\" }"
 snapshot_kind: text
 ---
 {
   "code": -10006,
   "data": {
     "send-certificate": {
-      "detail": "Certificate is too far in the future (height 153, max allowed 95)"
+      "detail": "Certificate height (153) outside of acceptable range (95..=105)"
     }
   },
   "message": "Cannot send certificate"

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_past.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_past.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+assertion_line: 144
+expression: "SendCertificate { detail: \"Certificate is in the past (height 55, expecting 57)\" }"
+snapshot_kind: text
+---
+{
+  "code": -10006,
+  "data": {
+    "send-certificate": {
+      "detail": "Certificate is in the past (height 55, expecting 57)"
+    }
+  },
+  "message": "Cannot send certificate"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_past.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_past.snap
@@ -1,14 +1,13 @@
 ---
 source: crates/agglayer-node/src/rpc/tests/errors.rs
-assertion_line: 144
-expression: "SendCertificate { detail: \"Certificate is in the past (height 55, expecting 57)\" }"
+expression: "SendCertificate { detail: \"Certificate height (55) outside of acceptable range (57..=67)\" }"
 snapshot_kind: text
 ---
 {
   "code": -10006,
   "data": {
     "send-certificate": {
-      "detail": "Certificate is in the past (height 55, expecting 57)"
+      "detail": "Certificate height (55) outside of acceptable range (57..=67)"
     }
   },
   "message": "Cannot send certificate"

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_replace_candidate.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_replace_candidate.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+assertion_line: 144
+expression: "SendCertificate { detail: \"Cannot replace an existing Candidate certificate\" }"
+snapshot_kind: text
+---
+{
+  "code": -10006,
+  "data": {
+    "send-certificate": {
+      "detail": "Cannot replace an existing Candidate certificate"
+    }
+  },
+  "message": "Cannot send certificate"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_submission.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_submission.snap
@@ -1,0 +1,15 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+assertion_line: 131
+expression: "SendCertificate { detail: \"Certificate submission failed\" }"
+snapshot_kind: text
+---
+{
+  "code": -10006,
+  "data": {
+    "send-certificate": {
+      "detail": "Certificate submission failed"
+    }
+  },
+  "message": "Cannot send certificate"
+}

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -220,6 +220,16 @@ pub enum CertificateStatus {
     Settled,
 }
 
+impl CertificateStatus {
+    /// Get the error if the certificate is in error.
+    pub fn as_error(&self) -> Option<&CertificateStatusError> {
+        match self {
+            Self::InError { error } => Some(error),
+            _ => None,
+        }
+    }
+}
+
 impl std::fmt::Display for CertificateStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
* The results of the initial certificate checks (before proving) are returned to the submitter via rpc. This includes certificate height check and certificate check. The initial checks do not include proof execution / generation.
* The certificate is only inserted into the storage once the initial checks pass, closing a potential DoS vector.

Related issues:
* #400 
* #401

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
