### PR TITLE
feat: adding SIGTERM signal to agglayer node and agglayer prover

### DIFF
--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -87,12 +87,27 @@ pub fn main(cfg: PathBuf) -> Result<()> {
             .cancellation_token(global_cancellation_token.clone())
             .start(),
     )?;
+    let terminate_signal = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("Fail to setup SIGTERM signal")
+            .recv()
+            .await;
+    };
 
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?
         .block_on(async {
             tokio::select! {
+                _ = terminate_signal => {
+                    info!("Received SIGTERM, shutting down...");
+                    // Cancel the global cancellation token to start the shutdown process.
+                    global_cancellation_token.cancel();
+                    // Wait for the node to shutdown.
+                    node.await_shutdown().await;
+                    // Wait for the metrics server to shutdown.
+                    _ = metrics_handle.await;
+                }
                 _ = tokio::signal::ctrl_c() => {
                     info!("Received SIGINT (ctrl-c), shutting down...");
                     // Cancel the global cancellation token to start the shutdown process.


### PR DESCRIPTION
# Description

This PR is adding the support of SIGTERM to both `agglayer-node` and `agglayer-prover`.

Fixes #472

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
