### PR TITLE
chore: agglayer primitives export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,6 @@ dependencies = [
  "agglayer-certificate-orchestrator",
  "agglayer-config",
  "agglayer-contracts",
- "agglayer-primitives",
  "agglayer-prover",
  "agglayer-prover-types",
  "agglayer-storage",
@@ -363,9 +362,6 @@ version = "0.1.0"
 dependencies = [
  "agglayer-config",
  "agglayer-storage",
- "agglayer-types",
- "alloy 0.7.3",
- "derive_builder",
  "pessimistic-proof",
  "pessimistic-proof-test-suite",
  "rstest",
@@ -459,22 +455,6 @@ dependencies = [
 
 [[package]]
 name = "alloy"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b0561294ccedc6181e5528b850b4579e3fbde696507baa00109bfd9054c5bb"
-dependencies = [
- "alloy-consensus 0.7.3",
- "alloy-core",
- "alloy-eips 0.7.3",
- "alloy-genesis 0.7.3",
- "alloy-provider 0.7.3",
- "alloy-rpc-client 0.7.3",
- "alloy-serde 0.7.3",
- "alloy-transport-http 0.7.3",
-]
-
-[[package]]
-name = "alloy"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e1758e5d759c0114140152ae72032eafcfdd7b599e995ebbc8eeafa2b4c977"
@@ -529,23 +509,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a101d4d016f47f13890a74290fdd17b05dd175191d9337bc600791fb96e4dea8"
-dependencies = [
- "alloy-eips 0.7.3",
- "alloy-primitives 0.8.15",
- "alloy-rlp",
- "alloy-serde 0.7.3",
- "alloy-trie",
- "auto_impl",
- "c-kzg",
- "derive_more 1.0.0",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a205d0cbb7bfdf9f4fd4b0ec842bc4c5f926e8c14ec3072d3fd75dd363baf1e0"
@@ -559,20 +522,6 @@ dependencies = [
  "c-kzg",
  "derive_more 1.0.0",
  "k256",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa60357dda9a3d0f738f18844bd6d0f4a5924cc5cf00bfad2ff1369897966123"
-dependencies = [
- "alloy-consensus 0.7.3",
- "alloy-eips 0.7.3",
- "alloy-primitives 0.8.15",
- "alloy-rlp",
- "alloy-serde 0.7.3",
  "serde",
 ]
 
@@ -706,24 +655,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6755b093afef5925f25079dd5a7c8d096398b804ba60cb5275397b06b31689"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives 0.8.15",
- "alloy-rlp",
- "alloy-serde 0.7.3",
- "c-kzg",
- "derive_more 1.0.0",
- "once_cell",
- "serde",
- "sha2",
-]
-
-[[package]]
-name = "alloy-eips"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1d9907c29ce622946759bf4fd3418166bfeae76c1c544b8081c7be3acd9b4be"
@@ -748,18 +679,6 @@ checksum = "e53f7877ded3921d18a0a9556d55bedf84535567198c9edab2aa23106da91855"
 dependencies = [
  "alloy-primitives 0.8.15",
  "alloy-serde 0.6.4",
- "serde",
-]
-
-[[package]]
-name = "alloy-genesis"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeec8e6eab6e52b7c9f918748c9b811e87dbef7312a2e3a2ca1729a92966a6af"
-dependencies = [
- "alloy-primitives 0.8.15",
- "alloy-serde 0.7.3",
- "alloy-trie",
  "serde",
 ]
 
@@ -803,20 +722,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa077efe0b834bcd89ff4ba547f48fb081e4fdc3673dd7da1b295a2cf2bb7b7"
-dependencies = [
- "alloy-primitives 0.8.15",
- "alloy-sol-types 0.8.15",
- "serde",
- "serde_json",
- "thiserror 2.0.8",
- "tracing",
-]
-
-[[package]]
-name = "alloy-json-rpc"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a786ce6bc7539dc30cabac6b7875644247c9e7d780e71a9f254d42ebdc013c"
@@ -854,42 +759,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209a1882a08e21aca4aac6e2a674dc6fcf614058ef8cb02947d63782b1899552"
-dependencies = [
- "alloy-consensus 0.7.3",
- "alloy-consensus-any 0.7.3",
- "alloy-eips 0.7.3",
- "alloy-json-rpc 0.7.3",
- "alloy-network-primitives 0.7.3",
- "alloy-primitives 0.8.15",
- "alloy-rpc-types-any 0.7.3",
- "alloy-rpc-types-eth 0.7.3",
- "alloy-serde 0.7.3",
- "alloy-signer 0.7.3",
- "alloy-sol-types 0.8.15",
- "async-trait",
- "auto_impl",
- "futures-utils-wasm",
- "serde",
- "serde_json",
- "thiserror 2.0.8",
-]
-
-[[package]]
-name = "alloy-network"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99051f82f77159d5bee06108f33cffee02849e2861fc500bf74213aa2ae8a26e"
 dependencies = [
  "alloy-consensus 0.8.1",
- "alloy-consensus-any 0.8.1",
+ "alloy-consensus-any",
  "alloy-eips 0.8.1",
  "alloy-json-rpc 0.8.1",
  "alloy-network-primitives 0.8.1",
  "alloy-primitives 0.8.15",
- "alloy-rpc-types-any 0.8.1",
+ "alloy-rpc-types-any",
  "alloy-rpc-types-eth 0.8.1",
  "alloy-serde 0.8.1",
  "alloy-signer 0.8.1",
@@ -912,19 +792,6 @@ dependencies = [
  "alloy-eips 0.6.4",
  "alloy-primitives 0.8.15",
  "alloy-serde 0.6.4",
- "serde",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20219d1ad261da7a6331c16367214ee7ded41d001fabbbd656fbf71898b2773"
-dependencies = [
- "alloy-consensus 0.7.3",
- "alloy-eips 0.7.3",
- "alloy-primitives 0.8.15",
- "alloy-serde 0.7.3",
  "serde",
 ]
 
@@ -1042,43 +909,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "tokio",
- "tracing",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-provider"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eefa6f4c798ad01f9b4202d02cea75f5ec11fa180502f4701e2b47965a8c0bb"
-dependencies = [
- "alloy-chains",
- "alloy-consensus 0.7.3",
- "alloy-eips 0.7.3",
- "alloy-json-rpc 0.7.3",
- "alloy-network 0.7.3",
- "alloy-network-primitives 0.7.3",
- "alloy-primitives 0.8.15",
- "alloy-rpc-client 0.7.3",
- "alloy-rpc-types-eth 0.7.3",
- "alloy-transport 0.7.3",
- "alloy-transport-http 0.7.3",
- "async-stream",
- "async-trait",
- "auto_impl",
- "dashmap",
- "futures",
- "futures-utils-wasm",
- "lru",
- "parking_lot",
- "pin-project 1.1.7",
- "reqwest 0.12.9",
- "schnellru",
- "serde",
- "serde_json",
- "thiserror 2.0.8",
  "tokio",
  "tracing",
  "url",
@@ -1217,29 +1047,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed30bf1041e84cabc5900f52978ca345dd9969f2194a945e6fdec25b0620705c"
-dependencies = [
- "alloy-json-rpc 0.7.3",
- "alloy-primitives 0.8.15",
- "alloy-transport 0.7.3",
- "alloy-transport-http 0.7.3",
- "futures",
- "pin-project 1.1.7",
- "reqwest 0.12.9",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower 0.5.2",
- "tracing",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-rpc-client"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fc8b0f68619cfab3a2e15dca7b80ab266f78430bb4353dec546528e04b7449"
@@ -1304,22 +1111,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200661999b6e235d9840be5d60a6e8ae2f0af9eb2a256dd378786744660e36ec"
-dependencies = [
- "alloy-consensus-any 0.7.3",
- "alloy-rpc-types-eth 0.7.3",
- "alloy-serde 0.7.3",
-]
-
-[[package]]
-name = "alloy-rpc-types-any"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e3aa433d3657b42e98e257ee6fa201f5c853245648a33da8fbb7497a5008bf"
 dependencies = [
- "alloy-consensus-any 0.8.1",
+ "alloy-consensus-any",
  "alloy-rpc-types-eth 0.8.1",
  "alloy-serde 0.8.1",
 ]
@@ -1377,32 +1173,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0600b8b5e2dc0cab12cbf91b5a885c35871789fb7b3a57b434bd4fced5b7a8b"
-dependencies = [
- "alloy-consensus 0.7.3",
- "alloy-consensus-any 0.7.3",
- "alloy-eips 0.7.3",
- "alloy-network-primitives 0.7.3",
- "alloy-primitives 0.8.15",
- "alloy-rlp",
- "alloy-serde 0.7.3",
- "alloy-sol-types 0.8.15",
- "derive_more 1.0.0",
- "itertools 0.13.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0643cc497a71941f526454fe4fecb47e9307d3a7b6c05f70718a0341643bcc79"
 dependencies = [
  "alloy-consensus 0.8.1",
- "alloy-consensus-any 0.8.1",
+ "alloy-consensus-any",
  "alloy-eips 0.8.1",
  "alloy-network-primitives 0.8.1",
  "alloy-primitives 0.8.15",
@@ -1420,17 +1196,6 @@ name = "alloy-serde"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfa4a7ccf15b2492bb68088692481fd6b2604ccbee1d0d6c44c21427ae4df83"
-dependencies = [
- "alloy-primitives 0.8.15",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afa753a97002a33b2ccb707d9f15f31c81b8c1b786c95b73cc62bb1d1fd0c3f"
 dependencies = [
  "alloy-primitives 0.8.15",
  "serde",
@@ -1460,20 +1225,6 @@ dependencies = [
  "elliptic-curve",
  "k256",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "alloy-signer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2cbff01a673936c2efd7e00d4c0e9a4dbbd6d600e2ce298078d33efbb19cd7"
-dependencies = [
- "alloy-primitives 0.8.15",
- "async-trait",
- "auto_impl",
- "elliptic-curve",
- "k256",
- "thiserror 2.0.8",
 ]
 
 [[package]]
@@ -1676,26 +1427,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69d36982b9e46075ae6b792b0f84208c6c2c15ad49f6c500304616ef67b70e0"
-dependencies = [
- "alloy-json-rpc 0.7.3",
- "base64 0.22.1",
- "futures-util",
- "futures-utils-wasm",
- "serde",
- "serde_json",
- "thiserror 2.0.8",
- "tokio",
- "tower 0.5.2",
- "tracing",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-transport"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf656f983e14812df65b5aee37e7b37535f68a848295e6ed736b2054a405cb7"
@@ -1722,21 +1453,6 @@ checksum = "5dc013132e34eeadaa0add7e74164c1503988bfba8bae885b32e0918ba85a8a6"
 dependencies = [
  "alloy-json-rpc 0.6.4",
  "alloy-transport 0.6.4",
- "reqwest 0.12.9",
- "serde_json",
- "tower 0.5.2",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "alloy-transport-http"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e02ffd5d93ffc51d72786e607c97de3b60736ca3e636ead0ec1f7dce68ea3fd"
-dependencies = [
- "alloy-json-rpc 0.7.3",
- "alloy-transport 0.7.3",
  "reqwest 0.12.9",
  "serde_json",
  "tower 0.5.2",
@@ -3275,37 +2991,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -6677,7 +6362,6 @@ dependencies = [
 name = "pessimistic-proof-test-suite"
 version = "0.1.0"
 dependencies = [
- "agglayer-primitives",
  "agglayer-types",
  "anyhow",
  "base64 0.22.1",

--- a/crates/agglayer-aggregator-notifier/Cargo.toml
+++ b/crates/agglayer-aggregator-notifier/Cargo.toml
@@ -9,9 +9,8 @@ agglayer-certificate-orchestrator = { path = "../agglayer-certificate-orchestrat
 agglayer-config = { path = "../agglayer-config" }
 agglayer-contracts = { path = "../agglayer-contracts" }
 agglayer-prover-types = { path = "../agglayer-prover-types" }
-agglayer-primitives.workspace = true
 agglayer-storage = { path = "../agglayer-storage" }
-agglayer-types = { path = "../agglayer-types" }
+agglayer-types.workspace = true
 pessimistic-proof = { path = "../pessimistic-proof" }
 
 anyhow.workspace = true

--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use agglayer_certificate_orchestrator::{CertificationError, Certifier, CertifierOutput};
 use agglayer_config::Config;
 use agglayer_contracts::RollupContract;
-use agglayer_primitives::Address;
 use agglayer_prover_types::{
     default_bincode_options,
     v1::{
@@ -12,7 +11,9 @@ use agglayer_prover_types::{
     },
 };
 use agglayer_storage::stores::{PendingCertificateReader, PendingCertificateWriter};
-use agglayer_types::{Certificate, Height, LocalNetworkStateData, NetworkId, Proof};
+use agglayer_types::{
+    primitives::Address, Certificate, Height, LocalNetworkStateData, NetworkId, Proof,
+};
 use bincode::Options as _;
 use pessimistic_proof::{
     generate_pessimistic_proof, local_exit_tree::hasher::Keccak256Hasher,

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -36,7 +36,7 @@ agglayer-config = { path = "../agglayer-config" }
 agglayer-contracts = { path = "../agglayer-contracts" }
 agglayer-clock = { path = "../agglayer-clock" }
 agglayer-telemetry = { path = "../agglayer-telemetry" }
-agglayer-types = { path = "../agglayer-types" }
+agglayer-types.workspace = true
 agglayer-signer = { path = "../agglayer-signer" }
 agglayer-storage = { path = "../agglayer-storage" }
 agglayer-certificate-orchestrator = { path = "../agglayer-certificate-orchestrator" }

--- a/crates/agglayer-prover-types/Cargo.toml
+++ b/crates/agglayer-prover-types/Cargo.toml
@@ -16,7 +16,7 @@ tonic = { workspace = true, default-features = false, features = [
     "transport",
 ] }
 
-agglayer-types = { path = "../agglayer-types" }
+agglayer-types.workspace = true
 pessimistic-proof = { path = "../pessimistic-proof" }
 
 [build-dependencies]

--- a/crates/agglayer-prover/Cargo.toml
+++ b/crates/agglayer-prover/Cargo.toml
@@ -32,8 +32,6 @@ agglayer-types.workspace = true
 sp1-sdk = { workspace = true, features = ["native-gnark"] }
 sp1-prover = { workspace = true, features = ["native-gnark"] }
 
-[dev-dependencies]
-
 [features]
 default = []
 testutils = []

--- a/crates/agglayer-prover/Cargo.toml
+++ b/crates/agglayer-prover/Cargo.toml
@@ -27,13 +27,12 @@ agglayer-config = { path = "../agglayer-config" }
 agglayer-prover-types = { path = "../agglayer-prover-types" }
 agglayer-telemetry = { path = "../agglayer-telemetry" }
 pessimistic-proof = { path = "../pessimistic-proof" }
-agglayer-types = { path = "../agglayer-types" }
+agglayer-types.workspace = true
 
 sp1-sdk = { workspace = true, features = ["native-gnark"] }
 sp1-prover = { workspace = true, features = ["native-gnark"] }
 
 [dev-dependencies]
-agglayer-types = { path = "../agglayer-types" }
 
 [features]
 default = []

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -16,7 +16,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 agglayer-config = { path = "../agglayer-config" }
-agglayer-types = { path = "../agglayer-types" }
+agglayer-types.workspace = true
 pessimistic-proof = { path = "../pessimistic-proof" }
 
 mockall = { workspace = true, optional = true }
@@ -28,7 +28,7 @@ rand.workspace = true
 rstest.workspace = true
 sp1-sdk.workspace = true
 
-agglayer-types = { path = "../agglayer-types", features = ["testutils"] }
+agglayer-types = {workspace = true, features = ["testutils"] }
 pessimistic-proof-test-suite = { path = "../pessimistic-proof-test-suite" }
 
 agglayer-storage = { path = ".", features = ["testutils"] }

--- a/crates/agglayer-test-suite/Cargo.toml
+++ b/crates/agglayer-test-suite/Cargo.toml
@@ -5,11 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-alloy = "0.7"
 agglayer-config = { path = "../agglayer-config" }
 agglayer-storage = { path = "../agglayer-storage" }
-agglayer-types = { path = "../agglayer-types" }
-derive_builder = "0.20.2"
 pessimistic-proof = { path = "../pessimistic-proof" }
 pessimistic-proof-test-suite = { path = "../pessimistic-proof-test-suite" }
 

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -34,14 +34,9 @@ pub type CertificateId = Digest;
 pub type Height = u64;
 pub type Metadata = Digest;
 
+pub use agglayer_primitives as primitives;
 pub use pessimistic_proof::bridge_exit::NetworkId;
 use sp1_sdk::SP1VerificationError;
-
-pub mod primitives {
-    pub use agglayer_primitives::{
-        address, ruint, Address, Signature, SignatureError, B256, U256, U512,
-    };
-}
 
 /// ELF of the pessimistic proof program
 pub(crate) const ELF: &[u8] =

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-pub use agglayer_primitives::{address, Address, Signature, B256, U256};
 use pessimistic_proof::global_index::GlobalIndex;
 pub use pessimistic_proof::keccak::digest::Digest;
 use pessimistic_proof::keccak::keccak256_combine;
@@ -27,6 +26,8 @@ use sp1_sdk::{
     SP1PublicValues, SP1Stdin,
 };
 
+use crate::primitives::{Address, Signature, B256, U256};
+
 pub type EpochNumber = u64;
 pub type CertificateIndex = u64;
 pub type CertificateId = Digest;
@@ -35,6 +36,12 @@ pub type Metadata = Digest;
 
 pub use pessimistic_proof::bridge_exit::NetworkId;
 use sp1_sdk::SP1VerificationError;
+
+pub mod primitives {
+    pub use agglayer_primitives::{
+        address, ruint, Address, Signature, SignatureError, B256, U256, U512,
+    };
+}
 
 /// ELF of the pessimistic proof program
 pub(crate) const ELF: &[u8] =

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -26,8 +26,6 @@ use sp1_sdk::{
     SP1PublicValues, SP1Stdin,
 };
 
-use crate::primitives::{Address, Signature, B256, U256};
-
 pub type EpochNumber = u64;
 pub type CertificateIndex = u64;
 pub type CertificateId = Digest;
@@ -35,6 +33,8 @@ pub type Height = u64;
 pub type Metadata = Digest;
 
 pub use agglayer_primitives as primitives;
+// Re-export common primitives again as agglayer-types root types
+pub use agglayer_primitives::{Address, Signature, SignatureError, B256, U256, U512};
 pub use pessimistic_proof::bridge_exit::NetworkId;
 use sp1_sdk::SP1VerificationError;
 

--- a/crates/pessimistic-proof-test-suite/Cargo.toml
+++ b/crates/pessimistic-proof-test-suite/Cargo.toml
@@ -12,8 +12,7 @@ name = "convertor"
 path = "src/bin/convertor.rs"
 
 [dependencies]
-agglayer-primitives.workspace = true
-agglayer-types = { path = "../agglayer-types", features = ["testutils"] }
+agglayer-types = { workspace = true, features = ["testutils"] }
 pessimistic-proof = { path = "../pessimistic-proof" }
 
 base64.workspace = true

--- a/crates/pessimistic-proof-test-suite/src/bin/convertor.rs
+++ b/crates/pessimistic-proof-test-suite/src/bin/convertor.rs
@@ -2,10 +2,7 @@ use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 
-use agglayer_types::{
-    primitives::{Address, Signature, U256},
-    Height, Metadata, NetworkId,
-};
+use agglayer_types::{Address, Height, Metadata, NetworkId, Signature, U256};
 use pessimistic_proof::bridge_exit::{LeafType, TokenInfo};
 use pessimistic_proof::global_index::GlobalIndex;
 use pessimistic_proof::keccak::keccak256;

--- a/crates/pessimistic-proof-test-suite/src/bin/convertor.rs
+++ b/crates/pessimistic-proof-test-suite/src/bin/convertor.rs
@@ -2,7 +2,10 @@ use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 
-use agglayer_types::{Address, Height, Metadata, NetworkId, Signature, U256};
+use agglayer_types::{
+    primitives::{Address, Signature, U256},
+    Height, Metadata, NetworkId,
+};
 use pessimistic_proof::bridge_exit::{LeafType, TokenInfo};
 use pessimistic_proof::global_index::GlobalIndex;
 use pessimistic_proof::keccak::keccak256;

--- a/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
+++ b/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
@@ -1,7 +1,9 @@
 use std::{path::PathBuf, time::Instant};
 
-use agglayer_primitives::Address;
-use agglayer_types::{Certificate, U256};
+use agglayer_types::{
+    primitives::{Address, U256},
+    Certificate,
+};
 use clap::Parser;
 use pessimistic_proof::{
     bridge_exit::{NetworkId, TokenInfo},

--- a/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
+++ b/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
@@ -1,9 +1,6 @@
 use std::{path::PathBuf, time::Instant};
 
-use agglayer_types::{
-    primitives::{Address, U256},
-    Certificate,
-};
+use agglayer_types::{Address, Certificate, U256};
 use clap::Parser;
 use pessimistic_proof::{
     bridge_exit::{NetworkId, TokenInfo},

--- a/crates/pessimistic-proof-test-suite/src/event_data.rs
+++ b/crates/pessimistic-proof-test-suite/src/event_data.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::BufReader};
 
-use agglayer_primitives::U256;
+use agglayer_types::primitives::U256;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use pessimistic_proof::bridge_exit::{BridgeExit, TokenInfo};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer};

--- a/crates/pessimistic-proof-test-suite/src/forest.rs
+++ b/crates/pessimistic-proof-test-suite/src/forest.rs
@@ -1,5 +1,8 @@
-use agglayer_primitives::{Address, U256};
-use agglayer_types::{compute_signature_info, Certificate, LocalNetworkStateData};
+use agglayer_types::{
+    compute_signature_info,
+    primitives::{Address, U256},
+    Certificate, LocalNetworkStateData,
+};
 use ethers_signers::{LocalWallet, Signer};
 use pessimistic_proof::{
     bridge_exit::{BridgeExit, LeafType, NetworkId, TokenInfo},

--- a/crates/pessimistic-proof-test-suite/src/forest.rs
+++ b/crates/pessimistic-proof-test-suite/src/forest.rs
@@ -1,8 +1,4 @@
-use agglayer_types::{
-    compute_signature_info,
-    primitives::{Address, U256},
-    Certificate, LocalNetworkStateData,
-};
+use agglayer_types::{compute_signature_info, Address, Certificate, LocalNetworkStateData, U256};
 use ethers_signers::{LocalWallet, Signer};
 use pessimistic_proof::{
     bridge_exit::{BridgeExit, LeafType, NetworkId, TokenInfo},

--- a/crates/pessimistic-proof-test-suite/src/sample_data.rs
+++ b/crates/pessimistic-proof-test-suite/src/sample_data.rs
@@ -2,8 +2,10 @@
 
 use std::path::PathBuf;
 
-use agglayer_primitives::{address, U256};
-use agglayer_types::Certificate;
+use agglayer_types::{
+    primitives::{address, U256},
+    Certificate,
+};
 use hex_literal::hex;
 use pessimistic_proof::{
     bridge_exit::{BridgeExit, NetworkId, TokenInfo},

--- a/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
+++ b/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
@@ -1,4 +1,4 @@
-use agglayer_primitives::U256;
+use agglayer_types::primitives::U256;
 use pessimistic_proof::{bridge_exit::TokenInfo, generate_pessimistic_proof, LocalNetworkState};
 use pessimistic_proof_test_suite::{
     forest::Forest,


### PR DESCRIPTION
# Description

Exported `agglayer_primitives` through `agglayer_types::primitives`. 

A bit of cleanup of Cargo.toml files.

Fixes #504 

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
