### PR TITLE
feat: enable backup for storage DBs with purge mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,12 +56,14 @@ dependencies = [
  "agglayer-config",
  "agglayer-node",
  "agglayer-prover",
+ "agglayer-storage",
  "anyhow",
  "assert_cmd",
  "clap",
  "dirs",
  "dotenvy",
  "insta",
+ "serde_json",
  "toml",
  "vergen-git2",
 ]
@@ -324,6 +326,7 @@ dependencies = [
  "agglayer-types",
  "arc-swap",
  "bincode",
+ "chrono",
  "criterion",
  "hex",
  "insta",
@@ -338,6 +341,7 @@ dependencies = [
  "sp1-sdk",
  "thiserror 2.0.8",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ fail = { version = "0.5.1", default-features = false }
 insta = { git = "https://github.com/freyskeyd/insta", branch = "chore/updating-deps-to-avoid-serialize-error", features = [
     "toml",
     "yaml",
+    "json",
 ] }
 mockall = "0.13.1"
 rand = "0.8.5"

--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -447,6 +447,7 @@ async fn test_certificate_orchestrator_can_stop() {
             0,
             pending_store.clone(),
             state_store.clone(),
+            BackupClient::noop(),
         )
         .expect("Unable to create store"),
     );
@@ -512,6 +513,7 @@ async fn test_collect_certificates() {
             0,
             pending_store.clone(),
             state_store.clone(),
+            BackupClient::noop(),
         )
         .expect("Unable to create store"),
     );
@@ -578,6 +580,7 @@ async fn test_collect_certificates_after_epoch() {
             0,
             pending_store.clone(),
             state_store.clone(),
+            BackupClient::noop(),
         )
         .expect("Unable to create store"),
     );
@@ -646,6 +649,7 @@ async fn test_collect_certificates_when_empty() {
             0,
             pending_store.clone(),
             state_store.clone(),
+            BackupClient::noop(),
         )
         .expect("Unable to create store"),
     );
@@ -725,6 +729,7 @@ fn check() -> (
             0,
             pending_store.clone(),
             state_store.clone(),
+            BackupClient::noop(),
         )
         .expect("Unable to create store"),
     );

--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -14,6 +14,7 @@ use agglayer_storage::{
         latest_proven_certificate_per_network::ProvenCertificate,
         latest_settled_certificate_per_network::SettledCertificate,
     },
+    storage::backup::BackupClient,
     stores::{
         epochs::EpochsStore, pending::PendingStore, per_epoch::PerEpochStore, state::StateStore,
         EpochStoreReader, EpochStoreWriter, PendingCertificateReader, PendingCertificateWriter,
@@ -437,7 +438,8 @@ async fn test_certificate_orchestrator_can_stop() {
             .expect("Unable to create store"),
     );
     let state_store = Arc::new(
-        StateStore::new_with_path(&config.storage.state_db_path).expect("Unable to create store"),
+        StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop())
+            .expect("Unable to create store"),
     );
     let epochs_store = Arc::new(
         EpochsStore::new(
@@ -500,7 +502,8 @@ async fn test_collect_certificates() {
             .expect("Unable to create store"),
     );
     let state_store = Arc::new(
-        StateStore::new_with_path(&config.storage.state_db_path).expect("Unable to create store"),
+        StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop())
+            .expect("Unable to create store"),
     );
 
     let epochs_store = Arc::new(
@@ -566,7 +569,8 @@ async fn test_collect_certificates_after_epoch() {
             .expect("Unable to create store"),
     );
     let state_store = Arc::new(
-        StateStore::new_with_path(&config.storage.state_db_path).expect("Unable to create store"),
+        StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop())
+            .expect("Unable to create store"),
     );
     let epochs_store = Arc::new(
         EpochsStore::new(
@@ -633,7 +637,8 @@ async fn test_collect_certificates_when_empty() {
             .expect("Unable to create store"),
     );
     let state_store = Arc::new(
-        StateStore::new_with_path(&config.storage.state_db_path).expect("Unable to create store"),
+        StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop())
+            .expect("Unable to create store"),
     );
     let epochs_store = Arc::new(
         EpochsStore::new(
@@ -711,7 +716,8 @@ fn check() -> (
             .expect("Unable to create store"),
     );
     let state_store = Arc::new(
-        StateStore::new_with_path(&config.storage.state_db_path).expect("Unable to create store"),
+        StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop())
+            .expect("Unable to create store"),
     );
     let epochs_store = Arc::new(
         EpochsStore::new(

--- a/crates/agglayer-config/src/storage.rs
+++ b/crates/agglayer-config/src/storage.rs
@@ -2,6 +2,7 @@ use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 
+use backup::BackupConfig;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -11,6 +12,8 @@ const PENDING_DB_NAME: &str = "pending";
 const STATE_DB_NAME: &str = "state";
 const EPOCHS_DB_PATH: &str = "epochs";
 const DEBUG_DB_PATH: &str = "debug";
+
+pub mod backup;
 
 /// Configuration for the storage.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -27,6 +30,8 @@ pub struct StorageConfig {
     pub epochs_db_path: PathBuf,
     /// Custom debug storage path or inferred from the db path.
     pub debug_db_path: PathBuf,
+    /// Backup config
+    pub backup: BackupConfig,
 }
 
 impl Default for StorageConfig {
@@ -37,6 +42,7 @@ impl Default for StorageConfig {
             state_db_path: Path::new("./").join(STORAGE_DIR).join(STATE_DB_NAME),
             epochs_db_path: Path::new("./").join(STORAGE_DIR).join(EPOCHS_DB_PATH),
             debug_db_path: Path::new("./").join(STORAGE_DIR).join(DEBUG_DB_PATH),
+            backup: BackupConfig::default(),
         }
     }
 }
@@ -67,6 +73,7 @@ impl StorageConfig {
             state_db_path: db_path.join(STATE_DB_NAME),
             epochs_db_path: db_path.join(EPOCHS_DB_PATH),
             debug_db_path: db_path.join(DEBUG_DB_PATH),
+            backup: BackupConfig::default(),
         }
     }
 }
@@ -87,6 +94,9 @@ struct StorageConfigHelper {
     pub epochs_db_path: Option<PathBuf>,
     /// Custom debug storage path or inferred from the db path.
     pub debug_db_path: Option<PathBuf>,
+    /// Backup config.
+    #[serde(default, skip_serializing_if = "BackupConfig::is_disabled")]
+    pub backup: BackupConfig,
 }
 
 impl From<StorageConfigHelper> for StorageConfig {
@@ -107,6 +117,7 @@ impl From<StorageConfigHelper> for StorageConfig {
             debug_db_path: value
                 .debug_db_path
                 .unwrap_or_else(|| value.db_path.join(DEBUG_DB_PATH)),
+            backup: value.backup,
         }
     }
 }
@@ -126,6 +137,7 @@ impl From<StorageConfig> for StorageConfigHelper {
             state_db_path: None,
             epochs_db_path: None,
             debug_db_path: None,
+            backup: value.backup,
         }
     }
 }

--- a/crates/agglayer-config/src/storage/backup.rs
+++ b/crates/agglayer-config/src/storage/backup.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for Storage backups.
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum BackupConfig {
+    /// Backups are disabled.
+    #[default]
+    Disabled,
+
+    /// Backups are enabled.
+    Enabled {
+        /// Path to the directory where backups are stored.
+        path: PathBuf,
+        /// Maximum number of backups to keep for the state storage.
+        #[serde(default = "default_max_backup_number")]
+        state_max_backup_number: usize,
+        /// Maximum number of backups to keep for the pending storage.
+        #[serde(default = "default_max_backup_number")]
+        pending_max_backup_number: usize,
+    },
+}
+
+impl BackupConfig {
+    /// Default maximum number of backups to keep.
+    const DEFAULT_MAX_BACKUP_NUMBER: usize = 100;
+
+    pub fn with_path<P: Into<PathBuf>>(path: P) -> Self {
+        BackupConfig::Enabled {
+            path: path.into(),
+            state_max_backup_number: default_max_backup_number(),
+            pending_max_backup_number: default_max_backup_number(),
+        }
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        *self == BackupConfig::Disabled
+    }
+}
+
+const fn default_max_backup_number() -> usize {
+    BackupConfig::DEFAULT_MAX_BACKUP_NUMBER
+}

--- a/crates/agglayer-config/src/storage/backup.rs
+++ b/crates/agglayer-config/src/storage/backup.rs
@@ -11,15 +11,16 @@ pub enum BackupConfig {
     Disabled,
 
     /// Backups are enabled.
+    #[serde(untagged)]
     Enabled {
         /// Path to the directory where backups are stored.
         path: PathBuf,
         /// Maximum number of backups to keep for the state storage.
         #[serde(default = "default_max_backup_number")]
-        state_max_backup_number: usize,
+        state_max_backup_count: usize,
         /// Maximum number of backups to keep for the pending storage.
         #[serde(default = "default_max_backup_number")]
-        pending_max_backup_number: usize,
+        pending_max_backup_count: usize,
     },
 }
 
@@ -30,8 +31,8 @@ impl BackupConfig {
     pub fn with_path<P: Into<PathBuf>>(path: P) -> Self {
         BackupConfig::Enabled {
             path: path.into(),
-            state_max_backup_number: default_max_backup_number(),
-            pending_max_backup_number: default_max_backup_number(),
+            state_max_backup_count: default_max_backup_number(),
+            pending_max_backup_count: default_max_backup_number(),
         }
     }
 

--- a/crates/agglayer-config/tests/backup.rs
+++ b/crates/agglayer-config/tests/backup.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+
+use agglayer_config::Config;
+use insta::assert_toml_snapshot;
+
+#[test]
+fn empty_rpcs() {
+    let input = "./tests/fixtures/valide_config/backup_enabled.toml";
+
+    let config = Config::try_load(Path::new(input)).unwrap();
+
+    assert_toml_snapshot!(config, {
+        ".storage.*" => insta::dynamic_redaction(|value, path| {
+            if path.to_string() != "storage.db-path" {
+                if let insta::internals::Content::String(path) = value {
+                    return insta::internals::Content::String(path.replace(Path::new("./").canonicalize().unwrap().to_str().unwrap(), "/tmp/agglayer"));
+                }
+            }
+
+            value
+        }),
+    });
+}

--- a/crates/agglayer-config/tests/backup.rs
+++ b/crates/agglayer-config/tests/backup.rs
@@ -4,7 +4,7 @@ use agglayer_config::Config;
 use insta::assert_toml_snapshot;
 
 #[test]
-fn empty_rpcs() {
+fn backup_enabled() {
     let input = "./tests/fixtures/valide_config/backup_enabled.toml";
 
     let config = Config::try_load(Path::new(input)).unwrap();

--- a/crates/agglayer-config/tests/fixtures/valide_config/backup_enabled.toml
+++ b/crates/agglayer-config/tests/fixtures/valide_config/backup_enabled.toml
@@ -1,2 +1,2 @@
-[storage.backup.enabled]
+[storage.backup]
 path = "./test/"

--- a/crates/agglayer-config/tests/fixtures/valide_config/backup_enabled.toml
+++ b/crates/agglayer-config/tests/fixtures/valide_config/backup_enabled.toml
@@ -1,0 +1,2 @@
+[storage.backup.enabled]
+path = "./test/"

--- a/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
+++ b/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
@@ -62,7 +62,7 @@ input-backpressure-buffer-size = 1000
 [storage]
 db-path = "/tmp/agglayer/tests/fixtures/valide_config/storage"
 
-[storage.backup.enabled]
+[storage.backup]
 path = "./test/"
-state_max_backup_number = 100
-pending_max_backup_number = 100
+state_max_backup_count = 100
+pending_max_backup_count = 100

--- a/crates/agglayer-config/tests/snapshots/backup__empty_rpcs.snap
+++ b/crates/agglayer-config/tests/snapshots/backup__empty_rpcs.snap
@@ -1,0 +1,68 @@
+---
+source: crates/agglayer-config/tests/backup.rs
+expression: config
+---
+prover-entrypoint = "http://127.0.0.1:8080"
+
+[full-node-rpcs]
+
+[l2]
+rpc-timeout = "45s"
+
+[proof-signers]
+
+[log]
+level = "info"
+outputs = []
+format = "pretty"
+
+[rpc]
+port = 9090
+host = "0.0.0.0"
+request-timeout = "3m"
+
+[rate-limiting]
+send-tx = "unlimited"
+
+[rate-limiting.network]
+
+[outbound.rpc.settle]
+max-retries = 3
+retry-interval = "7s"
+confirmations = 1
+settlement-timeout = "20m"
+
+[l1]
+chain-id = 1337
+node-url = "http://zkevm-mock-l1-network:8545/"
+ws-node-url = "ws://zkevm-mock-l1-network:8546/"
+max-reconnection-elapsed-time = "10s"
+rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+polygon-zkevm-global-exit-root-v2-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+rpc-timeout = "45s"
+
+[auth.local]
+private-keys = []
+
+[telemetry]
+prometheus-addr = "0.0.0.0:3000"
+
+[epoch.block-clock]
+epoch-duration = 6
+genesis-block = 0
+
+[shutdown]
+runtime-timeout = "5s"
+
+[certificate-orchestrator]
+input-backpressure-buffer-size = 1000
+
+[certificate-orchestrator.prover.sp1-local]
+
+[storage]
+db-path = "/tmp/agglayer/tests/fixtures/valide_config/storage"
+
+[storage.backup.enabled]
+path = "./test/"
+state_max_backup_number = 100
+pending_max_backup_number = 100

--- a/crates/agglayer-node/src/epoch_synchronizer.rs
+++ b/crates/agglayer-node/src/epoch_synchronizer.rs
@@ -103,7 +103,7 @@ mod tests {
     use agglayer_config::Config;
     use agglayer_storage::{
         columns::epochs::end_checkpoint::EndCheckpointColumn,
-        storage::epochs_db_cf_definitions,
+        storage::{backup::BackupClient, epochs_db_cf_definitions},
         stores::{
             epochs::EpochsStore, pending::PendingStore, state::StateStore, PendingCertificateWriter,
         },
@@ -276,8 +276,9 @@ mod tests {
     async fn lse_number_is_less_than_loe_real_db() {
         let tmp = TempDBDir::new();
         let config = Arc::new(Config::new(&tmp.path));
-        let state_store =
-            Arc::new(StateStore::new_with_path(&config.storage.state_db_path).unwrap());
+        let state_store = Arc::new(
+            StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop()).unwrap(),
+        );
         let pending_store =
             Arc::new(PendingStore::new_with_path(&config.storage.pending_db_path).unwrap());
 
@@ -396,8 +397,9 @@ mod tests {
     async fn current_epoch_should_be_open() {
         let tmp = TempDBDir::new();
         let config = Arc::new(Config::new(&tmp.path));
-        let state_store =
-            Arc::new(StateStore::new_with_path(&config.storage.state_db_path).unwrap());
+        let state_store = Arc::new(
+            StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop()).unwrap(),
+        );
         let pending_store =
             Arc::new(PendingStore::new_with_path(&config.storage.pending_db_path).unwrap());
 

--- a/crates/agglayer-node/src/epoch_synchronizer.rs
+++ b/crates/agglayer-node/src/epoch_synchronizer.rs
@@ -288,6 +288,7 @@ mod tests {
                 15,
                 pending_store.clone(),
                 state_store.clone(),
+                BackupClient::noop(),
             )
             .unwrap(),
         );
@@ -409,6 +410,7 @@ mod tests {
                 15,
                 pending_store.clone(),
                 state_store.clone(),
+                BackupClient::noop(),
             )
             .unwrap(),
         );

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -27,7 +27,11 @@ use agglayer_telemetry::ServerBuilder as MetricsBuilder;
 ///
 /// This function returns on fatal error or after graceful shutdown has
 /// completed.
-pub fn main(cfg: PathBuf, version: &str) -> Result<()> {
+pub fn main(
+    cfg: PathBuf,
+    version: &str,
+    cancellation_token: Option<CancellationToken>,
+) -> Result<()> {
     let cfg = cfg.canonicalize().map_err(|_| {
         anyhow::Error::msg(format!(
             "Configuration file path must be absolute, given: {}",
@@ -45,7 +49,11 @@ pub fn main(cfg: PathBuf, version: &str) -> Result<()> {
         )
     };
 
-    let global_cancellation_token = CancellationToken::new();
+    let global_cancellation_token = cancellation_token.unwrap_or_default();
+
+    if global_cancellation_token.is_cancelled() {
+        bail!("Received cancellation signal before starting the node.");
+    }
 
     // Initialize the logger
     logging::tracing(&config.log);

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -3,14 +3,17 @@ use std::{num::NonZeroU64, sync::Arc};
 use agglayer_aggregator_notifier::{CertifierClient, EpochPackerClient};
 use agglayer_certificate_orchestrator::CertificateOrchestrator;
 use agglayer_clock::{BlockClock, Clock, TimeClock};
-use agglayer_config::{Config, Epoch};
+use agglayer_config::{storage::backup::BackupConfig, Config, Epoch};
 use agglayer_contracts::{
     polygon_rollup_manager::PolygonRollupManager,
     polygon_zkevm_global_exit_root_v2::PolygonZkEVMGlobalExitRootV2, L1RpcClient,
 };
 use agglayer_signer::ConfiguredSigner;
 use agglayer_storage::{
-    storage::DB,
+    storage::{
+        backup::{BackupClient, BackupEngine},
+        DB,
+    },
     stores::{
         debug::DebugStore, epochs::EpochsStore, pending::PendingStore, state::StateStore,
         PerEpochReader as _,
@@ -87,7 +90,27 @@ impl Node {
             agglayer_storage::storage::state_db_cf_definitions(),
         )?);
 
-        let state_store = Arc::new(StateStore::new(state_db.clone()));
+        // Initialize backup engine
+        let backup_client = if let BackupConfig::Enabled {
+            path,
+            state_max_backup_number,
+            pending_max_backup_number,
+        } = &config.storage.backup
+        {
+            let (backup_engine, client) = BackupEngine::new(
+                path,
+                state_db.clone(),
+                pending_db.clone(),
+                *state_max_backup_number,
+                *pending_max_backup_number,
+            )?;
+            tokio::spawn(async move { backup_engine.run().await });
+
+            client
+        } else {
+            BackupClient::noop()
+        };
+        let state_store = Arc::new(StateStore::new(state_db.clone(), backup_client));
         let pending_store = Arc::new(PendingStore::new(pending_db.clone()));
         let debug_store = if config.debug_mode {
             Arc::new(DebugStore::new_with_path(&config.storage.debug_db_path)?)

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -93,19 +93,19 @@ impl Node {
         // Initialize backup engine
         let backup_client = if let BackupConfig::Enabled {
             path,
-            state_max_backup_number,
-            pending_max_backup_number,
+            state_max_backup_count,
+            pending_max_backup_count,
         } = &config.storage.backup
         {
             let (backup_engine, client) = BackupEngine::new(
                 path,
                 state_db.clone(),
                 pending_db.clone(),
-                *state_max_backup_number,
-                *pending_max_backup_number,
+                *state_max_backup_count,
+                *pending_max_backup_count,
+                cancellation_token.clone(),
             )?;
-            let backup_engine_cancellation_token = cancellation_token.child_token();
-            tokio::spawn(async move { backup_engine.run(backup_engine_cancellation_token).await });
+            tokio::spawn(backup_engine.run());
 
             client
         } else {
@@ -162,7 +162,7 @@ impl Node {
             current_epoch,
             pending_store.clone(),
             state_store.clone(),
-            backup_client.clone(),
+            backup_client,
         )?);
 
         info!("Epoch synchronization started.");

--- a/crates/agglayer-node/src/rpc/tests/get_latest_known_certificate_header.rs
+++ b/crates/agglayer-node/src/rpc/tests/get_latest_known_certificate_header.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use agglayer_config::Config;
 use agglayer_storage::{
-    storage::{pending_db_cf_definitions, state_db_cf_definitions, DB},
+    storage::{backup::BackupClient, pending_db_cf_definitions, state_db_cf_definitions, DB},
     stores::{pending::PendingStore, state::StateStore, PendingCertificateWriter, StateWriter},
     tests::TempDBDir,
 };
@@ -30,7 +30,7 @@ async fn returns_the_pending_certificate_header() {
             .expect("unable to open state db"),
     );
 
-    let state_db = StateStore::new(state_db);
+    let state_db = StateStore::new(state_db, BackupClient::noop());
     let pending_db = PendingStore::new(pending_db);
     let network_id = 1.into();
 
@@ -122,7 +122,7 @@ async fn returns_the_proven_certificate_header() {
             .expect("unable to open state db"),
     );
 
-    let state_db = StateStore::new(state_db);
+    let state_db = StateStore::new(state_db, BackupClient::noop());
     let pending_db = PendingStore::new(pending_db);
     let network_id = 1.into();
 
@@ -205,7 +205,7 @@ async fn returns_the_settled_certificate_header() {
             .expect("unable to open state db"),
     );
 
-    let state_db = StateStore::new(state_db);
+    let state_db = StateStore::new(state_db, BackupClient::noop());
     let pending_db = PendingStore::new(pending_db);
     let network_id = 1.into();
 
@@ -333,7 +333,7 @@ async fn returns_the_highest_height() {
             .expect("unable to open state db"),
     );
 
-    let state_db = StateStore::new(state_db);
+    let state_db = StateStore::new(state_db, BackupClient::noop());
     let pending_db = PendingStore::new(pending_db);
     let network_id = 1.into();
 

--- a/crates/agglayer-node/src/rpc/tests/get_tx_status.rs
+++ b/crates/agglayer-node/src/rpc/tests/get_tx_status.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use agglayer_config::Config;
+use agglayer_storage::storage::backup::BackupClient;
 use agglayer_storage::storage::{pending_db_cf_definitions, state_db_cf_definitions, DB};
 use agglayer_storage::stores::debug::DebugStore;
 use agglayer_storage::stores::pending::PendingStore;
@@ -104,7 +105,7 @@ async fn check_tx_status_fail() {
     let tmp = TempDBDir::new();
     let store_db = Arc::new(DB::open_cf(tmp.path.as_path(), state_db_cf_definitions()).unwrap());
     let store = Arc::new(PendingStore::new(db));
-    let state = Arc::new(StateStore::new(store_db));
+    let state = Arc::new(StateStore::new(store_db, BackupClient::noop()));
     let debug = Arc::new(DebugStore::new_with_path(&tmp.path.join("debug")).unwrap());
 
     let _server_handle = AgglayerImpl::new(

--- a/crates/agglayer-node/src/rpc/tests/mod.rs
+++ b/crates/agglayer-node/src/rpc/tests/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use agglayer_config::Config;
 use agglayer_storage::columns::latest_settled_certificate_per_network::SettledCertificate;
+use agglayer_storage::storage::backup::BackupClient;
 use agglayer_storage::storage::{pending_db_cf_definitions, state_db_cf_definitions, DB};
 use agglayer_storage::stores::debug::DebugStore;
 use agglayer_storage::stores::pending::PendingStore;
@@ -138,7 +139,7 @@ impl TestContext {
             DB::open_cf(&config.storage.pending_db_path, pending_db_cf_definitions()).unwrap(),
         );
 
-        let state_store = Arc::new(StateStore::new(state_db));
+        let state_store = Arc::new(StateStore::new(state_db, BackupClient::noop()));
         let pending_store = Arc::new(PendingStore::new(pending_db));
         let debug_store = if config.debug_mode {
             Arc::new(DebugStore::new_with_path(&config.storage.debug_db_path).unwrap())

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -13,6 +13,7 @@ rand = { version = "0.8.5", optional = true }
 rocksdb = "0.22.0"
 serde.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 
 agglayer-config = { path = "../agglayer-config" }

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -5,15 +5,17 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+thiserror.workspace = true
 arc-swap.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 bincode.workspace = true
 hex.workspace = true
 parking_lot.workspace = true
 rand = { version = "0.8.5", optional = true }
 rocksdb = "0.22.0"
 serde.workspace = true
-thiserror.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 
 agglayer-config = { path = "../agglayer-config" }

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -5,17 +5,17 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-thiserror.workspace = true
 arc-swap.workspace = true
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
 bincode.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 hex.workspace = true
 parking_lot.workspace = true
 rand = { version = "0.8.5", optional = true }
 rocksdb = "0.22.0"
 serde.workspace = true
-tokio.workspace = true
+thiserror.workspace = true
 tokio-util.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 
 agglayer-config = { path = "../agglayer-config" }
@@ -25,14 +25,14 @@ pessimistic-proof = { path = "../pessimistic-proof" }
 mockall = { workspace = true, optional = true }
 
 [dev-dependencies]
-tokio.workspace = true
 criterion = "0.5.1"
 insta.workspace = true
 rand.workspace = true
 rstest.workspace = true
 sp1-sdk.workspace = true
+tokio.workspace = true
 
-agglayer-types = {workspace = true, features = ["testutils"] }
+agglayer-types = { workspace = true, features = ["testutils"] }
 pessimistic-proof-test-suite = { path = "../pessimistic-proof-test-suite" }
 
 agglayer-storage = { path = ".", features = ["testutils"] }

--- a/crates/agglayer-storage/benches/latest_certificate_bench.rs
+++ b/crates/agglayer-storage/benches/latest_certificate_bench.rs
@@ -8,7 +8,7 @@ use agglayer_storage::{
     columns::latest_settled_certificate_per_network::{
         LatestSettledCertificatePerNetworkColumn, SettledCertificate,
     },
-    storage::{state_db_cf_definitions, DB},
+    storage::{backup::BackupClient, state_db_cf_definitions, DB},
     stores::{state::StateStore, StateReader as _},
 };
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -47,7 +47,7 @@ fn bench_latest_certificate(c: &mut Criterion) {
             )
             .expect("Unable to put certificate into storage");
         }
-        let store = StateStore::new(db.clone());
+        let store = StateStore::new(db.clone(), BackupClient::noop());
         let now = Instant::now();
         let iterator = store.get_active_networks().expect("Unable to get keys");
         let elapsed = now.elapsed();

--- a/crates/agglayer-storage/src/storage/backup/mod.rs
+++ b/crates/agglayer-storage/src/storage/backup/mod.rs
@@ -1,10 +1,17 @@
 use std::{
+    collections::BTreeMap,
+    fs::read_dir,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
-use rocksdb::backup::{BackupEngine as RocksBackupEngine, RestoreOptions};
+use rocksdb::backup::{
+    BackupEngine as RocksBackupEngine, BackupEngineInfo as RocksBackupEngineInfo,
+    BackupEngineOptions, RestoreOptions,
+};
+use serde::{Deserialize, Serialize};
 use tokio::sync;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 use super::{BackupError, DB};
@@ -16,6 +23,7 @@ pub struct BackupRequest {
 }
 
 /// Client used to request a backup.
+#[derive(Clone)]
 pub struct BackupClient {
     sender: Option<sync::mpsc::Sender<BackupRequest>>,
 }
@@ -79,6 +87,9 @@ impl BackupEngine {
 
         let (sender, backup_request) = sync::mpsc::channel(10);
 
+        let epochs_path = path.join("epochs");
+        std::fs::create_dir_all(&epochs_path)?;
+
         Ok((
             Self {
                 state_engine: RocksBackupEngine::open(&state_opts, &env)?,
@@ -86,7 +97,7 @@ impl BackupEngine {
                 env,
                 state_db,
                 pending_db,
-                epochs_path: path.join("epochs"),
+                epochs_path,
                 backup_request,
                 state_max_backup_number,
                 pending_max_backup_number,
@@ -101,34 +112,6 @@ impl BackupEngine {
     /// This function will also purge old backups as configured.
     pub fn create_new_backup(&mut self, request: &BackupRequest) -> Result<(), BackupError> {
         info!("Creating new backup");
-
-        if let Err(error) = self
-            .state_engine
-            .create_new_backup_flush(&self.state_db.rocksdb, true)
-        {
-            error!("Failed to create backup for state db: {:?}", error);
-        }
-
-        if let Err(error) = self
-            .state_engine
-            .purge_old_backups(self.state_max_backup_number)
-        {
-            error!("Failed to purge old backup for state db: {:?}", error);
-        }
-
-        if let Err(error) = self
-            .pending_engine
-            .create_new_backup_flush(&self.pending_db.rocksdb, true)
-        {
-            error!("Failed to create backup for pending db: {:?}", error);
-        }
-
-        if let Err(error) = self
-            .pending_engine
-            .purge_old_backups(self.pending_max_backup_number)
-        {
-            error!("Failed to purge old backup for pending db: {:?}", error);
-        }
 
         if let Some((db, epoch_number)) = request.epoch_db.as_ref() {
             let epochs_opts = rocksdb::backup::BackupEngineOptions::new(
@@ -145,6 +128,34 @@ impl BackupEngine {
                     }
                 }
             }
+        } else {
+            if let Err(error) = self
+                .state_engine
+                .create_new_backup_flush(&self.state_db.rocksdb, true)
+            {
+                error!("Failed to create backup for state db: {:?}", error);
+            }
+
+            if let Err(error) = self
+                .state_engine
+                .purge_old_backups(self.state_max_backup_number)
+            {
+                error!("Failed to purge old backup for state db: {:?}", error);
+            }
+
+            if let Err(error) = self
+                .pending_engine
+                .create_new_backup_flush(&self.pending_db.rocksdb, true)
+            {
+                error!("Failed to create backup for pending db: {:?}", error);
+            }
+
+            if let Err(error) = self
+                .pending_engine
+                .purge_old_backups(self.pending_max_backup_number)
+            {
+                error!("Failed to purge old backup for pending db: {:?}", error);
+            }
         }
 
         info!("Backup successfully created");
@@ -153,13 +164,16 @@ impl BackupEngine {
     }
 
     /// Run the backup engine, listen for new backup requests.
-    pub async fn run(mut self) -> Result<(), BackupError> {
+    pub async fn run(mut self, cancellation_token: CancellationToken) -> Result<(), BackupError> {
         loop {
             tokio::select! {
+                _ = cancellation_token.cancelled() => {
+                    info!("Backup engine cancelled");
+                    break;
+                }
                 Some(request) = self.backup_request.recv() =>{
                     self.create_new_backup(&request)?;
                 }
-                else => break
             }
         }
 
@@ -177,6 +191,56 @@ impl BackupEngine {
 
         Ok(engine.restore_from_latest_backup(db_path, db_path, &RestoreOptions::default())?)
     }
+
+    /// Restore the state database from the defined backup version.
+    pub fn restore_at(path: &Path, db_path: &Path, version: u32) -> Result<(), BackupError> {
+        let env = rocksdb::Env::new()?;
+        let opts = rocksdb::backup::BackupEngineOptions::new(path)?;
+
+        let mut engine = RocksBackupEngine::open(&opts, &env)?;
+
+        std::fs::create_dir_all(db_path).unwrap();
+
+        Ok(engine.restore_from_backup(db_path, db_path, &RestoreOptions::default(), version)?)
+    }
+
+    pub fn list_backups(path: &Path) -> Result<BackupReport, BackupError> {
+        let env = rocksdb::Env::new()?;
+
+        let mut report = BackupReport::default();
+
+        let opts = BackupEngineOptions::new(path.join("state"))?;
+        let engine = RocksBackupEngine::open(&opts, &env)?;
+
+        report.state(engine.get_backup_info());
+
+        let opts = BackupEngineOptions::new(path.join("pending"))?;
+        let engine = RocksBackupEngine::open(&opts, &env)?;
+
+        report.pending(engine.get_backup_info());
+
+        let epoch_path = path.join("epochs");
+        let mut epochs = (read_dir(&epoch_path)?)
+            .flatten()
+            .filter_map(|d| {
+                d.file_name()
+                    .to_string_lossy()
+                    .parse::<u64>()
+                    .map(|r| (r, d.path()))
+                    .ok()
+            })
+            .collect::<Vec<_>>();
+
+        epochs.sort_by(|(p, _), (n, _)| p.cmp(n));
+
+        for (epoch_number, path) in epochs {
+            let opts = BackupEngineOptions::new(path)?;
+            let engine = RocksBackupEngine::open(&opts, &env)?;
+            report.epochs(epoch_number, engine.get_backup_info());
+        }
+
+        Ok(report)
+    }
 }
 
 impl Drop for BackupEngine {
@@ -187,5 +251,77 @@ impl Drop for BackupEngine {
         self.env.set_bottom_priority_background_threads(0);
 
         self.env.join_all_threads();
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct BackupReport {
+    epochs: BTreeMap<u64, Vec<BackupEngineInfo>>,
+    state: Vec<BackupEngineInfo>,
+    pending: Vec<BackupEngineInfo>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BackupEngineInfo {
+    pub backup_id: u32,
+    #[serde(serialize_with = "timestamp_to_readable")]
+    pub timestamp: i64,
+    pub size: u64,
+    pub num_files: u32,
+}
+
+fn timestamp_to_readable<S>(timestamp: &i64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    chrono::DateTime::<chrono::Utc>::from_timestamp(*timestamp, 0)
+        .unwrap_or_default()
+        .to_rfc2822()
+        .serialize(serializer)
+}
+
+impl From<RocksBackupEngineInfo> for BackupEngineInfo {
+    fn from(info: RocksBackupEngineInfo) -> Self {
+        Self {
+            backup_id: info.backup_id,
+            timestamp: info.timestamp,
+            size: info.size,
+            num_files: info.num_files,
+        }
+    }
+}
+
+impl BackupReport {
+    pub fn state<V: IntoIterator<Item = T>, T: Into<BackupEngineInfo>>(&mut self, value: V) {
+        self.state = value.into_iter().map(Into::into).collect();
+    }
+
+    pub fn pending<V: IntoIterator<Item = T>, T: Into<BackupEngineInfo>>(&mut self, value: V) {
+        self.pending = value.into_iter().map(Into::into).collect();
+    }
+
+    pub fn epochs<V: IntoIterator<Item = T>, T: Into<BackupEngineInfo>>(
+        &mut self,
+        key: u64,
+        value: V,
+    ) {
+        self.epochs
+            .insert(key, value.into_iter().map(Into::into).collect());
+    }
+
+    pub fn get_state(&self) -> &[BackupEngineInfo] {
+        self.state.as_slice()
+    }
+
+    pub fn get_pending(&self) -> &[BackupEngineInfo] {
+        self.pending.as_slice()
+    }
+
+    pub fn get_epochs(&self) -> &BTreeMap<u64, Vec<BackupEngineInfo>> {
+        &self.epochs
+    }
+
+    pub fn get_epoch(&self, epoch: u64) -> Option<&Vec<BackupEngineInfo>> {
+        self.epochs.get(&epoch)
     }
 }

--- a/crates/agglayer-storage/src/storage/backup/mod.rs
+++ b/crates/agglayer-storage/src/storage/backup/mod.rs
@@ -1,0 +1,191 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use rocksdb::backup::{BackupEngine as RocksBackupEngine, RestoreOptions};
+use tokio::sync;
+use tracing::{error, info};
+
+use super::{BackupError, DB};
+
+/// Request to create a new backup.
+pub struct BackupRequest {
+    /// Optional epoch db to backup.
+    pub epoch_db: Option<(Arc<DB>, u64)>,
+}
+
+/// Client used to request a backup.
+pub struct BackupClient {
+    sender: Option<sync::mpsc::Sender<BackupRequest>>,
+}
+
+impl BackupClient {
+    /// Create a new backup client that do nothing.
+    /// This is useful for tests or when the backup is disabled.
+    pub fn noop() -> BackupClient {
+        BackupClient { sender: None }
+    }
+
+    /// Send a backup request.
+    ///
+    /// This function will send the request to the backup engine.
+    pub fn backup(&self, request: BackupRequest) -> Result<(), BackupError> {
+        if let Some(sender) = &self.sender {
+            let slot = sender
+                .try_reserve()
+                .map_err(|_| BackupError::UnableToSendBackupRequest)?;
+
+            slot.send(request);
+        }
+
+        Ok(())
+    }
+}
+
+/// Backup engine that creates backups for the state, pending and epochs
+/// databases.
+pub struct BackupEngine {
+    env: rocksdb::Env,
+    pending_engine: RocksBackupEngine,
+    state_engine: RocksBackupEngine,
+    state_db: Arc<DB>,
+    pending_db: Arc<DB>,
+    epochs_path: PathBuf,
+    backup_request: sync::mpsc::Receiver<BackupRequest>,
+    state_max_backup_number: usize,
+    pending_max_backup_number: usize,
+}
+
+// # Safety
+//
+// RocksBackupEngine is a simple pointer wrapper, so it's safe to send to
+// another thread since the underlying RocksDB backup engine is thread-safe.
+unsafe impl Send for BackupEngine {}
+
+impl BackupEngine {
+    /// Create a new backup engine, return the engine and a client to request
+    /// backups.
+    pub fn new(
+        path: &Path,
+        state_db: Arc<DB>,
+        pending_db: Arc<DB>,
+        state_max_backup_number: usize,
+        pending_max_backup_number: usize,
+    ) -> Result<(Self, BackupClient), BackupError> {
+        let env = rocksdb::Env::new()?;
+        let pending_opts = rocksdb::backup::BackupEngineOptions::new(path.join("pending"))?;
+        let state_opts = rocksdb::backup::BackupEngineOptions::new(path.join("state"))?;
+
+        let (sender, backup_request) = sync::mpsc::channel(10);
+
+        Ok((
+            Self {
+                state_engine: RocksBackupEngine::open(&state_opts, &env)?,
+                pending_engine: RocksBackupEngine::open(&pending_opts, &env)?,
+                env,
+                state_db,
+                pending_db,
+                epochs_path: path.join("epochs"),
+                backup_request,
+                state_max_backup_number,
+                pending_max_backup_number,
+            },
+            BackupClient {
+                sender: Some(sender),
+            },
+        ))
+    }
+
+    /// Create a new backup for the state, pending and epochs databases.
+    /// This function will also purge old backups as configured.
+    pub fn create_new_backup(&mut self, request: &BackupRequest) -> Result<(), BackupError> {
+        info!("Creating new backup");
+
+        if let Err(error) = self
+            .state_engine
+            .create_new_backup_flush(&self.state_db.rocksdb, true)
+        {
+            error!("Failed to create backup for state db: {:?}", error);
+        }
+
+        if let Err(error) = self
+            .state_engine
+            .purge_old_backups(self.state_max_backup_number)
+        {
+            error!("Failed to purge old backup for state db: {:?}", error);
+        }
+
+        if let Err(error) = self
+            .pending_engine
+            .create_new_backup_flush(&self.pending_db.rocksdb, true)
+        {
+            error!("Failed to create backup for pending db: {:?}", error);
+        }
+
+        if let Err(error) = self
+            .pending_engine
+            .purge_old_backups(self.pending_max_backup_number)
+        {
+            error!("Failed to purge old backup for pending db: {:?}", error);
+        }
+
+        if let Some((db, epoch_number)) = request.epoch_db.as_ref() {
+            let epochs_opts = rocksdb::backup::BackupEngineOptions::new(
+                self.epochs_path.join(format!("{}", epoch_number)),
+            )?;
+
+            match RocksBackupEngine::open(&epochs_opts, &self.env) {
+                Err(error) => {
+                    error!("Failed to open backup engine for epoch db: {:?}", error);
+                }
+                Ok(mut engine) => {
+                    if let Err(error) = engine.create_new_backup_flush(&db.rocksdb, true) {
+                        error!("Failed to create backup for epoch db: {:?}", error);
+                    }
+                }
+            }
+        }
+
+        info!("Backup successfully created");
+
+        Ok(())
+    }
+
+    /// Run the backup engine, listen for new backup requests.
+    pub async fn run(mut self) -> Result<(), BackupError> {
+        loop {
+            tokio::select! {
+                Some(request) = self.backup_request.recv() =>{
+                    self.create_new_backup(&request)?;
+                }
+                else => break
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Restore the state database from the latest backup.
+    pub fn restore(path: &Path, db_path: &Path) -> Result<(), BackupError> {
+        let env = rocksdb::Env::new()?;
+        let opts = rocksdb::backup::BackupEngineOptions::new(path)?;
+
+        let mut engine = RocksBackupEngine::open(&opts, &env)?;
+
+        std::fs::create_dir_all(db_path).unwrap();
+
+        Ok(engine.restore_from_latest_backup(db_path, db_path, &RestoreOptions::default())?)
+    }
+}
+
+impl Drop for BackupEngine {
+    fn drop(&mut self) {
+        self.env.set_background_threads(0);
+        self.env.set_low_priority_background_threads(0);
+        self.env.set_high_priority_background_threads(0);
+        self.env.set_bottom_priority_background_threads(0);
+
+        self.env.join_all_threads();
+    }
+}

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -36,6 +36,9 @@ pub enum BackupError {
 
     #[error("RocksDB error: {0}")]
     RocksDB(#[from] rocksdb::Error),
+
+    #[error("IO Error: {0}")]
+    IO(#[from] std::io::Error),
 }
 
 /// A physical storage storage component with an active RocksDB.

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -10,6 +10,8 @@ use crate::columns::{Codec, ColumnSchema};
 pub(crate) mod cf_definitions;
 pub(crate) mod iterators;
 
+pub mod backup;
+
 pub use cf_definitions::debug::debug_db_cf_definitions;
 pub use cf_definitions::epochs::epochs_db_cf_definitions;
 pub use cf_definitions::pending::pending_db_cf_definitions;
@@ -25,6 +27,15 @@ pub enum DBError {
 
     #[error("Trying to access an unknown ColumnFamily")]
     ColumnFamilyNotFound,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BackupError {
+    #[error("Unable to send backup request")]
+    UnableToSendBackupRequest,
+
+    #[error("RocksDB error: {0}")]
+    RocksDB(#[from] rocksdb::Error),
 }
 
 /// A physical storage storage component with an active RocksDB.

--- a/crates/agglayer-storage/src/stores/epochs.rs
+++ b/crates/agglayer-storage/src/stores/epochs.rs
@@ -10,7 +10,7 @@ use super::{
     per_epoch::PerEpochStore, EpochStoreReader, EpochStoreWriter, MetadataWriter,
     PendingCertificateReader, PendingCertificateWriter, StateReader, StateWriter,
 };
-use crate::error::Error;
+use crate::{error::Error, storage::backup::BackupClient};
 
 pub struct EpochsStore<PendingStore, StateStore> {
     config: Arc<agglayer_config::Config>,
@@ -18,6 +18,7 @@ pub struct EpochsStore<PendingStore, StateStore> {
     open_epochs: RwLock<BTreeSet<u64>>,
     pending_store: Arc<PendingStore>,
     state_store: Arc<StateStore>,
+    backup_client: BackupClient,
 }
 
 impl<PendingStore, StateStore> EpochsStore<PendingStore, StateStore> {
@@ -26,6 +27,7 @@ impl<PendingStore, StateStore> EpochsStore<PendingStore, StateStore> {
         epoch_number: u64,
         pending_store: Arc<PendingStore>,
         state_store: Arc<StateStore>,
+        backup_client: BackupClient,
     ) -> Result<Self, Error> {
         let open_epochs = RwLock::new(BTreeSet::new());
         open_epochs.write().insert(epoch_number);
@@ -35,6 +37,7 @@ impl<PendingStore, StateStore> EpochsStore<PendingStore, StateStore> {
             open_epochs,
             pending_store,
             state_store,
+            backup_client,
         })
     }
 }
@@ -52,6 +55,7 @@ where
             self.pending_store.clone(),
             self.state_store.clone(),
             None,
+            self.backup_client.clone(),
         )
     }
 
@@ -66,6 +70,7 @@ where
             self.pending_store.clone(),
             self.state_store.clone(),
             Some(start_checkpoint),
+            self.backup_client.clone(),
         )
     }
 }

--- a/crates/agglayer-storage/src/stores/per_epoch/tests.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/tests.rs
@@ -30,7 +30,8 @@ fn store() -> PerEpochStore<PendingStore, StateStore> {
         StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop()).unwrap(),
     );
 
-    PerEpochStore::try_open(config, 0, pending_store, state_store, None).unwrap()
+    let backup_client = BackupClient::noop();
+    PerEpochStore::try_open(config, 0, pending_store, state_store, None, backup_client).unwrap()
 }
 
 #[rstest]

--- a/crates/agglayer-storage/src/stores/per_epoch/tests.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/tests.rs
@@ -9,7 +9,6 @@ use agglayer_types::{Height, NetworkId, Proof};
 use parking_lot::RwLock;
 use rstest::{fixture, rstest};
 
-use crate::stores::interfaces::writer::StateWriter;
 use crate::stores::{PendingCertificateWriter as _, StateReader};
 use crate::{
     error::Error,
@@ -19,6 +18,7 @@ use crate::{
     },
     tests::TempDBDir,
 };
+use crate::{storage::backup::BackupClient, stores::interfaces::writer::StateWriter};
 
 #[fixture]
 fn store() -> PerEpochStore<PendingStore, StateStore> {
@@ -26,7 +26,9 @@ fn store() -> PerEpochStore<PendingStore, StateStore> {
     let config = Arc::new(Config::new(&tmp.path));
     let pending_store =
         Arc::new(PendingStore::new_with_path(&config.storage.pending_db_path).unwrap());
-    let state_store = Arc::new(StateStore::new_with_path(&config.storage.state_db_path).unwrap());
+    let state_store = Arc::new(
+        StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop()).unwrap(),
+    );
 
     PerEpochStore::try_open(config, 0, pending_store, state_store, None).unwrap()
 }

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -34,7 +34,10 @@ use crate::{
         ColumnSchema,
     },
     error::Error,
-    storage::DB,
+    storage::{
+        backup::{BackupClient, BackupRequest},
+        DB,
+    },
     types::{MetadataKey, MetadataValue, SmtKey, SmtKeyType, SmtValue},
 };
 
@@ -44,20 +47,21 @@ mod tests;
 /// A logical store for the state.
 pub struct StateStore {
     db: Arc<DB>,
+    backup_client: BackupClient,
 }
 
 impl StateStore {
-    pub fn new(db: Arc<DB>) -> Self {
-        Self { db }
+    pub fn new(db: Arc<DB>, backup_client: BackupClient) -> Self {
+        Self { db, backup_client }
     }
 
-    pub fn new_with_path(path: &Path) -> Result<Self, Error> {
+    pub fn new_with_path(path: &Path, backup_client: BackupClient) -> Result<Self, Error> {
         let db = Arc::new(DB::open_cf(
             path,
             crate::storage::state_db_cf_definitions(),
         )?);
 
-        Ok(Self { db })
+        Ok(Self { db, backup_client })
     }
 }
 
@@ -91,6 +95,13 @@ impl StateWriter for StateStore {
 
             self.db
                 .put::<CertificateHeaderColumn>(certificate_id, &certificate_header)?;
+
+            if let Err(error) = self.backup_client.backup(BackupRequest { epoch_db: None }) {
+                warn!(
+                    hash = certificate_id.to_string(),
+                    "Unable to trigger backup for the state database: {}", error
+                );
+            }
         } else {
             info!(
                 hash = %certificate_id,
@@ -294,6 +305,10 @@ impl StateWriter for StateStore {
 
         // Atomic write across the 3 cfs
         self.db.write_batch(atomic_batch)?;
+
+        if let Err(error) = self.backup_client.backup(BackupRequest { epoch_db: None }) {
+            warn!("Unable to trigger backup for the state database: {}", error);
+        }
 
         Ok(())
     }

--- a/crates/agglayer-storage/src/stores/state/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/tests.rs
@@ -13,7 +13,7 @@ use crate::{
         LatestSettledCertificatePerNetworkColumn, SettledCertificate,
     },
     error::Error,
-    storage::{state_db_cf_definitions, DB},
+    storage::{backup::BackupClient, state_db_cf_definitions, DB},
     stores::{state::StateStore, StateReader as _, StateWriter as _},
     tests::TempDBDir,
 };
@@ -24,7 +24,7 @@ mod metadata;
 fn can_retrieve_list_of_network() {
     let tmp = TempDBDir::new();
     let db = Arc::new(DB::open_cf(tmp.path.as_path(), state_db_cf_definitions()).unwrap());
-    let store = StateStore::new(db.clone());
+    let store = StateStore::new(db.clone(), BackupClient::noop());
     assert!(store.get_active_networks().unwrap().is_empty());
 
     db.put::<LatestSettledCertificatePerNetworkColumn>(
@@ -61,7 +61,7 @@ fn store() -> StateStore {
     let tmp = TempDBDir::new();
     let db = Arc::new(DB::open_cf(tmp.path.as_path(), state_db_cf_definitions()).unwrap());
 
-    StateStore::new(db.clone())
+    StateStore::new(db.clone(), BackupClient::noop())
 }
 
 #[rstest]

--- a/crates/agglayer-storage/src/stores/state/tests/metadata.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/metadata.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     columns::metadata::MetadataColumn,
-    storage::{state_db_cf_definitions, DB},
+    storage::{backup::BackupClient, state_db_cf_definitions, DB},
     stores::{state::StateStore, MetadataReader as _, MetadataWriter as _},
     tests::TempDBDir,
     types::{MetadataKey, MetadataValue},
@@ -13,7 +13,7 @@ fn can_retrieve_the_last_settled_epoch() {
     let tmp = TempDBDir::new();
     let db = Arc::new(DB::open_cf(tmp.path.as_path(), state_db_cf_definitions()).unwrap());
 
-    let store = StateStore::new(db.clone());
+    let store = StateStore::new(db.clone(), BackupClient::noop());
     assert!(store.get_latest_settled_epoch().unwrap().is_none());
 
     db.put::<MetadataColumn>(
@@ -30,7 +30,7 @@ fn can_set_the_latest_epoch_settled() {
     let tmp = TempDBDir::new();
     let db = Arc::new(DB::open_cf(tmp.path.as_path(), state_db_cf_definitions()).unwrap());
 
-    let store = StateStore::new(db.clone());
+    let store = StateStore::new(db.clone(), BackupClient::noop());
     assert!(store.get_latest_settled_epoch().unwrap().is_none());
 
     store

--- a/crates/agglayer-storage/src/tests.rs
+++ b/crates/agglayer-storage/src/tests.rs
@@ -45,6 +45,6 @@ impl TempDBDir {
 
 impl Drop for TempDBDir {
     fn drop(&mut self) {
-        std::fs::remove_dir_all(&self.path).unwrap();
+        _ = std::fs::remove_dir_all(&self.path);
     }
 }

--- a/crates/agglayer-test-suite/src/storage.rs
+++ b/crates/agglayer-test-suite/src/storage.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use agglayer_config::Config;
 use agglayer_storage::{
-    storage::{pending_db_cf_definitions, state_db_cf_definitions, DB},
+    storage::{backup::BackupClient, pending_db_cf_definitions, state_db_cf_definitions, DB},
     stores::{debug::DebugStore, pending::PendingStore, state::StateStore},
 };
 
@@ -21,7 +21,7 @@ impl StorageContext {
             DB::open_cf(&config.storage.pending_db_path, pending_db_cf_definitions()).unwrap(),
         );
 
-        let state = Arc::new(StateStore::new(state_db));
+        let state = Arc::new(StateStore::new(state_db, BackupClient::noop()));
         let pending = Arc::new(PendingStore::new(pending_db));
         let debug = if config.debug_mode {
             Arc::new(DebugStore::new_with_path(&config.storage.debug_db_path).unwrap())

--- a/crates/agglayer/Cargo.toml
+++ b/crates/agglayer/Cargo.toml
@@ -8,10 +8,12 @@ anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env", "string"] }
 dirs.workspace = true
 dotenvy.workspace = true
+serde_json.workspace = true
 toml.workspace = true
 
 agglayer-node = { path = "../agglayer-node" }
 agglayer-prover = { path = "../agglayer-prover" }
+agglayer-storage = { path = "../agglayer-storage" }
 agglayer-config = { path = "../agglayer-config" }
 
 [dev-dependencies]

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -9,7 +9,7 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.cmd {
-        cli::Commands::Run { cfg } => agglayer_node::main(cfg, &version())?,
+        cli::Commands::Run { cfg } => agglayer_node::main(cfg, &version(), None)?,
         cli::Commands::Prover { cfg } => agglayer_prover::main(cfg, &version())?,
         cli::Commands::ProverConfig => println!(
             "{}",

--- a/tests/integrations/Cargo.toml
+++ b/tests/integrations/Cargo.toml
@@ -17,9 +17,9 @@ fail = { workspace = true, features = ["failpoints"] }
 futures.workspace = true
 hex.workspace = true
 http-body-util = "0.1.2"
-hyper.workspace = true
 hyper-util = { version = "0.1.6", features = ["client"] }
-insta = { workspace = true, features = ["json"] }
+hyper.workspace = true
+insta.workspace = true
 jsonrpsee = { workspace = true, features = ["full"] }
 jsonrpsee-test-utils = { git = "https://github.com/paritytech/jsonrpsee.git", tag = "v0.24.7" }
 lazy_static.workspace = true

--- a/tests/integrations/Cargo.toml
+++ b/tests/integrations/Cargo.toml
@@ -19,7 +19,7 @@ hex.workspace = true
 http-body-util = "0.1.2"
 hyper.workspace = true
 hyper-util = { version = "0.1.6", features = ["client"] }
-insta.workspace = true
+insta = { workspace = true, features = ["json"] }
 jsonrpsee = { workspace = true, features = ["full"] }
 jsonrpsee-test-utils = { git = "https://github.com/paritytech/jsonrpsee.git", tag = "v0.24.7" }
 lazy_static.workspace = true

--- a/tests/integrations/src/agglayer_setup.rs
+++ b/tests/integrations/src/agglayer_setup.rs
@@ -129,9 +129,9 @@ pub async fn start_agglayer(
     let toml = toml::to_string_pretty(&config).unwrap();
     std::fs::write(&config_file, toml).unwrap();
 
-    let gracefull_shutdown_token = shutdown_token.clone();
+    let graceful_shutdown_token = shutdown_token.clone();
     let handle = std::thread::spawn(move || {
-        agglayer_node::main(config_file, "test", Some(gracefull_shutdown_token)).unwrap();
+        agglayer_node::main(config_file, "test", Some(graceful_shutdown_token)).unwrap();
         _ = shutdown.send(());
     });
     let url = format!("ws://{}/", config.rpc_addr());

--- a/tests/integrations/src/agglayer_setup.rs
+++ b/tests/integrations/src/agglayer_setup.rs
@@ -131,7 +131,7 @@ pub async fn start_agglayer(
 
     let gracefull_shutdown_token = shutdown_token.clone();
     let handle = std::thread::spawn(move || {
-        _ = agglayer_node::main(config_file, "test", Some(gracefull_shutdown_token)).unwrap();
+        agglayer_node::main(config_file, "test", Some(gracefull_shutdown_token)).unwrap();
         _ = shutdown.send(());
     });
     let url = format!("ws://{}/", config.rpc_addr());

--- a/tests/integrations/src/agglayer_setup.rs
+++ b/tests/integrations/src/agglayer_setup.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, time::Duration};
 
-use agglayer_config::{log::LogLevel, TelemetryConfig};
+use agglayer_config::{log::LogLevel, Config, TelemetryConfig};
 use agglayer_prover::fake::FakeProver;
 use ethers::{
     core::k256::ecdsa::SigningKey,
@@ -55,7 +55,11 @@ pub async fn start_l1() -> L1Docker {
     l1
 }
 
-pub async fn start_agglayer(tmp_dir: &Path, l1: &L1Docker) -> (oneshot::Receiver<()>, WsClient) {
+pub async fn start_agglayer(
+    config_path: &Path,
+    l1: &L1Docker,
+    config: Option<agglayer_config::Config>,
+) -> (oneshot::Receiver<()>, WsClient, CancellationToken) {
     let (shutdown, receiver) = oneshot::channel();
 
     // Make the mock prover pass
@@ -65,7 +69,7 @@ pub async fn start_agglayer(tmp_dir: &Path, l1: &L1Docker) -> (oneshot::Receiver
     )
     .unwrap();
 
-    let mut config = agglayer_config::Config::new(tmp_dir);
+    let mut config = config.unwrap_or_else(|| agglayer_config::Config::new(config_path));
     let prover_config = agglayer_config::prover::ProverConfig {
         grpc_endpoint: next_available_addr(),
         telemetry: TelemetryConfig {
@@ -79,7 +83,9 @@ pub async fn start_agglayer(tmp_dir: &Path, l1: &L1Docker) -> (oneshot::Receiver
     let endpoint = prover_config.grpc_endpoint;
 
     config.prover_entrypoint = format!("http://{}", endpoint);
-    let cancellation = CancellationToken::new();
+
+    let shutdown_token = CancellationToken::new();
+    let cancellation = shutdown_token.child_token();
     FakeProver::spawn_at(fake_prover, endpoint, cancellation.clone())
         .await
         .unwrap();
@@ -88,7 +94,7 @@ pub async fn start_agglayer(tmp_dir: &Path, l1: &L1Docker) -> (oneshot::Receiver
 
     let mut rng = rand::thread_rng();
     let (_key, uuid) = LocalWallet::encrypt_keystore(
-        tmp_dir,
+        config_path,
         &mut rng,
         wallet.signer().to_bytes(),
         "randpsswd",
@@ -96,7 +102,7 @@ pub async fn start_agglayer(tmp_dir: &Path, l1: &L1Docker) -> (oneshot::Receiver
     )
     .unwrap();
 
-    let key_path = tmp_dir.join(uuid);
+    let key_path = config_path.join(uuid);
 
     let addr = next_available_addr();
     config.rpc.port = addr.port();
@@ -119,12 +125,13 @@ pub async fn start_agglayer(tmp_dir: &Path, l1: &L1Docker) -> (oneshot::Receiver
         }],
     });
 
-    let config_file = tmp_dir.join("config.toml");
+    let config_file = config_path.join("config.toml");
     let toml = toml::to_string_pretty(&config).unwrap();
     std::fs::write(&config_file, toml).unwrap();
 
+    let gracefull_shutdown_token = shutdown_token.clone();
     let handle = std::thread::spawn(move || {
-        _ = agglayer_node::main(config_file, "test");
+        _ = agglayer_node::main(config_file, "test", Some(gracefull_shutdown_token)).unwrap();
         _ = shutdown.send(());
     });
     let url = format!("ws://{}/", config.rpc_addr());
@@ -142,7 +149,7 @@ pub async fn start_agglayer(tmp_dir: &Path, l1: &L1Docker) -> (oneshot::Receiver
 
         if handle.is_finished() {
             let _result = handle.join();
-            println!("{:?}", _result);
+            println!("Agglayer result: {:?}", _result);
             panic!("Server has finished");
         }
 
@@ -151,14 +158,17 @@ pub async fn start_agglayer(tmp_dir: &Path, l1: &L1Docker) -> (oneshot::Receiver
 
     assert!(!handle.is_finished());
 
-    (receiver, client)
+    (receiver, client, shutdown_token)
 }
 
-pub async fn setup_network(tmp_dir: &Path) -> (oneshot::Receiver<()>, L1Docker, WsClient) {
+pub async fn setup_network(
+    tmp_dir: &Path,
+    config: Option<Config>,
+) -> (oneshot::Receiver<()>, L1Docker, WsClient, CancellationToken) {
     let l1 = start_l1().await;
-    let (receiver, client) = start_agglayer(tmp_dir, &l1).await;
+    let (receiver, client, token) = start_agglayer(tmp_dir, &l1, config).await;
 
-    (receiver, l1, client)
+    (receiver, l1, client, token)
 }
 
 pub fn get_signer(index: u32) -> Wallet<SigningKey> {

--- a/tests/integrations/tests/certificate_settlement/concurrency.rs
+++ b/tests/integrations/tests/certificate_settlement/concurrency.rs
@@ -20,7 +20,7 @@ async fn schedule_two_certs() {
     let scenario = FailScenario::setup();
 
     // L1 is a RAII guard
-    let (_handle, _l1, client) = setup_network(&tmp_dir.path).await;
+    let (_handle, _l1, client, _) = setup_network(&tmp_dir.path, None).await;
     let signer = get_signer(0);
 
     let mut state = Forest::default().with_signer(signer);

--- a/tests/integrations/tests/certificate_settlement/happy_path.rs
+++ b/tests/integrations/tests/certificate_settlement/happy_path.rs
@@ -20,7 +20,7 @@ async fn successfully_push_certificate() {
     let scenario = FailScenario::setup();
 
     // L1 is a RAII guard
-    let (_handle, _l1, client) = setup_network(&tmp_dir.path).await;
+    let (_handle, _l1, client, _) = setup_network(&tmp_dir.path, None).await;
     let signer = get_signer(0);
 
     let state = Forest::default().with_signer(signer);

--- a/tests/integrations/tests/certificate_settlement/l1_settlement/failure.rs
+++ b/tests/integrations/tests/certificate_settlement/l1_settlement/failure.rs
@@ -26,7 +26,7 @@ async fn transaction_with_receipt_status_0() {
     .expect("Failed to configure failpoint");
 
     // L1 is a RAII guard
-    let (_handle, _l1, client) = setup_network(&tmp_dir.path).await;
+    let (_handle, _l1, client, _) = setup_network(&tmp_dir.path, None).await;
     let signer = get_signer(0);
 
     let state = Forest::default().with_signer(signer);
@@ -61,7 +61,7 @@ async fn transaction_with_receipt_status_0_retry() {
     .expect("Failed to configure failpoint");
 
     // L1 is a RAII guard
-    let (_handle, _l1, client) = setup_network(&tmp_dir.path).await;
+    let (_handle, _l1, client, _) = setup_network(&tmp_dir.path, None).await;
     let signer = get_signer(0);
 
     let state = Forest::default().with_signer(signer);
@@ -110,7 +110,7 @@ async fn transaction_without_receipt_status() {
     .expect("Failed to configure failpoint");
 
     // L1 is a RAII guard
-    let (_handle, _l1, client) = setup_network(&tmp_dir.path).await;
+    let (_handle, _l1, client, _) = setup_network(&tmp_dir.path, None).await;
     let signer = get_signer(0);
 
     let state = Forest::default().with_signer(signer);
@@ -145,7 +145,7 @@ async fn transaction_fails_due_to_out_of_gas() {
     .expect("Failed to configure failpoint");
 
     // L1 is a RAII guard
-    let (_handle, _l1, client) = setup_network(&tmp_dir.path).await;
+    let (_handle, _l1, client, _) = setup_network(&tmp_dir.path, None).await;
     let signer = get_signer(0);
 
     let state = Forest::default().with_signer(signer);

--- a/tests/integrations/tests/certificate_settlement/retries.rs
+++ b/tests/integrations/tests/certificate_settlement/retries.rs
@@ -28,7 +28,7 @@ async fn retry_on_error() {
     .expect("Failed to configure failpoint");
 
     // L1 is a RAII guard
-    let (_handle, _l1, client) = setup_network(&tmp_dir.path).await;
+    let (_handle, _l1, client, _) = setup_network(&tmp_dir.path, None).await;
     let signer = get_signer(0);
 
     let state = Forest::default().with_signer(signer);

--- a/tests/integrations/tests/certificate_settlement/retries/recovery.rs
+++ b/tests/integrations/tests/certificate_settlement/retries/recovery.rs
@@ -26,7 +26,7 @@ async fn sent_transaction_recover() {
     .expect("Failed to configure failpoint");
 
     // L1 is a RAII guard
-    let (agglayer_shutdowned, l1, client) = setup_network(&tmp_dir.path).await;
+    let (agglayer_shutdowned, l1, client, _) = setup_network(&tmp_dir.path, None).await;
     let signer = get_signer(0);
 
     let state = Forest::default().with_signer(signer);
@@ -50,7 +50,7 @@ async fn sent_transaction_recover() {
     )
     .expect("Failed to configure failpoint");
 
-    let (_agglayer_shutdowned, client) = start_agglayer(&tmp_dir.path, &l1).await;
+    let (_agglayer_shutdowned, client, _) = start_agglayer(&tmp_dir.path, &l1, None).await;
 
     println!("Node recovered, waiting for settlement...");
 

--- a/tests/integrations/tests/storage_backups/main.rs
+++ b/tests/integrations/tests/storage_backups/main.rs
@@ -90,8 +90,8 @@ async fn purge_after_n_backup() {
     let mut config = agglayer_config::Config::new(&tmp_dir.path);
     config.storage.backup = BackupConfig::Enabled {
         path: backup_dir.path.clone(),
-        state_max_backup_number: 1,
-        pending_max_backup_number: 1,
+        state_max_backup_count: 1,
+        pending_max_backup_count: 1,
     };
 
     // L1 is a RAII guard
@@ -222,6 +222,9 @@ async fn report_contains_all_backups() {
 
     let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
 
+    // There are 4 backups because 2 actions triggers a backup per certs:
+    // - One when the L1 `tx_hash` is known
+    // - One when the `Certificate` is settled and the network state is updated
     assert_eq!(backup_report.get_state().len(), 4);
     assert_eq!(backup_report.get_pending().len(), 4);
 
@@ -312,7 +315,6 @@ async fn restore_at_particular_level() {
     assert_eq!(backup_report.get_state().len(), 4);
     assert_eq!(backup_report.get_pending().len(), 4);
 
-    println!("{}", serde_json::to_string_pretty(&backup_report).unwrap());
     BackupEngine::restore_at(
         &backup_dir.path.join("state"),
         &config.storage.state_db_path,

--- a/tests/integrations/tests/storage_backups/main.rs
+++ b/tests/integrations/tests/storage_backups/main.rs
@@ -1,0 +1,156 @@
+use std::time::Duration;
+
+use agglayer_config::storage::backup::BackupConfig;
+use agglayer_storage::{storage::backup::BackupEngine, tests::TempDBDir};
+use agglayer_types::{CertificateHeader, CertificateId, CertificateStatus};
+use fail::FailScenario;
+use integrations::{
+    agglayer_setup::{get_signer, setup_network, start_agglayer},
+    wait_for_settlement_or_error,
+};
+use jsonrpsee::core::client::ClientT as _;
+use jsonrpsee::rpc_params;
+use pessimistic_proof_test_suite::forest::Forest;
+use rstest::rstest;
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(180))]
+async fn recover_with_backup() {
+    let tmp_dir = TempDBDir::new();
+    let backup_dir = TempDBDir::new();
+
+    assert_ne!(tmp_dir.path, backup_dir.path);
+
+    let scenario = FailScenario::setup();
+
+    let mut config = agglayer_config::Config::new(&tmp_dir.path);
+    config.storage.backup = BackupConfig::with_path(backup_dir.path.clone());
+
+    // L1 is a RAII guard
+    let (agglayer_shutdowned, l1, client, handle) =
+        setup_network(&tmp_dir.path, Some(config)).await;
+    let signer = get_signer(0);
+
+    let state = Forest::default().with_signer(signer);
+
+    let withdrawals = vec![];
+
+    let certificate = state.clone().apply_events(&[], &withdrawals);
+
+    let certificate_id: CertificateId = client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    let result = wait_for_settlement_or_error!(client, certificate_id).await;
+
+    assert_eq!(result.status, CertificateStatus::Settled);
+    handle.cancel();
+    _ = agglayer_shutdowned.await;
+
+    let config = agglayer_config::Config::new(&tmp_dir.path);
+    std::fs::remove_dir_all(&config.storage.pending_db_path).unwrap();
+    std::fs::remove_dir_all(&config.storage.epochs_db_path).unwrap();
+    std::fs::remove_dir_all(&config.storage.state_db_path).unwrap();
+
+    BackupEngine::restore(
+        &backup_dir.path.join("state"),
+        &config.storage.state_db_path,
+    )
+    .unwrap();
+
+    let (agglayer_shutdowned, client, handle) =
+        start_agglayer(&tmp_dir.path, &l1, Some(config)).await;
+
+    let certificate: CertificateHeader = client
+        .request("interop_getCertificateHeader", rpc_params![certificate_id])
+        .await
+        .unwrap();
+
+    assert_eq!(certificate.status, CertificateStatus::Settled);
+
+    handle.cancel();
+    _ = agglayer_shutdowned.await;
+
+    scenario.teardown();
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(360))]
+async fn purge_after_n_backup() {
+    let tmp_dir = TempDBDir::new();
+    let backup_dir = TempDBDir::new();
+
+    assert_ne!(tmp_dir.path, backup_dir.path);
+
+    let scenario = FailScenario::setup();
+
+    let mut config = agglayer_config::Config::new(&tmp_dir.path);
+    config.storage.backup = BackupConfig::Enabled {
+        path: backup_dir.path.clone(),
+        state_max_backup_number: 1,
+        pending_max_backup_number: 1,
+    };
+
+    // L1 is a RAII guard
+    let (agglayer_shutdowned, l1, client, handle) =
+        setup_network(&tmp_dir.path, Some(config)).await;
+    let signer = get_signer(0);
+
+    let state = Forest::default().with_signer(signer);
+
+    let withdrawals = vec![];
+
+    let certificate = state.clone().apply_events(&[], &withdrawals);
+    let mut certificate2 = state.clone().apply_events(&[], &[]);
+    certificate2.height = 1;
+
+    let certificate_id: CertificateId = client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    let result = wait_for_settlement_or_error!(client, certificate_id).await;
+
+    assert_eq!(result.status, CertificateStatus::Settled);
+
+    let certificate_id2: CertificateId = client
+        .request("interop_sendCertificate", rpc_params![certificate2])
+        .await
+        .unwrap();
+
+    let result = wait_for_settlement_or_error!(client, certificate_id2).await;
+
+    assert_eq!(result.status, CertificateStatus::Settled);
+
+    handle.cancel();
+    _ = agglayer_shutdowned.await;
+
+    let config = agglayer_config::Config::new(&tmp_dir.path);
+    std::fs::remove_dir_all(&config.storage.pending_db_path).unwrap();
+    std::fs::remove_dir_all(&config.storage.epochs_db_path).unwrap();
+    std::fs::remove_dir_all(&config.storage.state_db_path).unwrap();
+
+    BackupEngine::restore(
+        &backup_dir.path.join("state"),
+        &config.storage.state_db_path,
+    )
+    .unwrap();
+
+    let (agglayer_shutdowned, client, handle) =
+        start_agglayer(&tmp_dir.path, &l1, Some(config)).await;
+
+    let certificate: CertificateHeader = client
+        .request("interop_getCertificateHeader", rpc_params![certificate_id])
+        .await
+        .unwrap();
+
+    assert_eq!(certificate.status, CertificateStatus::Settled);
+
+    handle.cancel();
+    _ = agglayer_shutdowned.await;
+
+    scenario.teardown();
+}

--- a/tests/integrations/tests/storage_backups/main.rs
+++ b/tests/integrations/tests/storage_backups/main.rs
@@ -133,6 +133,11 @@ async fn purge_after_n_backup() {
     std::fs::remove_dir_all(&config.storage.epochs_db_path).unwrap();
     std::fs::remove_dir_all(&config.storage.state_db_path).unwrap();
 
+    let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
+
+    assert_eq!(backup_report.get_state().len(), 1);
+    assert_eq!(backup_report.get_pending().len(), 1);
+
     BackupEngine::restore(
         &backup_dir.path.join("state"),
         &config.storage.state_db_path,
@@ -148,6 +153,192 @@ async fn purge_after_n_backup() {
         .unwrap();
 
     assert_eq!(certificate.status, CertificateStatus::Settled);
+
+    let certificate: CertificateHeader = client
+        .request("interop_getCertificateHeader", rpc_params![certificate_id2])
+        .await
+        .unwrap();
+
+    assert_eq!(certificate.status, CertificateStatus::Settled);
+
+    handle.cancel();
+    _ = agglayer_shutdowned.await;
+
+    scenario.teardown();
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(360))]
+async fn report_contains_all_backups() {
+    let tmp_dir = TempDBDir::new();
+    let backup_dir = TempDBDir::new();
+
+    assert_ne!(tmp_dir.path, backup_dir.path);
+
+    let scenario = FailScenario::setup();
+
+    let mut config = agglayer_config::Config::new(&tmp_dir.path);
+    config.storage.backup = BackupConfig::with_path(backup_dir.path.clone());
+
+    // L1 is a RAII guard
+    let (agglayer_shutdowned, l1, client, handle) =
+        setup_network(&tmp_dir.path, Some(config)).await;
+    let signer = get_signer(0);
+
+    let state = Forest::default().with_signer(signer);
+
+    let withdrawals = vec![];
+
+    let certificate = state.clone().apply_events(&[], &withdrawals);
+    let mut certificate2 = state.clone().apply_events(&[], &[]);
+    certificate2.height = 1;
+
+    let certificate_id: CertificateId = client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    let result = wait_for_settlement_or_error!(client, certificate_id).await;
+
+    assert_eq!(result.status, CertificateStatus::Settled);
+
+    let certificate_id2: CertificateId = client
+        .request("interop_sendCertificate", rpc_params![certificate2])
+        .await
+        .unwrap();
+
+    let result = wait_for_settlement_or_error!(client, certificate_id2).await;
+
+    assert_eq!(result.status, CertificateStatus::Settled);
+
+    handle.cancel();
+    _ = agglayer_shutdowned.await;
+
+    let config = agglayer_config::Config::new(&tmp_dir.path);
+    std::fs::remove_dir_all(&config.storage.pending_db_path).unwrap();
+    std::fs::remove_dir_all(&config.storage.epochs_db_path).unwrap();
+    std::fs::remove_dir_all(&config.storage.state_db_path).unwrap();
+
+    let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
+
+    assert_eq!(backup_report.get_state().len(), 4);
+    assert_eq!(backup_report.get_pending().len(), 4);
+
+    BackupEngine::restore(
+        &backup_dir.path.join("state"),
+        &config.storage.state_db_path,
+    )
+    .unwrap();
+
+    let (agglayer_shutdowned, client, handle) =
+        start_agglayer(&tmp_dir.path, &l1, Some(config)).await;
+
+    let certificate: CertificateHeader = client
+        .request("interop_getCertificateHeader", rpc_params![certificate_id])
+        .await
+        .unwrap();
+
+    assert_eq!(certificate.status, CertificateStatus::Settled);
+
+    let certificate: CertificateHeader = client
+        .request("interop_getCertificateHeader", rpc_params![certificate_id2])
+        .await
+        .unwrap();
+
+    assert_eq!(certificate.status, CertificateStatus::Settled);
+
+    handle.cancel();
+    _ = agglayer_shutdowned.await;
+
+    scenario.teardown();
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(360))]
+async fn restore_at_particular_level() {
+    let tmp_dir = TempDBDir::new();
+    let backup_dir = TempDBDir::new();
+
+    assert_ne!(tmp_dir.path, backup_dir.path);
+
+    let scenario = FailScenario::setup();
+
+    let mut config = agglayer_config::Config::new(&tmp_dir.path);
+    config.storage.backup = BackupConfig::with_path(backup_dir.path.clone());
+
+    // L1 is a RAII guard
+    let (agglayer_shutdowned, l1, client, handle) =
+        setup_network(&tmp_dir.path, Some(config)).await;
+    let signer = get_signer(0);
+
+    let state = Forest::default().with_signer(signer);
+
+    let withdrawals = vec![];
+
+    let certificate = state.clone().apply_events(&[], &withdrawals);
+    let mut certificate2 = state.clone().apply_events(&[], &[]);
+    certificate2.height = 1;
+
+    let certificate_id: CertificateId = client
+        .request("interop_sendCertificate", rpc_params![certificate])
+        .await
+        .unwrap();
+
+    let result = wait_for_settlement_or_error!(client, certificate_id).await;
+
+    assert_eq!(result.status, CertificateStatus::Settled);
+
+    let certificate_id2: CertificateId = client
+        .request("interop_sendCertificate", rpc_params![certificate2])
+        .await
+        .unwrap();
+
+    let result = wait_for_settlement_or_error!(client, certificate_id2).await;
+
+    assert_eq!(result.status, CertificateStatus::Settled);
+
+    handle.cancel();
+    _ = agglayer_shutdowned.await;
+
+    let config = agglayer_config::Config::new(&tmp_dir.path);
+    std::fs::remove_dir_all(&config.storage.pending_db_path).unwrap();
+    std::fs::remove_dir_all(&config.storage.epochs_db_path).unwrap();
+    std::fs::remove_dir_all(&config.storage.state_db_path).unwrap();
+
+    let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
+
+    assert_eq!(backup_report.get_state().len(), 4);
+    assert_eq!(backup_report.get_pending().len(), 4);
+
+    println!("{}", serde_json::to_string_pretty(&backup_report).unwrap());
+    BackupEngine::restore_at(
+        &backup_dir.path.join("state"),
+        &config.storage.state_db_path,
+        2,
+    )
+    .unwrap();
+
+    let (agglayer_shutdowned, client, handle) =
+        start_agglayer(&tmp_dir.path, &l1, Some(config)).await;
+
+    let certificate: CertificateHeader = client
+        .request("interop_getCertificateHeader", rpc_params![certificate_id])
+        .await
+        .unwrap();
+
+    assert_eq!(certificate.status, CertificateStatus::Settled);
+
+    let error: Result<CertificateHeader, jsonrpsee::core::ClientError> = client
+        .request("interop_getCertificateHeader", rpc_params![certificate_id2])
+        .await;
+
+    let expected_message = format!("Resource not found: Certificate({:#})", certificate_id2);
+
+    assert!(
+        matches!(error.unwrap_err(), jsonrpsee::core::ClientError::Call(obj) if obj.message() == expected_message)
+    );
 
     handle.cancel();
     _ = agglayer_shutdowned.await;


### PR DESCRIPTION
# Description

This PR is adding a `BackupEngine` and its configuration to the `agglayer` node.

The goal is to allow `backups` of `state`, `pending` and `epoch` databases when triggered by the application.
The backups per database are cleaned up, keeping only a certain amount of backups.

## Config changes

```toml
[storage.backup.enabled]
path = "PATH TO BACKUP"
state_max_backup_number = 100 # default: 100
pending_max_backup_number = 100 # default: 100
```

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
