### PR TITLE
fix: ppgen PPGenArgs default value failure fix

### DIFF
--- a/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
+++ b/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
@@ -25,7 +25,7 @@ struct PPGenArgs {
     n_exits: usize,
 
     /// The number of imported bridge exits.
-    #[clap(long, default_value = "0")]
+    #[clap(long, default_value = "10")]
     n_imported_exits: usize,
 
     /// The optional output directory to write the proofs in JSON. If not set,


### PR DESCRIPTION
# Description

The initial value set for `n_imported_exits` in `PPGenArgs` is 0, which the chain doesnt have tokens at the beginning to bridge out which will cause failure when building `multi_batch_header`.

### Bug fix (non-breaking change which fixes an issue)

so we need to change the `n_imported_exits` default value to some other numbers (10 worked in this case) so that n_exits can be executed.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
