### PR TITLE
fix: auth kms rename

### DIFF
--- a/crates/agglayer-config/src/auth.rs
+++ b/crates/agglayer-config/src/auth.rs
@@ -58,23 +58,23 @@ pub struct PrivateKey {
 #[cfg_attr(any(test, feature = "testutils"), derive(Default))]
 #[serde(rename_all = "kebab-case")]
 pub struct GcpKmsConfig {
-    #[serde(rename = "ProjectId")]
+    #[serde(alias = "ProjectId")]
     #[serde_as(as = "NoneAsEmptyString")]
     #[serde(default)]
     pub project_id: Option<String>,
-    #[serde(rename = "Location")]
+    #[serde(alias = "Location")]
     #[serde_as(as = "NoneAsEmptyString")]
     #[serde(default)]
     pub location: Option<String>,
-    #[serde(rename = "Keyring")]
+    #[serde(alias = "Keyring")]
     #[serde_as(as = "NoneAsEmptyString")]
     #[serde(default)]
     pub keyring: Option<String>,
-    #[serde(rename = "KeyName")]
+    #[serde(alias = "KeyName")]
     #[serde_as(as = "NoneAsEmptyString")]
     #[serde(default)]
     pub key_name: Option<String>,
-    #[serde(rename = "KeyVersion")]
+    #[serde(alias = "KeyVersion")]
     #[serde(default)]
     pub key_version: Option<u64>,
 }

--- a/crates/agglayer-config/tests/auth_config.rs
+++ b/crates/agglayer-config/tests/auth_config.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+
+use agglayer_config::Config;
+use insta::assert_toml_snapshot;
+
+#[test]
+fn auth_kebab_case() {
+    let input = "./tests/fixtures/valide_config/auth_kebab_case.toml";
+
+    let config = Config::try_load(Path::new(input)).unwrap();
+
+    assert_toml_snapshot!(config, {
+        ".storage.*" => insta::dynamic_redaction(|value, path| {
+            if path.to_string() != "storage.db-path" {
+                if let insta::internals::Content::String(path) = value {
+                    return insta::internals::Content::String(path.replace(Path::new("./").canonicalize().unwrap().to_str().unwrap(), "/tmp/agglayer"));
+                }
+            }
+
+            value
+        }),
+    });
+}

--- a/crates/agglayer-config/tests/fixtures/valide_config/auth_kebab_case.toml
+++ b/crates/agglayer-config/tests/fixtures/valide_config/auth_kebab_case.toml
@@ -1,0 +1,6 @@
+[auth.gcpkms]
+project-id = "project-id_test"
+location = "location-test"
+keyring = "keyring-test"
+key-name = "key-name-test"
+key-version = 2

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_kebab_case.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_kebab_case.snap
@@ -1,0 +1,65 @@
+---
+source: crates/agglayer-config/tests/auth_config.rs
+expression: config
+---
+prover-entrypoint = "http://127.0.0.1:8080"
+
+[full-node-rpcs]
+
+[l2]
+rpc-timeout = "45s"
+
+[proof-signers]
+
+[log]
+level = "info"
+outputs = []
+format = "pretty"
+
+[rpc]
+port = 9090
+host = "0.0.0.0"
+request-timeout = "3m"
+
+[rate-limiting]
+send-tx = "unlimited"
+
+[rate-limiting.network]
+
+[outbound.rpc.settle]
+max-retries = 3
+retry-interval = "7s"
+confirmations = 1
+settlement-timeout = "20m"
+
+[l1]
+chain-id = 1337
+node-url = "http://zkevm-mock-l1-network:8545/"
+ws-node-url = "ws://zkevm-mock-l1-network:8546/"
+rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+rpc-timeout = "45s"
+
+[auth.gcp-kms]
+project-id = "project-id_test"
+location = "location-test"
+keyring = "keyring-test"
+key-name = "key-name-test"
+key-version = 2
+
+[telemetry]
+prometheus-addr = "0.0.0.0:3000"
+
+[epoch.block-clock]
+epoch-duration = 6
+genesis-block = 0
+
+[shutdown]
+runtime-timeout = "5s"
+
+[certificate-orchestrator]
+input-backpressure-buffer-size = 1000
+
+[certificate-orchestrator.prover.sp1-local]
+
+[storage]
+db-path = "/tmp/agglayer/tests/fixtures/valide_config/storage"


### PR DESCRIPTION
# Description

Fixes #413

This PR fixes an issue with the rename of the GCP KMS keys.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
