### PR TITLE
fix: notify network task on failure when adding the cert to epoch

### DIFF
--- a/crates/agglayer-aggregator-notifier/src/packer/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/packer/mod.rs
@@ -85,7 +85,11 @@ where
             if let Some(certificate) = related_epoch.get_certificate_at_index(certificate_index)? {
                 certificate
             } else {
-                return Err(Error::InternalError);
+                return Err(Error::InternalError(format!(
+                    "Unable to find the certificate in the epoch {} at index {}",
+                    related_epoch.get_epoch_number(),
+                    certificate_index
+                )));
             };
 
         let network_id = certificate.network_id;
@@ -107,10 +111,12 @@ where
                 {
                     (output, proof.bytes())
                 } else {
-                    return Err(Error::InternalError);
+                    return Err(Error::InternalError(
+                        "Unable to deserialize the proof output".to_string(),
+                    ));
                 }
             } else {
-                return Err(Error::InternalError);
+                return Err(Error::InternalError("Unable to find the proof".to_string()));
             };
 
         let contract_call = self
@@ -233,7 +239,12 @@ where
             })
             .await
             // TODO: Handle error in a better way
-            .map_err(|_| Error::InternalError)?;
+            .map_err(|_| {
+                Error::InternalError(format!(
+                    "Unable to join the packing task for {}",
+                    epoch_number
+                ))
+            })?;
 
             Ok(())
         }))

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -128,6 +128,10 @@ pub enum CertificateStatusError {
     InternalError(String),
     #[error("Settlement error: {0}")]
     SettlementError(String),
+    #[error("Pre certification error: {0}")]
+    PreCertificationError(String),
+    #[error("Certification error: {0}")]
+    CertificationError(String),
     #[error("L1 Info root not found for l1 leaf count: {0}")]
     L1InfoRootNotFound(u32),
 }


### PR DESCRIPTION
# Description

This PR is adding the notification of a failure when trying to add a certificate to the current epoch.

Fixes #467 

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
