### PR TITLE
feat: add version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "dotenvy",
  "insta",
  "toml",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -2093,7 +2094,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2113,7 +2114,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -5308,7 +5309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5741,7 +5742,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -6830,7 +6831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -6863,7 +6864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -8444,7 +8445,7 @@ dependencies = [
  "tokio",
  "tracing",
  "twirp-rs",
- "vergen",
+ "vergen 8.3.2",
 ]
 
 [[package]]
@@ -9675,6 +9676,45 @@ dependencies = [
  "git2",
  "rustversion",
  "time",
+]
+
+[[package]]
+name = "vergen"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f25fc8f8f05df455c7941e87f093ad22522a9ff33d7a027774815acf6f0639"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e63e069d8749fead1e3bab7a9d79e8fb90516b2ec66fc2243a798ecdc1a31d7"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "git2",
+ "rustversion",
+ "time",
+ "vergen 9.0.2",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0c767e6751c09fc85cde58722cf2f1007e80e4c8d5a4321fc90d83dc54ca147"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,6 +2995,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -50,6 +50,7 @@ use crate::{
 
 pub(crate) mod mocks;
 
+#[allow(dead_code)]
 #[derive(Default)]
 pub(crate) struct DummyPendingStore {
     pub(crate) current_epoch: u64,

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -27,7 +27,7 @@ use agglayer_telemetry::ServerBuilder as MetricsBuilder;
 ///
 /// This function returns on fatal error or after graceful shutdown has
 /// completed.
-pub fn main(cfg: PathBuf) -> Result<()> {
+pub fn main(cfg: PathBuf, version: &str) -> Result<()> {
     let cfg = cfg.canonicalize().map_err(|_| {
         anyhow::Error::msg(format!(
             "Configuration file path must be absolute, given: {}",
@@ -49,6 +49,8 @@ pub fn main(cfg: PathBuf) -> Result<()> {
 
     // Initialize the logger
     logging::tracing(&config.log);
+
+    info!("Starting agglayer node version info: {}", version);
 
     let node_runtime = tokio::runtime::Builder::new_multi_thread()
         .thread_name("agglayer-node-runtime")

--- a/crates/agglayer-prover/src/lib.rs
+++ b/crates/agglayer-prover/src/lib.rs
@@ -25,7 +25,7 @@ mod rpc;
 ///
 /// This function returns on fatal error or after graceful shutdown has
 /// completed.
-pub fn main(cfg: PathBuf) -> Result<()> {
+pub fn main(cfg: PathBuf, version: &str) -> Result<()> {
     // Load the configuration file
     let config: Arc<ProverConfig> = Arc::new(toml::from_str(&std::fs::read_to_string(cfg)?)?);
 
@@ -33,6 +33,8 @@ pub fn main(cfg: PathBuf) -> Result<()> {
 
     // Initialize the logger
     logging::tracing(&config.log);
+
+    info!("Starting agglayer prover version info: {}", version);
 
     let node_runtime = tokio::runtime::Builder::new_multi_thread()
         .thread_name("agglayer-prover-runtime")

--- a/crates/agglayer/Cargo.toml
+++ b/crates/agglayer/Cargo.toml
@@ -17,3 +17,6 @@ agglayer-config = { path = "../agglayer-config" }
 [dev-dependencies]
 assert_cmd = "2.0.14"
 insta.workspace = true
+
+[build-dependencies]
+vergen-git2 = { version = "1.0.0", features = ["build"] }

--- a/crates/agglayer/build.rs
+++ b/crates/agglayer/build.rs
@@ -1,0 +1,9 @@
+use vergen_git2::{BuildBuilder, Emitter, Git2Builder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    Emitter::new()
+        .add_instructions(&BuildBuilder::default().build_timestamp(true).build()?)?
+        .add_instructions(&Git2Builder::default().describe(true, true, None).build()?)?
+        .emit()?;
+    Ok(())
+}

--- a/crates/agglayer/build.rs
+++ b/crates/agglayer/build.rs
@@ -1,9 +1,13 @@
-use vergen_git2::{BuildBuilder, Emitter, Git2Builder};
+use vergen_git2::{Emitter, Git2Builder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     Emitter::new()
-        .add_instructions(&BuildBuilder::default().build_timestamp(true).build()?)?
-        .add_instructions(&Git2Builder::default().describe(true, true, None).build()?)?
+        .add_instructions(
+            &Git2Builder::default()
+                .describe(true, true, None)
+                .commit_timestamp(true)
+                .build()?,
+        )?
         .emit()?;
     Ok(())
 }

--- a/crates/agglayer/src/cli.rs
+++ b/crates/agglayer/src/cli.rs
@@ -3,8 +3,12 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueHint};
 
+use crate::version;
+
 /// Agglayer command line interface.
 #[derive(Parser)]
+#[command(version = version())]
+#[command(propagate_version = true)]
 pub(crate) struct Cli {
     #[command(subcommand)]
     pub(crate) cmd: Commands,
@@ -48,6 +52,4 @@ pub(crate) enum Commands {
     },
 
     Vkey,
-
-    Version,
 }

--- a/crates/agglayer/src/cli.rs
+++ b/crates/agglayer/src/cli.rs
@@ -48,4 +48,6 @@ pub(crate) enum Commands {
     },
 
     Vkey,
+
+    Version,
 }

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -43,6 +43,6 @@ fn main() -> anyhow::Result<()> {
 pub fn version() -> String {
     let pkg_name = env!("CARGO_PKG_NAME");
     let git_describe = env!("VERGEN_GIT_DESCRIBE");
-    let timestamp = env!("VERGEN_BUILD_TIMESTAMP");
-    format!("{pkg_name} ({git_describe}) [built: {timestamp}]")
+    let timestamp = env!("VERGEN_GIT_COMMIT_TIMESTAMP");
+    format!("{pkg_name} ({git_describe}) [git commit timestamp: {timestamp}]")
 }

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -9,8 +9,8 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.cmd {
-        cli::Commands::Run { cfg } => agglayer_node::main(cfg)?,
-        cli::Commands::Prover { cfg } => agglayer_prover::main(cfg)?,
+        cli::Commands::Run { cfg } => agglayer_node::main(cfg, &version())?,
+        cli::Commands::Prover { cfg } => agglayer_prover::main(cfg, &version())?,
         cli::Commands::ProverConfig => println!(
             "{}",
             toml::to_string_pretty(&agglayer_config::prover::ProverConfig::default()).unwrap()
@@ -31,7 +31,18 @@ fn main() -> anyhow::Result<()> {
             let vkey = agglayer_prover::get_vkey();
             println!("{}", vkey);
         }
+        cli::Commands::Version => {
+            println!("version info: {}", version());
+        }
     }
 
     Ok(())
+}
+
+/// Common information about the executed agglayer for the `version`
+pub fn version() -> String {
+    let pkg_name = env!("CARGO_PKG_NAME");
+    let git_describe = env!("VERGEN_GIT_DESCRIBE");
+    let timestamp = env!("VERGEN_BUILD_TIMESTAMP");
+    format!("{pkg_name} ({git_describe}) [built: {timestamp}]")
 }

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Common information about the executed agglayer for the `version`
+/// Common version information about the executed agglayer binary.
 pub fn version() -> String {
     let pkg_name = env!("CARGO_PKG_NAME");
     let git_describe = env!("VERGEN_GIT_DESCRIBE");

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -31,9 +31,6 @@ fn main() -> anyhow::Result<()> {
             let vkey = agglayer_prover::get_vkey();
             println!("{}", vkey);
         }
-        cli::Commands::Version => {
-            println!("version info: {}", version());
-        }
     }
 
     Ok(())

--- a/tests/integrations/src/agglayer_setup.rs
+++ b/tests/integrations/src/agglayer_setup.rs
@@ -124,7 +124,7 @@ pub async fn start_agglayer(tmp_dir: &Path, l1: &L1Docker) -> (oneshot::Receiver
     std::fs::write(&config_file, toml).unwrap();
 
     let handle = std::thread::spawn(move || {
-        _ = agglayer_node::main(config_file);
+        _ = agglayer_node::main(config_file, "test");
         _ = shutdown.send(());
     });
     let url = format!("ws://{}/", config.rpc_addr());


### PR DESCRIPTION
# Description

Adds detailed version info cli command and prints version info on startup of node and prover.

It looks like this:

```
$ cargo run -- --version  
$ cargo run -- -V

agglayer agglayer (v0.2.0-rc.20-20-g7c3e48d-dirty) [git commit timestamp: 2025-01-08T18:13:56.000000000Z]

```


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
