### PR TITLE
fix: check for receipt status during settlement of certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "futures",
  "hex",
  "mockall",
+ "mockall_double",
  "pessimistic-proof",
  "pessimistic-proof-test-suite",
  "reth-primitives",
@@ -173,6 +174,7 @@ dependencies = [
  "async-trait",
  "ethers",
  "ethers-contract",
+ "mockall",
  "reth-primitives",
  "thiserror 1.0.69",
  "tokio",
@@ -4943,7 +4945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5142,6 +5144,18 @@ name = "mockall_derive"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "mockall_double"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ca96e5ac35256ae3e13536edd39b172b88f41615e1d7b653c8ad24524113e8"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,6 @@ dependencies = [
  "futures",
  "hex",
  "mockall",
- "mockall_double",
  "pessimistic-proof",
  "pessimistic-proof-test-suite",
  "reth-primitives",
@@ -5144,18 +5143,6 @@ name = "mockall_derive"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
-
-[[package]]
-name = "mockall_double"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ca96e5ac35256ae3e13536edd39b172b88f41615e1d7b653c8ad24524113e8"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [workspace.dependencies]
+# Core dependencies
 anyhow = "1.0.93"
 arc-swap = "1.7.1"
 async-trait = "0.1.82"
@@ -27,23 +28,14 @@ dotenvy = "0.15.7"
 ethers = "2.0.14"
 ethers-gcp-kms-signer = "0.1.5"
 ethers-signers = "2.0.14"
-fail = "0.5.1"
 futures = "0.3.31"
 hex = "0.4.3"
-insta = { git = "https://github.com/freyskeyd/insta", branch = "chore/updating-deps-to-avoid-serialize-error", features = [
-    "toml",
-    "yaml",
-] }
 jsonrpsee = { version = "0.24.7", features = ["full"] }
 lazy_static = "1.5.0"
-mockall = "0.13.1"
 parking_lot = "0.12.3"
-rand = "0.8.5"
-rstest = "0.22.0"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 serde_with = "3.11.0"
-test-log = "0.2.16"
 thiserror = "1.0.67"
 tokio = { version = "1.41.1", features = ["full"] }
 tokio-util = "0.7.11"
@@ -55,6 +47,19 @@ tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = { version = "2.5.4", features = ["serde"] }
 
+# Test dependencies
+fail = { version = "0.5.1", default-features = false }
+insta = { git = "https://github.com/freyskeyd/insta", branch = "chore/updating-deps-to-avoid-serialize-error", features = [
+    "toml",
+    "yaml",
+] }
+mockall = "0.13.1"
+rand = "0.8.5"
+rstest = "0.22.0"
+test-log = "0.2.16"
+
+
+# SP1 dependencies
 reth-primitives = { git = "https://github.com/sp1-patches/reth", default-features = false, branch = "sp1-reth" }
 sp1-core-machine = "3.1.0"
 sp1-sdk = "3.0.0"

--- a/crates/agglayer-aggregator-notifier/Cargo.toml
+++ b/crates/agglayer-aggregator-notifier/Cargo.toml
@@ -5,31 +5,30 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+agglayer-certificate-orchestrator = { path = "../agglayer-certificate-orchestrator" }
+agglayer-config = { path = "../agglayer-config" }
+agglayer-contracts = { path = "../agglayer-contracts" }
+agglayer-prover-types = { path = "../agglayer-prover-types" }
+agglayer-storage = { path = "../agglayer-storage" }
+agglayer-types = { path = "../agglayer-types" }
 anyhow.workspace = true
 arc-swap.workspace = true
 bincode.workspace = true
 ethers.workspace = true
-hex.workspace = true
+fail.workspace = true
 futures.workspace = true
-fail = { workspace = true, default-features = false, features = [] }
-serde.workspace = true
-thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
-tracing.workspace = true
-agglayer-certificate-orchestrator = { path = "../agglayer-certificate-orchestrator" }
-agglayer-config = { path = "../agglayer-config" }
-agglayer-contracts = { path = "../agglayer-contracts" }
-agglayer-storage = { path = "../agglayer-storage" }
-agglayer-types = { path = "../agglayer-types" }
-agglayer-prover-types = { path = "../agglayer-prover-types" }
+hex.workspace = true
 pessimistic-proof = { path = "../pessimistic-proof" }
 reth-primitives.workspace = true
-tonic = { workspace = true, features = ["zstd"] }
+serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tonic = { workspace = true, features = ["zstd"] }
+tracing.workspace = true
 
 sp1-sdk.workspace = true
 sp1-prover.workspace = true
-mockall_double = "0.3.1"
 
 [dev-dependencies]
 agglayer-prover = { path = "../agglayer-prover", features = ["testutils"] }

--- a/crates/agglayer-aggregator-notifier/Cargo.toml
+++ b/crates/agglayer-aggregator-notifier/Cargo.toml
@@ -8,9 +8,10 @@ license.workspace = true
 anyhow.workspace = true
 arc-swap.workspace = true
 bincode.workspace = true
+ethers.workspace = true
 hex.workspace = true
 futures.workspace = true
-fail.workspace = true
+fail = { workspace = true, default-features = false, features = [] }
 serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
@@ -28,6 +29,7 @@ serde_json.workspace = true
 
 sp1-sdk.workspace = true
 sp1-prover.workspace = true
+mockall_double = "0.3.1"
 
 [dev-dependencies]
 agglayer-prover = { path = "../agglayer-prover", features = ["testutils"] }

--- a/crates/agglayer-aggregator-notifier/src/packer/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/packer/mod.rs
@@ -286,7 +286,6 @@ where
     let receipt = pending_tx
         .inspect(|tx| info!(hash, "Inspect settle transaction: {:?}", tx))
         .map_err(|e| {
-            println!("Error: {:?}", e);
             let error_str = RollupManagerRpc::decode_contract_revert(&e).unwrap_or(e.to_string());
 
             error!(

--- a/crates/agglayer-aggregator-notifier/src/packer/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/packer/mod.rs
@@ -11,6 +11,11 @@ use agglayer_types::{
     CertificateHeader, CertificateId, CertificateIndex, CertificateStatus, NetworkId, Proof,
 };
 use bincode::Options;
+use ethers::{
+    contract::ContractError,
+    providers::{Middleware, PendingTransaction},
+    types::{TransactionReceipt, H160, H256, U64},
+};
 use futures::future::BoxFuture;
 use pessimistic_proof::PessimisticProofOutput;
 use tracing::Instrument;
@@ -146,76 +151,91 @@ where
 
         let state_store = self.state_store.clone();
         let config = self.config.clone();
+
         // Call the Provider
         let fut = Box::pin(
             async move {
-                let _tx = contract_call
-                    .send()
-                    .await
-                    .inspect(|tx| info!(hash, "Inspect settle transaction: {:?}", tx))
-                    // .map_err(SettlementError::ContractError)?
-                    .map_err(|e| {
-                        let error_str =
-                            RollupManagerRpc::decode_contract_revert(&e).unwrap_or(e.to_string());
+                // Send the transaction
+                let pending_tx = contract_call.send().await;
+                // wait for the receipt
+                let receipt = handle_pending_tx::<RollupManagerRpc>(
+                    pending_tx,
+                    hash.clone(),
+                    certificate_id,
+                    config,
+                )
+                .await?
+                // If the result is `None`, it means the transaction is no longer
+                // in the mempool.
+                .ok_or(Error::SettlementError {
+                    certificate_id,
+                    error: "No receipt hash returned, transaction still in mempool".to_string(),
+                })?;
 
-                        error!(
-                        error_code = %e,
-                        error = error_str,
-                        hash,
-                            "Failed to settle the certificate {certificate_id}: {}", error_str);
-
-                        Error::SettlementError {
+                match receipt.status {
+                    Some(n) if n == U64::zero() => {
+                        warn!(
+                            hash,
+                            "The transaction failed to settle the certificate {}", certificate_id
+                        );
+                        Err(Error::SettlementError {
                             certificate_id,
-                            error: error_str,
+                            error: "SettlementTransaction failed".to_string(),
+                        })
+                    }
+                    None => {
+                        error!(
+                            hash,
+                            "The transaction failed to settle the certificate {}", certificate_id
+                        );
+
+                        Err(Error::SettlementError {
+                            certificate_id,
+                            error: "SettlementTransaction failed due to no receipt status"
+                                .to_string(),
+                        })
+                    }
+                    Some(_) => {
+                        if let Err(error) = state_store.update_certificate_header_status(
+                            &certificate_id,
+                            &CertificateStatus::Settled,
+                        ) {
+                            error!(
+                                hash,
+                                "Certificate settled but failed to update the certificate status \
+                                 of {} due to: {}",
+                                certificate_id,
+                                error
+                            );
                         }
-                    })?
-                    .interval(config.retry_interval)
-                    .retries(config.max_retries)
-                    .confirmations(config.confirmations)
-                    .await
-                    .map_err(|error| Error::SettlementError {
-                        certificate_id,
-                        error: error.to_string(),
-                    })?
-                    // If the result is `None`, it means the transaction is no longer
-                    // in the mempool.
-                    .ok_or(Error::SettlementError {
-                        certificate_id,
-                        error: "No receipt hash returned, transaction still in mempool".to_string(),
-                    })?;
+                        if let Err(error) = state_store.set_latest_settled_certificate_for_network(
+                            &network_id,
+                            &height,
+                            &certificate_id,
+                            &epoch_number,
+                            &certificate_index,
+                        ) {
+                            error!(
+                                hash,
+                                "Certificate settled but failed to update the latest settled \
+                                 certificate for network {} with {} due to: {}",
+                                network_id,
+                                certificate_id,
+                                error
+                            );
+                        }
 
-                if let Err(error) = state_store
-                    .update_certificate_header_status(&certificate_id, &CertificateStatus::Settled)
-                {
-                    error!(
-                        hash,
-                        "Certificate settled but failed to update the certificate status of {} \
-                         due to: {}",
-                        certificate_id,
-                        error
-                    );
+                        Ok::<_, Error>((
+                            network_id,
+                            SettledCertificate(
+                                certificate_id,
+                                height,
+                                epoch_number,
+                                certificate_index,
+                            ),
+                        ))
+                    }
                 }
-                if let Err(error) = state_store.set_latest_settled_certificate_for_network(
-                    &network_id,
-                    &height,
-                    &certificate_id,
-                    &epoch_number,
-                    &certificate_index,
-                ) {
-                    error!(
-                        hash,
-                        "Certificate settled but failed to update the latest settled certificate \
-                         for network {} with {} due to: {}",
-                        network_id,
-                        certificate_id,
-                        error
-                    );
-                }
-
-                Ok::<_, Error>((
-                    network_id,
-                    SettledCertificate(certificate_id, height, epoch_number, certificate_index),
-                ))
             }
             .instrument(tracing::Span::current()),
         );
@@ -249,4 +269,74 @@ where
             Ok(())
         }))
     }
+}
+
+async fn handle_pending_tx<RollupManagerRpc>(
+    pending_tx: Result<
+        PendingTransaction<'_, <<RollupManagerRpc as Settler>::M as Middleware>::Provider>,
+        ContractError<<RollupManagerRpc as Settler>::M>,
+    >,
+    hash: String,
+    certificate_id: CertificateId,
+    config: Arc<OutboundRpcSettleConfig>,
+) -> Result<Option<TransactionReceipt>, Error>
+where
+    RollupManagerRpc: RollupContract + Settler + Send + Sync + 'static,
+{
+    let receipt = pending_tx
+        .inspect(|tx| info!(hash, "Inspect settle transaction: {:?}", tx))
+        .map_err(|e| {
+            println!("Error: {:?}", e);
+            let error_str = RollupManagerRpc::decode_contract_revert(&e).unwrap_or(e.to_string());
+
+            error!(
+                error_code = %e,
+                error = error_str,
+                hash,
+                "Failed to settle the certificate {certificate_id}: {}", error_str
+            );
+
+            Error::SettlementError {
+                certificate_id,
+                error: error_str,
+            }
+        })?
+        .interval(config.retry_interval)
+        .retries(config.max_retries)
+        .confirmations(config.confirmations)
+        .await;
+
+    fail::fail_point!(
+        "notifier::packer::settle_certificate::receipt_future_ended::status_0",
+        |_| {
+            Ok(Some(TransactionReceipt {
+                transaction_hash: H256::random(),
+                transaction_index: U64([1; 1]),
+                block_hash: None,
+                block_number: None,
+                from: H160::random(),
+                to: None,
+                cumulative_gas_used: ethers::types::U256::zero(),
+                gas_used: None,
+                contract_address: None,
+                logs: vec![],
+                status: Some(U64([0; 1])),
+                root: None,
+                logs_bloom: ethers::types::Bloom::zero(),
+                transaction_type: None,
+                effective_gas_price: None,
+                other: ethers::types::OtherFields::default(),
+            }))
+        }
+    );
+
+    fail::fail_point!(
+        "notifier::packer::settle_certificate::receipt_future_ended::no_receipt",
+        |_| { Ok(None) }
+    );
+
+    receipt.map_err(|error| Error::SettlementError {
+        certificate_id,
+        error: error.to_string(),
+    })
 }

--- a/crates/agglayer-clock/Cargo.toml
+++ b/crates/agglayer-clock/Cargo.toml
@@ -4,7 +4,9 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+alloy = { version = "0.6.4", features = ["full"] }
 async-trait.workspace = true
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ethers = { workspace = true, features = ["ws"] }
 fail.workspace = true
@@ -13,8 +15,6 @@ thiserror.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-alloy = { version = "0.6.4", features = ["full"] }
-backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 
 [dev-dependencies]
 fail = { workspace = true, features = ["failpoints"] }

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -12,7 +12,7 @@ use serde_with::DisplayFromStr;
 use shutdown::ShutdownConfig;
 use url::Url;
 
-use self::telemetry::TelemetryConfig;
+pub use self::telemetry::TelemetryConfig;
 
 pub mod prover;
 

--- a/crates/agglayer-contracts/Cargo.toml
+++ b/crates/agglayer-contracts/Cargo.toml
@@ -10,9 +10,10 @@ ethers.workspace = true
 ethers-contract = "2.0.14"
 reth-primitives.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+mockall.workspace = true
 
 [build-dependencies]
 ethers-contract = "2.0.14"


### PR DESCRIPTION
# Description

This PR checks the receipt status during the settlement of a certificate.
If the status isn't `success` the certificate is tagged as `InError`.

Fixes #471 

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
