### PR TITLE
test: cycle tracker improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6320,6 +6320,7 @@ dependencies = [
  "ethers-signers",
  "hex",
  "hex-literal",
+ "insta",
  "lazy_static",
  "pessimistic-proof",
  "rand",

--- a/crates/agglayer-certificate-orchestrator/src/network_task/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task/tests.rs
@@ -857,8 +857,8 @@ async fn process_next_certificate() {
     let mut forest = Forest::default();
 
     let certificate = forest.apply_events(
-        &[(*USDC, 10.try_into().unwrap())],
-        &[(*USDC, 1.try_into().unwrap())],
+        &[(USDC, 10.try_into().unwrap())],
+        &[(USDC, 1.try_into().unwrap())],
     );
     let certificate_id = certificate.hash();
     storage
@@ -871,7 +871,7 @@ async fn process_next_certificate() {
         .insert_certificate_header(&certificate, CertificateStatus::Pending)
         .expect("Failed to insert certificate header");
 
-    let mut certificate = forest.apply_events(&[], &[(*USDC, 1.try_into().unwrap())]);
+    let mut certificate = forest.apply_events(&[], &[(USDC, 1.try_into().unwrap())]);
     certificate.height = 1;
     let certificate_id2 = certificate.hash();
 

--- a/crates/agglayer-certificate-orchestrator/src/network_task/tests/status.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task/tests/status.rs
@@ -31,8 +31,8 @@ async fn from_pending_to_settle() {
     let mut forest = Forest::default();
 
     let certificate = forest.apply_events(
-        &[(*USDC, 10.try_into().unwrap())],
-        &[(*USDC, 1.try_into().unwrap())],
+        &[(USDC, 10.try_into().unwrap())],
+        &[(USDC, 1.try_into().unwrap())],
     );
     let certificate_id = certificate.hash();
     storage
@@ -137,8 +137,8 @@ async fn from_proven_to_settle() {
     let mut forest = Forest::default();
 
     let certificate = forest.apply_events(
-        &[(*USDC, 10.try_into().unwrap())],
-        &[(*USDC, 1.try_into().unwrap())],
+        &[(USDC, 10.try_into().unwrap())],
+        &[(USDC, 1.try_into().unwrap())],
     );
     let certificate_id = certificate.hash();
     storage
@@ -244,8 +244,8 @@ async fn from_candidate_to_settle() {
     let signer = forest.get_signer();
 
     let certificate = forest.apply_events(
-        &[(*USDC, 10.try_into().unwrap())],
-        &[(*USDC, 1.try_into().unwrap())],
+        &[(USDC, 10.try_into().unwrap())],
+        &[(USDC, 1.try_into().unwrap())],
     );
     let certificate_id = certificate.hash();
     storage
@@ -341,8 +341,8 @@ async fn from_settle_to_settle() {
     let mut forest = Forest::default();
 
     let certificate = forest.apply_events(
-        &[(*USDC, 10.try_into().unwrap())],
-        &[(*USDC, 1.try_into().unwrap())],
+        &[(USDC, 10.try_into().unwrap())],
+        &[(USDC, 1.try_into().unwrap())],
     );
     let certificate_id = certificate.hash();
     storage

--- a/crates/pessimistic-proof-test-suite/Cargo.toml
+++ b/crates/pessimistic-proof-test-suite/Cargo.toml
@@ -34,5 +34,6 @@ uuid = { version = "1.11.0", features = ["v4", "fast-rng"] }
 regex = "1.11"
 
 [dev-dependencies]
+insta.workspace = true
 rstest.workspace = true
 tracing.workspace = true

--- a/crates/pessimistic-proof-test-suite/src/event_data.rs
+++ b/crates/pessimistic-proof-test-suite/src/event_data.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::BufReader};
+use std::{fs::File, io::BufReader, path::Path};
 
 use agglayer_types::primitives::U256;
 use base64::{engine::general_purpose::STANDARD, Engine};
@@ -9,15 +9,15 @@ use serde_json::Number;
 
 /// Load a data file from the test suite data folder. It is expected to be
 /// a json representation of an object of type `T`.
-pub fn load_json_data_file<T: DeserializeOwned>(filename: impl AsRef<str>) -> T {
-    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+pub fn load_json_data_file<T: DeserializeOwned>(filename: impl AsRef<Path>) -> T {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join(filename.as_ref());
     parse_json_file(path)
 }
 
 /// Load a json file from the specified path.
-pub fn parse_json_file<T>(json_file_path: impl AsRef<std::path::Path>) -> T
+pub fn parse_json_file<T>(json_file_path: impl AsRef<Path>) -> T
 where
     T: DeserializeOwned,
 {

--- a/crates/pessimistic-proof-test-suite/src/sample_data.rs
+++ b/crates/pessimistic-proof-test-suite/src/sample_data.rs
@@ -1,7 +1,5 @@
 //! Sample data, either synthetic or taken from real traces.
 
-use std::path::PathBuf;
-
 use agglayer_types::{
     primitives::{address, U256},
     Certificate, NetworkId,
@@ -22,18 +20,16 @@ use crate::{
 type TreeHasher = pessimistic_proof::local_exit_tree::hasher::Keccak256Hasher;
 type LocalExitTree = local_exit_tree::LocalExitTree<TreeHasher>;
 
-lazy_static::lazy_static! {
-    pub static ref NETWORK_A: NetworkId = 0u32.into();
-    pub static ref NETWORK_B: NetworkId = 1u32.into();
-    pub static ref USDC: TokenInfo = TokenInfo {
-        origin_network: **NETWORK_A,
-        origin_token_address: address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
-    };
-    pub static ref ETH: TokenInfo = TokenInfo {
-        origin_network: **NETWORK_A,
-        origin_token_address: address!("0000000000000000000000000000000000000000"),
-    };
-}
+pub const NETWORK_A: NetworkId = NetworkId::new(0);
+pub const NETWORK_B: NetworkId = NetworkId::new(1);
+pub const USDC: TokenInfo = TokenInfo {
+    origin_network: NETWORK_A.to_u32(),
+    origin_token_address: address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+};
+pub const ETH: TokenInfo = TokenInfo {
+    origin_network: NETWORK_A.to_u32(),
+    origin_token_address: address!("0000000000000000000000000000000000000000"),
+};
 
 pub fn empty_state() -> LocalNetworkState {
     LocalNetworkState {
@@ -86,7 +82,7 @@ fn sample_exit_tree_01() -> LocalExitTree {
 
 pub fn sample_state_01() -> Forest {
     let large_amount = U256::MAX.checked_div(U256::from(2u64)).unwrap(); // not max to allow importing bridge exits
-    let balances = [(*ETH, large_amount), (*USDC, large_amount)];
+    let balances = [(ETH, large_amount), (USDC, large_amount)];
     Forest::new_with_local_exit_tree(balances, sample_exit_tree_01())
 }
 
@@ -94,16 +90,22 @@ pub fn sample_state_00() -> Forest {
     Forest::new_with_local_exit_tree([], LocalExitTree::default())
 }
 
-pub fn sample_bridge_exits_01() -> impl Iterator<Item = BridgeExit> + Clone {
+pub fn sample_bridge_exits_01() -> impl ExactSizeIterator<Item = BridgeExit> + Clone {
     load_json_data_file::<Vec<DepositEventData>>("withdrawals.json")
         .into_iter()
-        .map(Into::into)
+        .map(|evt_data| {
+            let mut exit = BridgeExit::from(evt_data);
+            exit.dest_network = NETWORK_A;
+            exit
+        })
 }
 
-pub fn sample_bridge_exits(sample_path: PathBuf) -> impl Iterator<Item = BridgeExit> + Clone {
-    parse_json_file::<Vec<DepositEventData>>(sample_path.as_path())
+pub fn sample_bridge_exits(
+    sample_path: impl AsRef<std::path::Path>,
+) -> impl ExactSizeIterator<Item = BridgeExit> + Clone {
+    parse_json_file::<Vec<DepositEventData>>(sample_path.as_ref())
         .into_iter()
-        .map(Into::into)
+        .map(BridgeExit::from)
 }
 
 pub fn load_certificate(cert_path: &str) -> Certificate {

--- a/crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+++ b/crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
@@ -2,43 +2,28 @@ use std::time::Duration;
 
 use pessimistic_proof::bridge_exit::BridgeExit;
 use pessimistic_proof_test_suite::{forest::Forest, runner::Runner, sample_data as data};
-use tracing::{debug, info};
+
+#[rstest::rstest]
+#[timeout(Duration::from_secs(10))]
+fn sanity_check() {
+    cycles_on_sample_inputs("s00_be000", Forest::new([]), std::iter::empty());
+}
 
 #[rstest::rstest]
 #[timeout(Duration::from_secs(30))]
-#[case::empty(Forest::new([]), std::iter::empty())]
-fn sanity_check(#[case] state: Forest, #[case] bridge_exits: impl Iterator<Item = BridgeExit>) {
-    cycles_on_sample_inputs_inner(state, bridge_exits);
+fn cycles_on_state01(#[values(0, 1, 2, 20, 50, 100, usize::MAX)] n_exits: usize) {
+    let bridge_exits = data::sample_bridge_exits_01().take(n_exits);
+    let name = format!("s01_be{:03}", bridge_exits.len());
+    cycles_on_sample_inputs(&name, data::sample_state_01(), bridge_exits);
 }
 
-#[rstest::rstest]
-#[case::s01_n000(data::sample_state_01(), std::iter::empty())]
-#[case::s01_n001(data::sample_state_01(), data::sample_bridge_exits_01().take(1))]
-#[case::s01_n002(data::sample_state_01(), data::sample_bridge_exits_01().take(2))]
-#[case::s01_n020(data::sample_state_01(), data::sample_bridge_exits_01().take(20))]
-#[case::s01_n100(data::sample_state_01(), data::sample_bridge_exits_01().take(100))]
-#[case::s01_full(data::sample_state_01(), data::sample_bridge_exits_01())]
-#[ignore = "Too expensive to run by default"]
 fn cycles_on_sample_inputs(
-    #[case] state: Forest,
-    #[case] bridge_exits: impl Iterator<Item = BridgeExit>,
-) {
-    cycles_on_sample_inputs_inner(state, bridge_exits);
-}
-
-fn cycles_on_sample_inputs_inner(
+    name: &str,
     mut state: Forest,
-    bridge_exits: impl Iterator<Item = BridgeExit>,
+    bridge_exits: impl IntoIterator<Item = BridgeExit>,
 ) {
-    sp1_sdk::utils::setup_logger();
-
-    let withdrawals = bridge_exits
-        .map(|be| (be.token_info, be.amount))
-        .collect::<Vec<_>>();
-    let n_exits = withdrawals.len();
-
     let old_state = state.local_state();
-    let certificate = state.clone().apply_events(&[], &withdrawals);
+    let certificate = state.clone().apply_bridge_exits([], bridge_exits);
 
     let multi_batch_header = state
         .state_b
@@ -56,10 +41,5 @@ fn cycles_on_sample_inputs_inner(
     // Double check the roots match what is calculated by the proof-external state.
     state.assert_output_matches(&new_roots);
 
-    debug!("full execution stats:\n{stats}");
-    debug!("result: {new_roots:?}");
-
-    let cycles = stats.total_instruction_count();
-    let syscalls = stats.total_syscall_count();
-    info!("execution summary: n={n_exits}, cycles={cycles}, syscalls={syscalls}");
+    insta::assert_snapshot!(name, stats);
 }

--- a/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
+++ b/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
@@ -36,9 +36,9 @@ fn e2e_local_pp_simple_helper(
 #[test]
 fn e2e_local_pp_simple() {
     e2e_local_pp_simple_helper(
-        vec![(*USDC, u(100)), (*ETH, u(200))],
-        vec![(*USDC, u(50)), (*ETH, u(100)), (*USDC, u(10))],
-        vec![(*USDC, u(20)), (*ETH, u(50)), (*USDC, u(130))],
+        vec![(USDC, u(100)), (ETH, u(200))],
+        vec![(USDC, u(50)), (ETH, u(100)), (USDC, u(10))],
+        vec![(USDC, u(20)), (ETH, u(50)), (USDC, u(130))],
     )
 }
 
@@ -46,8 +46,8 @@ fn e2e_local_pp_simple() {
 fn e2e_local_pp_simple_zero_initial_balances() {
     e2e_local_pp_simple_helper(
         [],
-        vec![(*USDC, u(50)), (*ETH, u(100)), (*USDC, u(10))],
-        vec![(*USDC, u(20)), (*ETH, u(50)), (*USDC, u(30))],
+        vec![(USDC, u(50)), (ETH, u(100)), (USDC, u(10))],
+        vec![(USDC, u(20)), (ETH, u(50)), (USDC, u(30))],
     )
 }
 
@@ -55,7 +55,7 @@ fn e2e_local_pp_simple_zero_initial_balances() {
 fn e2e_local_pp_random() {
     let target = u(u64::MAX);
     let upper = u64::MAX / 10;
-    let mut forest = Forest::new(vec![(*USDC, target), (*ETH, target)]);
+    let mut forest = Forest::new(vec![(USDC, target), (ETH, target)]);
     // Generate random bridge events such that the sum of the USDC and ETH amounts
     // is less than `target`
     let get_events = || {
@@ -64,12 +64,8 @@ fn e2e_local_pp_random() {
         let mut events = Vec::new();
         loop {
             let amount = u(random::<u64>() % upper);
-            let token = if random::<u64>() & 1 == 1 {
-                *USDC
-            } else {
-                *ETH
-            };
-            if token == *USDC {
+            let token = if random::<u64>() & 1 == 1 { USDC } else { ETH };
+            if token == USDC {
                 usdc_acc += amount;
                 if usdc_acc > target {
                     break;
@@ -104,9 +100,9 @@ fn test_sp1_simple() {
     // Setup logging.
     utils::setup_logger();
 
-    let mut forest = Forest::new(vec![(*USDC, u(100)), (*ETH, u(200))]);
-    let imported_bridge_events = vec![(*USDC, u(50)), (*ETH, u(100)), (*USDC, u(10))];
-    let bridge_events = vec![(*USDC, u(20)), (*ETH, u(50)), (*USDC, u(130))];
+    let mut forest = Forest::new(vec![(USDC, u(100)), (ETH, u(200))]);
+    let imported_bridge_events = vec![(USDC, u(50)), (ETH, u(100)), (USDC, u(10))];
+    let bridge_events = vec![(USDC, u(20)), (ETH, u(50)), (USDC, u(130))];
 
     let initial_state = forest.state_b.clone();
     let certificate = forest.apply_events(&imported_bridge_events, &bridge_events);

--- a/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s00_be000.snap
+++ b/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s00_be000.snap
@@ -1,0 +1,45 @@
+---
+source: crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+expression: stats
+snapshot_kind: text
+---
+opcode counts (636955 total instructions):
+    159086 add
+    103413 sw
+     93188 lw
+     49960 lbu
+     35234 sb
+     28659 xor
+     23127 bne
+     18952 beq
+     16840 bltu
+     14544 sltu
+     14393 jalr
+     13040 and
+     11341 sub
+     10303 or
+      9869 srl
+      9796 sll
+      7818 auipc
+      4008 jal
+      3771 sra
+      2843 lb
+      2474 mul
+      2097 mulhu
+      1034 ecall
+       841 bgeu
+       308 sh
+         7 lh
+         4 lhu
+         4 blt
+         1 divu
+syscall counts (1034 total syscall instructions):
+    512 secp256k1_double
+    263 keccak_permute
+    230 secp256k1_add
+      8 commit
+      8 commit_deferred_proofs
+      5 hint_len
+      5 hint_read
+      2 write
+      1 halt

--- a/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be000.snap
+++ b/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be000.snap
@@ -1,0 +1,45 @@
+---
+source: crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+expression: stats
+snapshot_kind: text
+---
+opcode counts (639031 total instructions):
+    159733 add
+    103761 sw
+     93610 lw
+     49952 lbu
+     35234 sb
+     28659 xor
+     23059 bne
+     19126 beq
+     16840 bltu
+     14654 jalr
+     14544 sltu
+     13040 and
+     11401 sub
+     10303 or
+      9869 srl
+      9796 sll
+      7992 auipc
+      4045 jal
+      3771 sra
+      2843 lb
+      2474 mul
+      2097 mulhu
+      1063 ecall
+       841 bgeu
+       308 sh
+         7 lh
+         4 lhu
+         4 blt
+         1 divu
+syscall counts (1063 total syscall instructions):
+    512 secp256k1_double
+    263 keccak_permute
+    259 secp256k1_add
+      8 commit
+      8 commit_deferred_proofs
+      5 hint_len
+      5 hint_read
+      2 write
+      1 halt

--- a/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be001.snap
+++ b/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be001.snap
@@ -1,0 +1,46 @@
+---
+source: crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+expression: stats
+snapshot_kind: text
+---
+opcode counts (1374605 total instructions):
+    342104 add
+    239696 sw
+    206890 lw
+    123694 lbu
+     90410 sb
+     54293 bne
+     54186 xor
+     45593 beq
+     39868 bltu
+     31249 jalr
+     23753 and
+     17326 sltu
+     16269 auipc
+     15951 or
+     14507 sub
+     14242 srl
+     13676 sll
+     10127 jal
+      7835 lb
+      3771 sra
+      2871 mul
+      2097 mulhu
+      2018 bgeu
+      1434 ecall
+       712 sh
+        13 lh
+        13 lhu
+         5 blt
+         1 divu
+         1 bge
+syscall counts (1434 total syscall instructions):
+    649 keccak_permute
+    512 secp256k1_double
+    244 secp256k1_add
+      8 commit
+      8 commit_deferred_proofs
+      5 hint_len
+      5 hint_read
+      2 write
+      1 halt

--- a/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be002.snap
+++ b/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be002.snap
@@ -1,0 +1,46 @@
+---
+source: crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+expression: stats
+snapshot_kind: text
+---
+opcode counts (1380219 total instructions):
+    343455 add
+    240524 sw
+    207671 lw
+    124317 lbu
+     90789 sb
+     54572 bne
+     54302 xor
+     45800 beq
+     39966 bltu
+     31422 jalr
+     23861 and
+     17387 sltu
+     16364 auipc
+     16080 or
+     14566 sub
+     14262 srl
+     13786 sll
+     10189 jal
+      7922 lb
+      3771 sra
+      2875 mul
+      2097 mulhu
+      2032 bgeu
+      1440 ecall
+       725 sh
+        19 lh
+        17 lhu
+         5 blt
+         2 bge
+         1 divu
+syscall counts (1440 total syscall instructions):
+    650 keccak_permute
+    512 secp256k1_double
+    249 secp256k1_add
+      8 commit
+      8 commit_deferred_proofs
+      5 hint_len
+      5 hint_read
+      2 write
+      1 halt

--- a/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be020.snap
+++ b/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be020.snap
@@ -1,0 +1,46 @@
+---
+source: crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+expression: stats
+snapshot_kind: text
+---
+opcode counts (1500282 total instructions):
+    372391 add
+    258975 sw
+    223890 lw
+    138101 lbu
+     99602 sb
+     61134 bne
+     57776 xor
+     49362 beq
+     42796 bltu
+     34212 jalr
+     26265 and
+     18583 sltu
+     18486 or
+     17795 auipc
+     15766 sll
+     15640 sub
+     14622 srl
+     11086 jal
+      9904 lb
+      3771 sra
+      2968 mul
+      2347 bgeu
+      2097 mulhu
+      1491 ecall
+       980 sh
+       127 lh
+        89 lhu
+        20 bge
+         5 blt
+         1 divu
+syscall counts (1491 total syscall instructions):
+    689 keccak_permute
+    512 secp256k1_double
+    261 secp256k1_add
+      8 commit
+      8 commit_deferred_proofs
+      5 hint_len
+      5 hint_read
+      2 write
+      1 halt

--- a/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be050.snap
+++ b/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be050.snap
@@ -1,0 +1,46 @@
+---
+source: crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+expression: stats
+snapshot_kind: text
+---
+opcode counts (1688544 total instructions):
+    417191 add
+    287660 sw
+    249271 lw
+    159909 lbu
+    113733 sb
+     71412 bne
+     63038 xor
+     55016 beq
+     47094 bltu
+     38466 jalr
+     30077 and
+     22464 or
+     20507 sltu
+     19940 auipc
+     19066 sll
+     17310 sub
+     15222 srl
+     13250 lb
+     12578 jal
+      3771 sra
+      3115 mul
+      2848 bgeu
+      2097 mulhu
+      1540 ecall
+      1397 sh
+       307 lh
+       209 lhu
+        50 bge
+         5 blt
+         1 divu
+syscall counts (1540 total syscall instructions):
+    746 keccak_permute
+    512 secp256k1_double
+    253 secp256k1_add
+      8 commit
+      8 commit_deferred_proofs
+      5 hint_len
+      5 hint_read
+      2 write
+      1 halt

--- a/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be100.snap
+++ b/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be100.snap
@@ -1,0 +1,46 @@
+---
+source: crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+expression: stats
+snapshot_kind: text
+---
+opcode counts (2742918 total instructions):
+    675898 add
+    472463 sw
+    405614 lw
+    270353 lbu
+    192500 sb
+    120032 bne
+     97685 xor
+     90957 beq
+     77554 bltu
+     62345 jalr
+     47210 and
+     34645 or
+     31922 auipc
+     28337 sll
+     26519 sltu
+     23625 lb
+     23256 sub
+     21283 jal
+     20575 srl
+      4869 bgeu
+      3771 sra
+      3762 mul
+      2490 sh
+      2097 mulhu
+      2020 ecall
+       607 lh
+       418 lhu
+       101 bge
+         9 blt
+         1 divu
+syscall counts (2020 total syscall instructions):
+    1233 keccak_permute
+     512 secp256k1_double
+     246 secp256k1_add
+       8 commit
+       8 commit_deferred_proofs
+       5 hint_len
+       5 hint_read
+       2 write
+       1 halt

--- a/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be223.snap
+++ b/crates/pessimistic-proof-test-suite/tests/snapshots/cycle_tracker__s01_be223.snap
@@ -1,0 +1,46 @@
+---
+source: crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+expression: stats
+snapshot_kind: text
+---
+opcode counts (3534252 total instructions):
+    865050 add
+    593542 sw
+    512367 lw
+    361724 lbu
+    251484 sb
+    163258 bne
+    120204 xor
+    114531 beq
+     95921 bltu
+     80333 jalr
+     63169 and
+     51013 or
+     41867 sll
+     41038 auipc
+     37318 lb
+     34513 sltu
+     30284 sub
+     27417 jal
+     23035 srl
+      6966 bgeu
+      4379 mul
+      4214 sh
+      3771 sra
+      2267 ecall
+      2097 mulhu
+      1345 lh
+       910 lhu
+       225 bge
+         9 blt
+         1 divu
+syscall counts (2267 total syscall instructions):
+    1481 keccak_permute
+     512 secp256k1_double
+     245 secp256k1_add
+       8 commit
+       8 commit_deferred_proofs
+       5 hint_len
+       5 hint_read
+       2 write
+       1 halt

--- a/crates/pessimistic-proof/src/bridge_exit.rs
+++ b/crates/pessimistic-proof/src/bridge_exit.rs
@@ -123,8 +123,13 @@ impl Display for NetworkId {
 
 impl NetworkId {
     pub const BITS: usize = u32::BITS as usize;
+
     pub const fn new(value: u32) -> Self {
         Self(value)
+    }
+
+    pub const fn to_u32(self) -> u32 {
+        self.0
     }
 }
 


### PR DESCRIPTION
A bunch of improvements to the cycle tracker that came up during the removal of the sp1 patch hack.

* Make the cycle tracker inputs and outputs deterministic
* Record cycle execution stats in a snapshot
  * This allows us to observe perf changes. Can be reverted if deemed too annoying.
* Enable cycle tracker by default (it's not actually that slow)
* A number of minor refactors

Related:
* changes prompted by #438
* related #143

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
