### PR TITLE
fix: epoch considered packed when still open

### DIFF
--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -52,9 +52,13 @@ pub(crate) struct DummyPendingStore {
     pub(crate) certificate_headers: RwLock<BTreeMap<CertificateId, CertificateHeader>>,
     pub(crate) latest_proven_certificate_per_network:
         RwLock<BTreeMap<NetworkId, ProvenCertificate>>,
+    pub(crate) is_packed: bool,
 }
 
 impl PerEpochReader for DummyPendingStore {
+    fn is_epoch_packed(&self) -> bool {
+        self.is_packed
+    }
     fn get_epoch_number(&self) -> u64 {
         self.current_epoch
     }

--- a/crates/agglayer-storage/src/stores/interfaces/reader.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/reader.rs
@@ -105,4 +105,6 @@ pub trait PerEpochReader: Send + Sync {
         &self,
         network_id: NetworkId,
     ) -> Result<Option<Height>, Error>;
+
+    fn is_epoch_packed(&self) -> bool;
 }

--- a/crates/agglayer-storage/src/stores/per_epoch/tests.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/tests.rs
@@ -38,7 +38,10 @@ fn can_start_packing_an_unpacked_epoch(store: PerEpochStore<PendingStore, StateS
 
 #[rstest]
 fn cant_start_packing_a_packed_epoch(store: PerEpochStore<PendingStore, StateStore>) {
-    let _lock = store.packing_lock.write().insert(0);
+    let mut lock = store.packing_lock.write();
+    *lock = true;
+    drop(lock);
+
     assert!(store.start_packing().is_err());
 }
 

--- a/crates/agglayer-storage/src/tests/mocks/per_epoch_store.rs
+++ b/crates/agglayer-storage/src/tests/mocks/per_epoch_store.rs
@@ -13,6 +13,7 @@ mock! {
     pub PerEpochStore {}
 
     impl PerEpochReader for PerEpochStore {
+        fn is_epoch_packed(&self) -> bool;
         fn get_epoch_number(&self) -> u64;
         fn get_start_checkpoint(&self) -> &BTreeMap<NetworkId, Height>;
         fn get_end_checkpoint(&self) -> BTreeMap<NetworkId, Height>;

--- a/crates/agglayer-storage/src/types.rs
+++ b/crates/agglayer-storage/src/types.rs
@@ -1,8 +1,4 @@
-use std::collections::BTreeMap;
-
-use agglayer_types::{
-    Certificate, CertificateHeader, CertificateId, Digest, Height, NetworkId, Proof,
-};
+use agglayer_types::{Certificate, CertificateHeader, CertificateId, Digest, NetworkId, Proof};
 use serde::{Deserialize, Serialize};
 
 use crate::columns::Codec;
@@ -28,15 +24,13 @@ pub enum MetadataValue {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum PerEpochMetadataKey {
     SettlementTxHash,
-    StartCheckpoint,
-    EndCheckpoint,
+    Packed,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum PerEpochMetadataValue {
-    SettlementTxHash([u8; 32]),
-    StartCheckpoint(BTreeMap<NetworkId, Height>),
-    EndCheckpoint(BTreeMap<NetworkId, Height>),
+    SettlementTxHash(Digest),
+    Packed(bool),
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
# Description

This PR is fixing a corner case on the epoch synchronization and the opening of the latest epoch.

Fixes #466 

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
