### PR TITLE
feat: allow gas to be configured using multiplier factor

### DIFF
--- a/crates/agglayer-config/src/outbound.rs
+++ b/crates/agglayer-config/src/outbound.rs
@@ -45,6 +45,15 @@ pub struct OutboundRpcSettleConfig {
     #[serde(default = "default_settlement_timeout")]
     #[serde(with = "crate::with::HumanDuration")]
     pub settlement_timeout: Duration,
+
+    /// Gas multiplier factor for the transaction.
+    /// The gas is calculated as follows:
+    /// `gas = estimate_gas * (gas_multiplier / 100)
+    #[serde(
+        default = "default_gas_multiplier_factor",
+        skip_serializing_if = "same_as_default_gas_multiplier_factor"
+    )]
+    pub gas_multiplier_factor: u32,
 }
 
 impl Default for OutboundRpcSettleConfig {
@@ -54,8 +63,18 @@ impl Default for OutboundRpcSettleConfig {
             retry_interval: default_rpc_retry_interval(),
             confirmations: default_rpc_confirmations(),
             settlement_timeout: default_settlement_timeout(),
+            gas_multiplier_factor: default_gas_multiplier_factor(),
         }
     }
+}
+
+/// Default gas price multiplier for the transaction.
+const fn default_gas_multiplier_factor() -> u32 {
+    100
+}
+
+const fn same_as_default_gas_multiplier_factor(v: &u32) -> bool {
+    *v == default_gas_multiplier_factor()
 }
 
 /// Default number of retries for the transaction. It matches the ethers default


### PR DESCRIPTION
# Description

This PR introduces a new configuration option to configure the `gas` used by the settlement contract call.

The `gas` is now configured using a `gas_multiplier_factor` applied on the `estimate_gas` result.
The `gas_multiplier_factor` should represent the ending purcentage expected, for 10% bonus, `gas_multiplier_factor=110`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
