### PR TITLE
feat: await for the l1 info tree entry to be finalized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "mockall",
  "thiserror 2.0.8",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -257,7 +257,7 @@ where
                     });
                 }
 
-                declared_root
+                retrieved_root
             }
             // Inconsistent declared L1 info tree entry
             (l1_leaf, l1_info_root) => {

--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -225,34 +225,50 @@ where
             .await
             .map_err(|_| CertificationError::TrustedSequencerNotFound(network_id))?;
 
-        let l1_info_leaf_count = certificate
-            .l1_info_tree_leaf_count()
-            .unwrap_or_else(|| self.l1_rpc.default_l1_info_tree_entry().0);
-
-        let l1_info_root = self
-            .l1_rpc
-            .get_l1_info_root(l1_info_leaf_count)
-            .await
-            .map_err(|_| {
-                CertificationError::L1InfoRootNotFound(certificate_id, l1_info_leaf_count)
-            })?
-            .into();
-
         let declared_l1_info_root = certificate
             .l1_info_root()
             .map_err(|source| CertificationError::Types { source })?;
 
-        if let Some(declared) = declared_l1_info_root {
-            if declared != l1_info_root {
-                return Err(CertificationError::Types {
-                    source: agglayer_types::Error::L1InfoRootIncorrect {
-                        declared,
-                        retrieved: l1_info_root,
-                        leaf_count: l1_info_leaf_count,
-                    },
-                });
+        let declared_l1_info_leaf_count = certificate.l1_info_tree_leaf_count();
+
+        let l1_info_root = match (declared_l1_info_leaf_count, declared_l1_info_root) {
+            // Use the default corresponding to the entry set by the event `InitL1InfoRootMap`
+            (None, None) => self.l1_rpc.default_l1_info_tree_entry().1.into(),
+            // Retrieve the event corresponding to the declared entry and await for finalization
+            (Some(declared_leaf), Some(declared_root)) => {
+                // Retrieve from contract and await for finalization
+                let retrieved_root = self
+                    .l1_rpc
+                    .get_l1_info_root(declared_leaf)
+                    .await
+                    .map_err(|_| {
+                        CertificationError::L1InfoRootNotFound(certificate_id, declared_leaf)
+                    })?
+                    .into();
+
+                // Check that the retrieve l1 info root is equal to the declared one
+                if declared_root != retrieved_root {
+                    return Err(CertificationError::Types {
+                        source: agglayer_types::Error::L1InfoRootIncorrect {
+                            declared: declared_root,
+                            retrieved: retrieved_root,
+                            leaf_count: declared_leaf,
+                        },
+                    });
+                }
+
+                declared_root
             }
-        }
+            // Inconsistent declared L1 info tree entry
+            (l1_leaf, l1_info_root) => {
+                return Err(CertificationError::Types {
+                    source: agglayer_types::Error::InconsistentL1InfoTreeInformation {
+                        l1_leaf,
+                        l1_info_root,
+                    },
+                })
+            }
+        };
 
         let initial_state = LocalNetworkState::from(state.clone());
 

--- a/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
@@ -66,11 +66,6 @@ async fn happy_path() {
         .return_once(|_, _| Ok(()));
 
     l1_rpc
-        .expect_get_l1_info_root()
-        .once()
-        .returning(move |_| Ok(Default::default()));
-
-    l1_rpc
         .expect_get_trusted_sequencer_address()
         .once()
         .returning(move |_, _| Ok(signer));
@@ -107,7 +102,7 @@ async fn happy_path() {
 
 #[rstest::rstest]
 #[test_log::test(tokio::test)]
-#[timeout(Duration::from_secs(10))]
+#[timeout(Duration::from_secs(20))]
 async fn prover_timeout() {
     let scenario = FailScenario::setup();
     let base_path = TempDBDir::new();
@@ -165,11 +160,6 @@ async fn prover_timeout() {
         .expect_get_trusted_sequencer_address()
         .once()
         .returning(move |_, _| Ok(signer));
-
-    l1_rpc
-        .expect_get_l1_info_root()
-        .once()
-        .returning(move |_| Ok(Default::default()));
 
     l1_rpc
         .expect_default_l1_info_tree_entry()

--- a/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, thread, time::Duration};
 
 use agglayer_certificate_orchestrator::Certifier;
 use agglayer_config::Config;
-use agglayer_contracts::Settler;
+use agglayer_contracts::{L1RpcError, Settler};
 use agglayer_prover::fake::FakeProver;
 use agglayer_storage::tests::{mocks::MockPendingStore, TempDBDir};
 use agglayer_types::{LocalNetworkStateData, NetworkId};
@@ -202,7 +202,7 @@ mockall::mock! {
             proof_signers: std::collections::HashMap<u32,ethers::types::Address> ,
         ) -> Result<ethers::types::Address, ()>;
 
-        async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], ()>;
+        async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], L1RpcError>;
         fn default_l1_info_tree_entry(&self) -> (u32, [u8; 32]);
     }
     #[async_trait::async_trait]

--- a/crates/agglayer-aggregator-notifier/src/packer/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/packer/tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use agglayer_certificate_orchestrator::EpochPacker;
 use agglayer_config::outbound::OutboundRpcSettleConfig;
-use agglayer_contracts::Settler;
+use agglayer_contracts::{L1RpcError, Settler};
 use agglayer_storage::tests::mocks::{MockPendingStore, MockPerEpochStore, MockStateStore};
 use agglayer_types::{CertificateHeader, Proof};
 use arc_swap::ArcSwap;
@@ -30,7 +30,7 @@ mockall::mock! {
             proof_signers: std::collections::HashMap<u32,ethers::types::Address> ,
         ) -> Result<ethers::types::Address, ()>;
 
-        async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], ()>;
+        async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], L1RpcError>;
         fn default_l1_info_tree_entry(&self) -> (u32, [u8; 32]);
     }
     #[async_trait::async_trait]

--- a/crates/agglayer-contracts/Cargo.toml
+++ b/crates/agglayer-contracts/Cargo.toml
@@ -12,6 +12,7 @@ ethers.workspace = true
 ethers-contract = "2.0.14"
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/agglayer-contracts/src/lib.rs
+++ b/crates/agglayer-contracts/src/lib.rs
@@ -124,8 +124,9 @@ where
             }
 
             debug!(
-                "Retrieved the default L1 Info Tree entry. leaf_count: {}, root: {:?}",
-                l1_leaf_count, l1_info_root
+                "Retrieved the default L1 Info Tree entry. leaf_count: {}, root: {}",
+                l1_leaf_count,
+                H256::from_slice(l1_info_root.as_slice())
             );
 
             // Use this entry as default
@@ -185,8 +186,10 @@ where
 
         debug!(
             "Retrieved UpdateL1InfoTreeV2 event from block {}. L1 info tree leaf count: {}, root: \
-             {:?}",
-            event_block_number, l1_leaf_count, l1_info_root
+             {}",
+            event_block_number,
+            l1_leaf_count,
+            H256::from_slice(l1_info_root.as_slice())
         );
 
         // Await for the related block to be finalized

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -124,6 +124,14 @@ pub enum Error {
         declared: Digest,
         retrieved: Digest,
     },
+    #[error(
+        "Incorrect declared L1 Info Tree information: l1_leaf: {l1_leaf:?}, l1_root: \
+         {l1_info_root:?}"
+    )]
+    InconsistentL1InfoTreeInformation {
+        l1_leaf: Option<u32>,
+        l1_info_root: Option<Digest>,
+    },
     /// The operation cannot be applied on the smt.
     #[error(transparent)]
     InvalidSmtOperation(#[from] SmtError),


### PR DESCRIPTION
# Description

- Check that the L1 Info Root / leaf count referred by the Certificate exists on the latest L1 block, reject otherwise
- Await the certifier process until that the referred L1 Info Root is referred in a finalized block

If the L1 ends up doing a reorg leading to the referred L1 info tree entry to be non-existent, then the Certificate will become `InError` with the error `CertificationError::L1InfoRootNotFound`.

Fixes #479 

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
