### PR TITLE
feat: add a debug-mode to the node

### DIFF
--- a/agglayer.toml
+++ b/agglayer.toml
@@ -1,34 +1,60 @@
-[FullNodeRPCs]
-1 = "http://zkevm-node:8123"
+prover-entrypoint = "http://127.0.0.1:8080"
 
-[RPC]
-Host = "0.0.0.0"
-Port = 9090
+[full-node-rpcs]
 
-[Log]
-Level = "info"
-Outputs = ["stderr"]
+[l2]
+rpc-timeout = "45s"
 
-[L1]
-ChainID = 1337
-NodeURL = "https://rpc-cdk-validium-cardona-03-zkevm.polygondev.tools"
-RollupManagerContract = "0x32d33D5137a7cFFb54c5Bf8371172bcEc5f310ff"
+[proof-signers]
 
-[auth.local]
-PrivateKeys = [{ Path = "/pk/agglayer.keystore", Password = "testonly" }]
+[log]
+level = "info"
+outputs = []
+format = "pretty"
 
-[auth.gcpkms]
-ProjectId = ""
-Location = ""
-Keyring = ""
-KeyName = ""
+[rpc]
+port = 9090
+host = "0.0.0.0"
+request-timeout = "3m"
 
-[Telemetry]
+[rate-limiting]
+send-tx = "unlimited"
+
+[rate-limiting.network]
 
 [outbound.rpc.settle]
-max_retries = 10
-retry_interval = 1
-confirmations = 3
+max-retries = 3
+retry-interval = "7s"
+confirmations = 1
+settlement-timeout = "20m"
+
+[l1]
+chain-id = 1337
+node-url = "http://zkevm-mock-l1-network:8545/"
+ws-node-url = "ws://zkevm-mock-l1-network:8546/"
+max-reconnection-elapsed-time = "10s"
+rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+polygon-zkevm-global-exit-root-v2-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+rpc-timeout = "45s"
+
+[auth.local]
+private-keys = []
+
+[telemetry]
+prometheus-addr = "0.0.0.0:3000"
+
+[epoch.block-clock]
+epoch-duration = 6
+genesis-block = 0
 
 [shutdown]
-runtime_timeout = 5
+runtime-timeout = "5s"
+
+[certificate-orchestrator]
+input-backpressure-buffer-size = 1000
+
+[certificate-orchestrator.prover.sp1-local]
+
+[storage]
+db-path = "/Users/spaitrault/work/polygon/agglayer/storage"
+

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -104,6 +104,10 @@ pub struct Config {
     #[serde(default = "default_prover_entrypoint")]
     #[serde(skip_serializing_if = "String::is_empty")]
     pub prover_entrypoint: String,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "<&bool as std::ops::Not>::not")]
+    pub debug_mode: bool,
 }
 
 impl Config {
@@ -153,6 +157,7 @@ impl Config {
             shutdown: Default::default(),
             certificate_orchestrator: Default::default(),
             prover_entrypoint: default_prover_entrypoint(),
+            debug_mode: false,
         }
     }
 

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -106,7 +106,7 @@ pub struct Config {
     pub prover_entrypoint: String,
 
     #[serde(default)]
-    #[serde(skip_serializing_if = "<&bool as std::ops::Not>::not")]
+    #[serde(skip_serializing_if = "is_false")]
     pub debug_mode: bool,
 }
 
@@ -224,4 +224,8 @@ impl<'de> DeserializeSeed<'de> for ConfigDeserializer<'_> {
             .validate()
             .map_err(|e| serde::de::Error::custom(e.to_string()))
     }
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }

--- a/crates/agglayer-config/src/storage.rs
+++ b/crates/agglayer-config/src/storage.rs
@@ -10,6 +10,7 @@ const METADATA_DB_NAME: &str = "metadata";
 const PENDING_DB_NAME: &str = "pending";
 const STATE_DB_NAME: &str = "state";
 const EPOCHS_DB_PATH: &str = "epochs";
+const DEBUG_DB_PATH: &str = "debug";
 
 /// Configuration for the storage.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -24,6 +25,8 @@ pub struct StorageConfig {
     pub state_db_path: PathBuf,
     /// Custom epochs storage path or inferred from the db path.
     pub epochs_db_path: PathBuf,
+    /// Custom debug storage path or inferred from the db path.
+    pub debug_db_path: PathBuf,
 }
 
 impl Default for StorageConfig {
@@ -33,6 +36,7 @@ impl Default for StorageConfig {
             pending_db_path: Path::new("./").join(STORAGE_DIR).join(PENDING_DB_NAME),
             state_db_path: Path::new("./").join(STORAGE_DIR).join(STATE_DB_NAME),
             epochs_db_path: Path::new("./").join(STORAGE_DIR).join(EPOCHS_DB_PATH),
+            debug_db_path: Path::new("./").join(STORAGE_DIR).join(DEBUG_DB_PATH),
         }
     }
 }
@@ -43,6 +47,7 @@ impl StorageConfig {
         self.pending_db_path = normalize_path(&base_path.join(&self.pending_db_path));
         self.state_db_path = normalize_path(&base_path.join(&self.state_db_path));
         self.epochs_db_path = normalize_path(&base_path.join(&self.epochs_db_path));
+        self.debug_db_path = normalize_path(&base_path.join(&self.debug_db_path));
 
         self
     }
@@ -61,6 +66,7 @@ impl StorageConfig {
             pending_db_path: db_path.join(PENDING_DB_NAME),
             state_db_path: db_path.join(STATE_DB_NAME),
             epochs_db_path: db_path.join(EPOCHS_DB_PATH),
+            debug_db_path: db_path.join(DEBUG_DB_PATH),
         }
     }
 }
@@ -79,6 +85,8 @@ struct StorageConfigHelper {
     pub state_db_path: Option<PathBuf>,
     /// Custom epochs storage path or inferred from the db path.
     pub epochs_db_path: Option<PathBuf>,
+    /// Custom debug storage path or inferred from the db path.
+    pub debug_db_path: Option<PathBuf>,
 }
 
 impl From<StorageConfigHelper> for StorageConfig {
@@ -96,6 +104,9 @@ impl From<StorageConfigHelper> for StorageConfig {
             epochs_db_path: value
                 .epochs_db_path
                 .unwrap_or_else(|| value.db_path.join(EPOCHS_DB_PATH)),
+            debug_db_path: value
+                .debug_db_path
+                .unwrap_or_else(|| value.db_path.join(DEBUG_DB_PATH)),
         }
     }
 }
@@ -114,6 +125,7 @@ impl From<StorageConfig> for StorageConfigHelper {
             pending_db_path: None,
             state_db_path: None,
             epochs_db_path: None,
+            debug_db_path: None,
         }
     }
 }
@@ -181,5 +193,6 @@ mod tests {
         assert_eq!(config.pending_db_path, PathBuf::from("/tmp/base/pending"));
         assert_eq!(config.state_db_path, PathBuf::from("/tmp/base/state"));
         assert_eq!(config.epochs_db_path, PathBuf::from("/tmp/base/epochs"));
+        assert_eq!(config.debug_db_path, PathBuf::from("/tmp/base/debug"));
     }
 }

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -11,7 +11,10 @@ use agglayer_contracts::{
 use agglayer_signer::ConfiguredSigner;
 use agglayer_storage::{
     storage::DB,
-    stores::{epochs::EpochsStore, pending::PendingStore, state::StateStore, PerEpochReader as _},
+    stores::{
+        debug::DebugStore, epochs::EpochsStore, pending::PendingStore, state::StateStore,
+        PerEpochReader as _,
+    },
 };
 use alloy::providers::WsConnect;
 use anyhow::Result;
@@ -86,6 +89,12 @@ impl Node {
 
         let state_store = Arc::new(StateStore::new(state_db.clone()));
         let pending_store = Arc::new(PendingStore::new(pending_db.clone()));
+        let debug_store = if config.debug_mode {
+            Arc::new(DebugStore::new_with_path(&config.storage.debug_db_path)?)
+        } else {
+            Arc::new(DebugStore::Disabled)
+        };
+
         info!("Storage initialized.");
 
         // Spawn the TimeClock.
@@ -203,6 +212,7 @@ impl Node {
             data_sender,
             pending_store.clone(),
             state_store.clone(),
+            debug_store,
             config.clone(),
         )
         .start()

--- a/crates/agglayer-node/src/rpc/mod.rs
+++ b/crates/agglayer-node/src/rpc/mod.rs
@@ -481,7 +481,6 @@ where
         &self,
         certificate_id: CertificateId,
     ) -> RpcResult<(Certificate, Option<CertificateHeader>)> {
-        trace!("Received request to get certificate for id {certificate_id}");
         match self.debug_store.get_certificate(&certificate_id) {
             Ok(Some(cert)) => match self
                 .state

--- a/crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
+++ b/crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
@@ -163,3 +163,233 @@ async fn certificate_header(#[future] raw_rpc: RawRpcContext) {
         .unwrap()
     );
 }
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn debug_fetch_unkown_certificate() {
+    let mut config = TestContext::get_default_config();
+    config.debug_mode = true;
+
+    let context = TestContext::new_with_config(config).await;
+
+    let payload: Result<(Certificate, Option<CertificateHeader>), ClientError> = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![Hash([0; 32])])
+        .await;
+
+    let error = payload.unwrap_err();
+
+    let expected_message = format!("Resource not found: Certificate({:#})", Hash([0; 32]));
+    assert!(matches!(error, ClientError::Call(obj) if obj.message() == expected_message));
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn debug_fetch_kown_certificate() {
+    let mut config = TestContext::get_default_config();
+    config.debug_mode = true;
+
+    let mut context = TestContext::new_with_config(config).await;
+
+    let certificate = Certificate::new_for_test(1.into(), 0);
+    let id = certificate.hash();
+
+    let res: CertificateId = context
+        .client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    assert_eq!(id, res);
+    assert!(context.certificate_receiver.try_recv().is_ok());
+
+    let (recv_cert, header): (Certificate, Option<CertificateHeader>) = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![id])
+        .await
+        .unwrap();
+
+    assert!(header.is_some());
+    let header = header.unwrap();
+    assert_eq!(header.certificate_id, id);
+    assert_eq!(recv_cert.hash(), id);
+    assert_eq!(header.status, CertificateStatus::Pending);
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn debug_get_certificate_after_sending_the_certificate() {
+    let mut config = TestContext::get_default_config();
+    config.debug_mode = true;
+
+    let mut context = TestContext::new_with_config(config).await;
+
+    let certificate = Certificate::new_for_test(1.into(), 0);
+    let id = certificate.hash();
+
+    let res: CertificateId = context
+        .client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    assert_eq!(id, res);
+    assert!(context.certificate_receiver.try_recv().is_ok());
+
+    let (recv_cert, header): (Certificate, Option<CertificateHeader>) = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![id])
+        .await
+        .unwrap();
+
+    assert!(header.is_some());
+    let header = header.unwrap();
+    assert_eq!(header.certificate_id, id);
+    assert_eq!(recv_cert.hash(), id);
+    assert_eq!(header.status, CertificateStatus::Pending);
+
+    let payload: Result<(Certificate, Option<CertificateHeader>), ClientError> = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![Hash([0; 32])])
+        .await;
+
+    let error = payload.unwrap_err();
+
+    let expected_message = format!("Resource not found: Certificate({:#})", Hash([0; 32]));
+    assert!(matches!(error, ClientError::Call(obj) if obj.message() == expected_message));
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn debug_get_certificate_after_overwrite() {
+    let mut config = TestContext::get_default_config();
+    config.debug_mode = true;
+
+    let mut context = TestContext::new_with_config(config).await;
+
+    let certificate = Certificate::new_for_test(1.into(), 0);
+    let id = certificate.hash();
+
+    let res: CertificateId = context
+        .client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    assert_eq!(id, res);
+    assert!(context.certificate_receiver.try_recv().is_ok());
+
+    let (recv_cert, header): (Certificate, Option<CertificateHeader>) = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![id])
+        .await
+        .unwrap();
+
+    assert!(header.is_some());
+    let header = header.unwrap();
+    assert_eq!(header.certificate_id, id);
+    assert_eq!(recv_cert.hash(), id);
+    assert_eq!(header.status, CertificateStatus::Pending);
+
+    let mut certificate = Certificate::new_for_test(1.into(), 0);
+    certificate.prev_local_exit_root = [2; 32];
+    let id2 = certificate.hash();
+
+    let res: CertificateId = context
+        .client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    assert_eq!(id2, res);
+    assert!(context.certificate_receiver.try_recv().is_ok());
+
+    // Retrieve 1
+    let (recv_cert, header): (Certificate, Option<CertificateHeader>) = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![id])
+        .await
+        .unwrap();
+
+    assert!(header.is_some());
+    let header = header.unwrap();
+    assert_eq!(header.certificate_id, id);
+    assert_eq!(recv_cert.hash(), id);
+    assert_eq!(header.status, CertificateStatus::Pending);
+
+    // Retrieve 2
+    let (recv_cert, header): (Certificate, Option<CertificateHeader>) = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![id2])
+        .await
+        .unwrap();
+
+    assert!(header.is_some());
+    let header = header.unwrap();
+    assert_eq!(header.certificate_id, id2);
+    assert_eq!(recv_cert.hash(), id2);
+    assert_eq!(header.status, CertificateStatus::Pending);
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn debug_get_certificate_after_overwrite_with_debug_false() {
+    let mut config = TestContext::get_default_config();
+    config.debug_mode = false;
+
+    let mut context = TestContext::new_with_config(config).await;
+
+    let certificate = Certificate::new_for_test(1.into(), 0);
+    let id = certificate.hash();
+
+    let res: CertificateId = context
+        .client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    assert_eq!(id, res);
+    assert!(context.certificate_receiver.try_recv().is_ok());
+
+    let payload: Result<(Certificate, Option<CertificateHeader>), ClientError> = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![id])
+        .await;
+
+    let error = payload.unwrap_err();
+
+    let expected_message = format!("Resource not found: Certificate({:#})", id);
+    assert!(matches!(error, ClientError::Call(obj) if obj.message() == expected_message));
+
+    let mut certificate = Certificate::new_for_test(1.into(), 0);
+    certificate.prev_local_exit_root = [2; 32];
+    let id2 = certificate.hash();
+
+    let res: CertificateId = context
+        .client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    assert_eq!(id2, res);
+    assert!(context.certificate_receiver.try_recv().is_ok());
+
+    let payload: Result<(Certificate, Option<CertificateHeader>), ClientError> = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![id])
+        .await;
+
+    let error = payload.unwrap_err();
+
+    let expected_message = format!("Resource not found: Certificate({:#})", id);
+    assert!(matches!(error, ClientError::Call(obj) if obj.message() == expected_message));
+
+    let payload: Result<(Certificate, Option<CertificateHeader>), ClientError> = context
+        .client
+        .request("interop_debugGetCertificate", rpc_params![id2])
+        .await;
+
+    let error = payload.unwrap_err();
+
+    let expected_message = format!("Resource not found: Certificate({:#})", id2);
+    assert!(matches!(error, ClientError::Call(obj) if obj.message() == expected_message));
+}

--- a/crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
+++ b/crates/agglayer-node/src/rpc/tests/get_certificate_header.rs
@@ -15,7 +15,7 @@ use crate::rpc::{tests::RawRpcContext, AgglayerServer};
 #[rstest]
 #[awt]
 #[test_log::test(tokio::test)]
-async fn fetch_unkown_certificate_header(#[future] context: TestContext) {
+async fn fetch_unknown_certificate_header(#[future] context: TestContext) {
     let payload: Result<CertificateHeader, ClientError> = context
         .client
         .request("interop_getCertificateHeader", rpc_params![Hash([0; 32])])
@@ -30,7 +30,7 @@ async fn fetch_unkown_certificate_header(#[future] context: TestContext) {
 #[rstest]
 #[awt]
 #[test_log::test(tokio::test)]
-async fn fetch_kown_certificate_header(#[future] mut context: TestContext) {
+async fn fetch_known_certificate_header(#[future] mut context: TestContext) {
     let certificate = Certificate::new_for_test(1.into(), 0);
     let id = certificate.hash();
 
@@ -165,7 +165,7 @@ async fn certificate_header(#[future] raw_rpc: RawRpcContext) {
 }
 #[rstest]
 #[test_log::test(tokio::test)]
-async fn debug_fetch_unkown_certificate() {
+async fn debug_fetch_unknown_certificate() {
     let mut config = TestContext::get_default_config();
     config.debug_mode = true;
 
@@ -184,7 +184,7 @@ async fn debug_fetch_unkown_certificate() {
 
 #[rstest]
 #[test_log::test(tokio::test)]
-async fn debug_fetch_kown_certificate() {
+async fn debug_fetch_known_certificate() {
     let mut config = TestContext::get_default_config();
     config.debug_mode = true;
 

--- a/crates/agglayer-node/src/rpc/tests/send_certificate.rs
+++ b/crates/agglayer-node/src/rpc/tests/send_certificate.rs
@@ -36,6 +36,7 @@ async fn send_certificate_method_can_be_called() {
         certificate_sender,
         Arc::new(DummyStore {}),
         Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
         config.clone(),
     )
     .start()
@@ -75,6 +76,7 @@ async fn send_certificate_method_can_be_called_and_fail() {
     let _server_handle = AgglayerImpl::new(
         kernel,
         certificate_sender,
+        Arc::new(DummyStore {}),
         Arc::new(DummyStore {}),
         Arc::new(DummyStore {}),
         config.clone(),

--- a/crates/agglayer-storage/src/columns/debug_certificates/mod.rs
+++ b/crates/agglayer-storage/src/columns/debug_certificates/mod.rs
@@ -1,0 +1,19 @@
+use agglayer_types::{Certificate, CertificateId};
+
+use super::{ColumnSchema, DEBUG_CERTIFICATES_CF};
+
+/// Column family containing the certificates received.
+///
+/// ## Column definition
+///
+/// | key             | value           |
+/// | --              | --              |
+/// | `CertificateId` | `Certificate`   |
+pub(crate) struct DebugCertificatesColumn;
+
+impl ColumnSchema for DebugCertificatesColumn {
+    type Key = CertificateId;
+    type Value = Certificate;
+
+    const COLUMN_FAMILY_NAME: &'static str = DEBUG_CERTIFICATES_CF;
+}

--- a/crates/agglayer-storage/src/columns/mod.rs
+++ b/crates/agglayer-storage/src/columns/mod.rs
@@ -36,6 +36,9 @@ pub const PER_EPOCH_TRANSACTION_HASH_PER_CERTIFICATE_INDEX: &str =
 pub const PENDING_QUEUE_CF: &str = "pending_queue_cf";
 pub const PROOF_PER_CERTIFICATE_CF: &str = "proof_per_certificate_cf";
 
+// debug CFs
+pub const DEBUG_CERTIFICATES_CF: &str = "debug_certificates";
+
 pub trait Codec: Sized + Serialize + DeserializeOwned {
     fn encode(&self) -> Result<Vec<u8>, Error> {
         Ok(default_bincode_options().serialize(self)?)
@@ -68,6 +71,9 @@ pub(crate) mod certificate_header;
 pub mod latest_proven_certificate_per_network;
 pub mod latest_settled_certificate_per_network;
 pub(crate) mod metadata;
+
+// Debug
+pub(crate) mod debug_certificates;
 
 // PerEpoch
 pub mod epochs {

--- a/crates/agglayer-storage/src/storage/cf_definitions.rs
+++ b/crates/agglayer-storage/src/storage/cf_definitions.rs
@@ -1,5 +1,6 @@
 use rocksdb::ColumnFamilyDescriptor;
 
+pub mod debug;
 pub mod epochs;
 pub mod pending;
 pub mod state;

--- a/crates/agglayer-storage/src/storage/cf_definitions/debug.rs
+++ b/crates/agglayer-storage/src/storage/cf_definitions/debug.rs
@@ -1,0 +1,8 @@
+use rocksdb::ColumnFamilyDescriptor;
+
+pub const CFS: [&str; 1] = [crate::columns::DEBUG_CERTIFICATES_CF];
+
+/// Definitions for the column families in the debug storage.
+pub fn debug_db_cf_definitions() -> Vec<ColumnFamilyDescriptor> {
+    super::default_db_cf_definitions(&CFS)
+}

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -16,6 +16,7 @@ use crate::{
 pub(crate) mod cf_definitions;
 pub(crate) mod iterators;
 
+pub use cf_definitions::debug::debug_db_cf_definitions;
 pub use cf_definitions::epochs::epochs_db_cf_definitions;
 pub use cf_definitions::pending::pending_db_cf_definitions;
 pub use cf_definitions::state::state_db_cf_definitions;

--- a/crates/agglayer-storage/src/stores/debug.rs
+++ b/crates/agglayer-storage/src/stores/debug.rs
@@ -1,0 +1,55 @@
+use std::{path::Path, sync::Arc};
+
+use agglayer_types::{Certificate, CertificateId};
+
+use super::interfaces::{reader::DebugReader, writer::DebugWriter};
+use crate::{columns::debug_certificates::DebugCertificatesColumn, error::Error, storage::DB};
+
+pub enum DebugStore {
+    Enabled(EnabledDebugStore),
+    Disabled,
+}
+
+/// A logical store for debug.
+#[derive(Debug, Clone)]
+pub struct EnabledDebugStore {
+    db: Arc<DB>,
+}
+
+impl DebugStore {
+    pub fn new(db: Arc<DB>) -> Self {
+        Self::Enabled(EnabledDebugStore { db })
+    }
+
+    pub fn new_with_path(path: &Path) -> Result<Self, Error> {
+        let db = Arc::new(DB::open_cf(
+            path,
+            crate::storage::debug_db_cf_definitions(),
+        )?);
+
+        Ok(Self::new(db))
+    }
+}
+
+impl DebugReader for DebugStore {
+    fn get_certificate(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<Certificate>, Error> {
+        match self {
+            DebugStore::Enabled(store) => store.db.get::<DebugCertificatesColumn>(certificate_id),
+            DebugStore::Disabled => Ok(None),
+        }
+    }
+}
+
+impl DebugWriter for DebugStore {
+    fn add_certificate(&self, certificate: &Certificate) -> Result<(), Error> {
+        match self {
+            DebugStore::Enabled(store) => store
+                .db
+                .put::<DebugCertificatesColumn>(&certificate.hash(), certificate),
+            DebugStore::Disabled => Ok(()),
+        }
+    }
+}

--- a/crates/agglayer-storage/src/stores/interfaces/reader.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/reader.rs
@@ -13,6 +13,11 @@ use crate::{
     error::Error,
 };
 
+pub trait DebugReader: Send + Sync {
+    fn get_certificate(&self, certificate_id: &CertificateId)
+        -> Result<Option<Certificate>, Error>;
+}
+
 pub trait EpochStoreReader: Send + Sync {}
 
 pub trait PendingCertificateReader: Send + Sync {

--- a/crates/agglayer-storage/src/stores/interfaces/writer.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/writer.rs
@@ -7,6 +7,10 @@ use agglayer_types::{
 
 use crate::{error::Error, stores::PerEpochReader};
 
+pub trait DebugWriter: Send + Sync {
+    fn add_certificate(&self, certificate: &Certificate) -> Result<(), Error>;
+}
+
 pub trait PerEpochWriter: Send + Sync {
     fn add_certificate(
         &self,

--- a/crates/agglayer-storage/src/stores/mod.rs
+++ b/crates/agglayer-storage/src/stores/mod.rs
@@ -2,13 +2,16 @@ mod interfaces;
 
 pub use interfaces::{
     reader::{
-        EpochStoreReader, MetadataReader, PendingCertificateReader, PerEpochReader, StateReader,
+        DebugReader, EpochStoreReader, MetadataReader, PendingCertificateReader, PerEpochReader,
+        StateReader,
     },
     writer::{
-        EpochStoreWriter, MetadataWriter, PendingCertificateWriter, PerEpochWriter, StateWriter,
+        DebugWriter, EpochStoreWriter, MetadataWriter, PendingCertificateWriter, PerEpochWriter,
+        StateWriter,
     },
 };
 
+pub mod debug;
 pub mod epochs;
 pub mod pending;
 pub mod per_epoch;


### PR DESCRIPTION
# Description

This PR is adding a new field in the config to activate a `debug-mode`.
The Debug mode will save all certificates received in another DB.
A new API is also exposed to retrieve them.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
