### PR TITLE
feat: adding deserialization of max request field for rpc

### DIFF
--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -56,6 +56,8 @@ impl<PendingStore, L1Rpc> CertifierClient<PendingStore, L1Rpc> {
             pending_store,
             prover: ProofGenerationServiceClient::connect(prover)
                 .await?
+                .max_decoding_message_size(config.prover.grpc.max_decoding_message_size)
+                .max_encoding_message_size(config.prover.grpc.max_encoding_message_size)
                 .send_compressed(CompressionEncoding::Zstd)
                 .accept_compressed(CompressionEncoding::Zstd),
             verifier: Arc::new(verifier),

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -105,6 +105,9 @@ pub struct Config {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub prover_entrypoint: String,
 
+    #[serde(default, skip_serializing_if = "crate::default")]
+    pub prover: prover::ClientProverConfig,
+
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]
     pub debug_mode: bool,
@@ -157,6 +160,7 @@ impl Config {
             shutdown: Default::default(),
             certificate_orchestrator: Default::default(),
             prover_entrypoint: default_prover_entrypoint(),
+            prover: Default::default(),
             debug_mode: false,
         }
     }
@@ -228,4 +232,8 @@ impl<'de> DeserializeSeed<'de> for ConfigDeserializer<'_> {
 
 fn is_false(b: &bool) -> bool {
     !*b
+}
+
+pub(crate) fn default<T: Default + PartialEq>(t: &T) -> bool {
+    *t == Default::default()
 }

--- a/crates/agglayer-config/src/rpc.rs
+++ b/crates/agglayer-config/src/rpc.rs
@@ -39,7 +39,7 @@ pub struct RpcConfig {
     pub max_connections: u32,
     /// The maximum number of requests in a batch request. If `None`, the
     /// batch request limit is unlimited.
-    #[serde(skip_serializing_if = "default")]
+    #[serde(skip_serializing_if = "crate::default")]
     pub batch_request_limit: Option<u32>,
     /// The interval at which to send ping messages
     #[serde(skip)]
@@ -107,10 +107,6 @@ fn from_env_or_default<T: FromStr>(key: &str, default: T) -> T {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(default)
-}
-
-fn default<T: Default + PartialEq>(t: &T) -> bool {
-    *t == Default::default()
 }
 
 fn same_as_default_body_size(size: &u32) -> bool {

--- a/crates/agglayer-config/src/rpc.rs
+++ b/crates/agglayer-config/src/rpc.rs
@@ -19,20 +19,27 @@ pub struct RpcConfig {
     #[serde(default = "default_host")]
     pub host: Ipv4Addr,
 
-    // Skip serialization of these fields as we don't need to expose them in the
-    // configuration yet.
     /// The maximum size of the request body in bytes.
-    #[serde(skip, default = "default_body_size")]
+    #[serde(
+        skip_serializing_if = "same_as_default_body_size",
+        default = "default_body_size"
+    )]
     pub max_request_body_size: u32,
     /// The maximum size of the response body in bytes.
-    #[serde(skip, default = "default_body_size")]
+    #[serde(
+        skip_serializing_if = "same_as_default_body_size",
+        default = "default_body_size"
+    )]
     pub max_response_body_size: u32,
     /// The maximum number of connections.
-    #[serde(skip, default = "default_max_connections")]
+    #[serde(
+        skip_serializing_if = "same_as_default_max_connections",
+        default = "default_max_connections"
+    )]
     pub max_connections: u32,
     /// The maximum number of requests in a batch request. If `None`, the
     /// batch request limit is unlimited.
-    #[serde(skip)]
+    #[serde(skip_serializing_if = "default")]
     pub batch_request_limit: Option<u32>,
     /// The interval at which to send ping messages
     #[serde(skip)]
@@ -100,4 +107,16 @@ fn from_env_or_default<T: FromStr>(key: &str, default: T) -> T {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(default)
+}
+
+fn default<T: Default + PartialEq>(t: &T) -> bool {
+    *t == Default::default()
+}
+
+fn same_as_default_body_size(size: &u32) -> bool {
+    *size == default_body_size()
+}
+
+fn same_as_default_max_connections(max_connections: &u32) -> bool {
+    *max_connections == default_max_connections()
 }

--- a/crates/agglayer-config/tests/fixtures/valide_config/grpc_max_decoding_message_size.toml
+++ b/crates/agglayer-config/tests/fixtures/valide_config/grpc_max_decoding_message_size.toml
@@ -1,0 +1,2 @@
+[prover.grpc]
+max-decoding-message-size = 104857600

--- a/crates/agglayer-config/tests/fixtures/valide_config/max_rpc_request_size.toml
+++ b/crates/agglayer-config/tests/fixtures/valide_config/max_rpc_request_size.toml
@@ -1,0 +1,2 @@
+[rpc]
+max-request-body-size = 104857600

--- a/crates/agglayer-config/tests/fixtures/valide_config/prover_grpc_max_decoding_message_size.toml
+++ b/crates/agglayer-config/tests/fixtures/valide_config/prover_grpc_max_decoding_message_size.toml
@@ -1,0 +1,2 @@
+[grpc]
+max-decoding-message-size = 104857600

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
@@ -1,0 +1,66 @@
+---
+source: crates/agglayer-config/tests/validate_deserialize.rs
+expression: config
+---
+prover-entrypoint = "http://127.0.0.1:8080"
+
+[full-node-rpcs]
+
+[l2]
+rpc-timeout = "45s"
+
+[proof-signers]
+
+[log]
+level = "info"
+outputs = []
+format = "pretty"
+
+[rpc]
+port = 9090
+host = "0.0.0.0"
+request-timeout = "3m"
+
+[rate-limiting]
+send-tx = "unlimited"
+
+[rate-limiting.network]
+
+[outbound.rpc.settle]
+max-retries = 3
+retry-interval = "7s"
+confirmations = 1
+settlement-timeout = "20m"
+
+[l1]
+chain-id = 1337
+node-url = "http://zkevm-mock-l1-network:8545/"
+ws-node-url = "ws://zkevm-mock-l1-network:8546/"
+max-reconnection-elapsed-time = "10s"
+rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+polygon-zkevm-global-exit-root-v2-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+rpc-timeout = "45s"
+
+[auth.local]
+private-keys = []
+
+[telemetry]
+prometheus-addr = "0.0.0.0:3000"
+
+[epoch.block-clock]
+epoch-duration = 6
+genesis-block = 0
+
+[shutdown]
+runtime-timeout = "5s"
+
+[certificate-orchestrator]
+input-backpressure-buffer-size = 1000
+
+[certificate-orchestrator.prover.sp1-local]
+
+[storage]
+db-path = "/tmp/agglayer/tests/fixtures/valide_config/storage"
+
+[prover.grpc]
+max-decoding-message-size = 104857600

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
@@ -1,0 +1,64 @@
+---
+source: crates/agglayer-config/tests/validate_deserialize.rs
+expression: config
+---
+prover-entrypoint = "http://127.0.0.1:8080"
+
+[full-node-rpcs]
+
+[l2]
+rpc-timeout = "45s"
+
+[proof-signers]
+
+[log]
+level = "info"
+outputs = []
+format = "pretty"
+
+[rpc]
+port = 9090
+host = "0.0.0.0"
+max-request-body-size = 104857600
+request-timeout = "3m"
+
+[rate-limiting]
+send-tx = "unlimited"
+
+[rate-limiting.network]
+
+[outbound.rpc.settle]
+max-retries = 3
+retry-interval = "7s"
+confirmations = 1
+settlement-timeout = "20m"
+
+[l1]
+chain-id = 1337
+node-url = "http://zkevm-mock-l1-network:8545/"
+ws-node-url = "ws://zkevm-mock-l1-network:8546/"
+max-reconnection-elapsed-time = "10s"
+rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+polygon-zkevm-global-exit-root-v2-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+rpc-timeout = "45s"
+
+[auth.local]
+private-keys = []
+
+[telemetry]
+prometheus-addr = "0.0.0.0:3000"
+
+[epoch.block-clock]
+epoch-duration = 6
+genesis-block = 0
+
+[shutdown]
+runtime-timeout = "5s"
+
+[certificate-orchestrator]
+input-backpressure-buffer-size = 1000
+
+[certificate-orchestrator.prover.sp1-local]
+
+[storage]
+db-path = "/tmp/agglayer/tests/fixtures/valide_config/storage"

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
@@ -1,0 +1,36 @@
+---
+source: crates/agglayer-config/tests/validate_deserialize.rs
+expression: config
+---
+grpc-endpoint = "127.0.0.1:8080"
+max-concurrency-limit = 100
+max-request-duration = "5m"
+max-buffered-queries = 100
+
+[grpc]
+max-decoding-message-size = 104857600
+
+[log]
+level = "info"
+outputs = []
+format = "pretty"
+
+[telemetry]
+prometheus-addr = "0.0.0.0:3000"
+
+[shutdown]
+runtime-timeout = "5s"
+
+[cpu-prover]
+enabled = true
+max-concurrency-limit = 100
+proving-timeout = "5m"
+
+[network-prover]
+enabled = false
+proving-timeout = "5m"
+
+[gpu-prover]
+enabled = false
+max-concurrency-limit = 100
+proving-timeout = "5m"

--- a/crates/agglayer-config/tests/validate_deserialize.rs
+++ b/crates/agglayer-config/tests/validate_deserialize.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use agglayer_config::Config;
 use insta::assert_toml_snapshot;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn empty_rpcs() {
@@ -20,4 +21,25 @@ fn empty_rpcs() {
             value
         }),
     });
+}
+
+#[test]
+fn max_rpc_request_size() {
+    let input = "./tests/fixtures/valide_config/max_rpc_request_size.toml";
+
+    let config = Config::try_load(Path::new(input)).unwrap();
+
+    assert_toml_snapshot!(config, {
+        ".storage.*" => insta::dynamic_redaction(|value, path| {
+            if path.to_string() != "storage.db-path" {
+                if let insta::internals::Content::String(path) = value {
+                    return insta::internals::Content::String(path.replace(Path::new("./").canonicalize().unwrap().to_str().unwrap(), "/tmp/agglayer"));
+                }
+            }
+
+            value
+        }),
+    });
+
+    assert_eq!(config.rpc.max_request_body_size, 100 * 1024 * 1024);
 }

--- a/crates/agglayer-config/tests/validate_deserialize.rs
+++ b/crates/agglayer-config/tests/validate_deserialize.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use agglayer_config::Config;
+use agglayer_config::{prover::ProverConfig, Config};
 use insta::assert_toml_snapshot;
 use pretty_assertions::assert_eq;
 
@@ -42,4 +42,49 @@ fn max_rpc_request_size() {
     });
 
     assert_eq!(config.rpc.max_request_body_size, 100 * 1024 * 1024);
+}
+
+#[test]
+fn grpc_max_decoding_message_size() {
+    let input = "./tests/fixtures/valide_config/grpc_max_decoding_message_size.toml";
+
+    let config = Config::try_load(Path::new(input)).unwrap();
+
+    assert_toml_snapshot!(config, {
+        ".storage.*" => insta::dynamic_redaction(|value, path| {
+            if path.to_string() != "storage.db-path" {
+                if let insta::internals::Content::String(path) = value {
+                    return insta::internals::Content::String(path.replace(Path::new("./").canonicalize().unwrap().to_str().unwrap(), "/tmp/agglayer"));
+                }
+            }
+
+            value
+        }),
+    });
+
+    assert_eq!(
+        config.prover.grpc.max_decoding_message_size,
+        100 * 1024 * 1024
+    );
+}
+
+#[test]
+fn prover_grpc_max_decoding_message_size() {
+    let input = "./tests/fixtures/valide_config/prover_grpc_max_decoding_message_size.toml";
+
+    let config: ProverConfig = toml::from_str(&std::fs::read_to_string(input).unwrap()).unwrap();
+
+    assert_toml_snapshot!(config, {
+        ".storage.*" => insta::dynamic_redaction(|value, path| {
+            if path.to_string() != "storage.db-path" {
+                if let insta::internals::Content::String(path) = value {
+                    return insta::internals::Content::String(path.replace(Path::new("./").canonicalize().unwrap().to_str().unwrap(), "/tmp/agglayer"));
+                }
+            }
+
+            value
+        }),
+    });
+
+    assert_eq!(config.grpc.max_decoding_message_size, 100 * 1024 * 1024);
 }

--- a/crates/agglayer-prover/src/prover.rs
+++ b/crates/agglayer-prover/src/prover.rs
@@ -46,6 +46,8 @@ impl Prover {
         let rpc = ProverRPC::new(executor);
 
         let svc = ProofGenerationServiceServer::new(rpc)
+            .max_decoding_message_size(config.grpc.max_decoding_message_size)
+            .max_encoding_message_size(config.grpc.max_encoding_message_size)
             .send_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Zstd);
 


### PR DESCRIPTION
# Description

This PR is activating the `deserialization` and the `serialization` (if not default) for max request fields of the RPC endpoint.

## Additions

- `max-request-body-size` allows the configuration of the maximum request body size in bytes on the JSON-RPC API
- `max_response_body_size` allows the configuration of the maximum response body size in bytes on the JSON-RPC API
- `max-decoding-message-size`  allows the configuration of the maximum message size in bytes when decoding on the prover config
- `max-encoding-message-size`  allows the configuration of the maximum message size in bytes when encoding on the prover config

### `agglayer` config

```toml
[rpc]
# size is define in bytes e.g. 100 * 1024 * 1024
# same for `max_response_body_size`
# default value is equal to 10MB
max-request-body-size = 104857600

[prover.grpc]
# size is define in bytes e.g. 100 * 1024 * 1024
# same for `max-encoding-message-size`
# default value is equal to 4MB
max-decoding-message-size = 104857600
```

### `agglayer-prover` config

```toml
[grpc]
# size is define in bytes e.g. 100 * 1024 * 1024
# same for `max-encoding-message-size`
# default value is equal to 4MB
max-decoding-message-size = 104857600
```

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
