### PR TITLE
chore: re-export `primitives` from `agglayer-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,6 @@ dependencies = [
  "agglayer-certificate-orchestrator",
  "agglayer-config",
  "agglayer-contracts",
- "agglayer-primitives",
  "agglayer-prover",
  "agglayer-prover-types",
  "agglayer-storage",
@@ -6677,7 +6676,6 @@ dependencies = [
 name = "pessimistic-proof-test-suite"
 version = "0.1.0"
 dependencies = [
- "agglayer-primitives",
  "agglayer-types",
  "anyhow",
  "base64 0.22.1",

--- a/crates/agglayer-aggregator-notifier/Cargo.toml
+++ b/crates/agglayer-aggregator-notifier/Cargo.toml
@@ -9,7 +9,6 @@ agglayer-certificate-orchestrator = { path = "../agglayer-certificate-orchestrat
 agglayer-config = { path = "../agglayer-config" }
 agglayer-contracts = { path = "../agglayer-contracts" }
 agglayer-prover-types = { path = "../agglayer-prover-types" }
-agglayer-primitives.workspace = true
 agglayer-storage = { path = "../agglayer-storage" }
 agglayer-types = { path = "../agglayer-types" }
 pessimistic-proof = { path = "../pessimistic-proof" }

--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use agglayer_certificate_orchestrator::{CertificationError, Certifier, CertifierOutput};
 use agglayer_config::Config;
 use agglayer_contracts::RollupContract;
-use agglayer_primitives::Address;
 use agglayer_prover_types::{
     default_bincode_options,
     v1::{
@@ -12,7 +11,7 @@ use agglayer_prover_types::{
     },
 };
 use agglayer_storage::stores::{PendingCertificateReader, PendingCertificateWriter};
-use agglayer_types::{Certificate, Height, LocalNetworkStateData, NetworkId, Proof};
+use agglayer_types::{Address, Certificate, Height, LocalNetworkStateData, NetworkId, Proof};
 use bincode::Options as _;
 use pessimistic_proof::{
     generate_pessimistic_proof, local_exit_tree::hasher::Keccak256Hasher,

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-pub use agglayer_primitives::{address, Address, Signature, B256, U256};
+pub use agglayer_primitives::{self as primitives, address, Address, Signature, B256, U256};
 use pessimistic_proof::global_index::GlobalIndex;
 pub use pessimistic_proof::keccak::digest::Digest;
 use pessimistic_proof::keccak::keccak256_combine;

--- a/crates/pessimistic-proof-test-suite/Cargo.toml
+++ b/crates/pessimistic-proof-test-suite/Cargo.toml
@@ -12,7 +12,6 @@ name = "convertor"
 path = "src/bin/convertor.rs"
 
 [dependencies]
-agglayer-primitives.workspace = true
 agglayer-types = { path = "../agglayer-types", features = ["testutils"] }
 pessimistic-proof = { path = "../pessimistic-proof" }
 

--- a/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
+++ b/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
@@ -1,7 +1,6 @@
 use std::{path::PathBuf, time::Instant};
 
-use agglayer_primitives::Address;
-use agglayer_types::{Certificate, U256};
+use agglayer_types::{Address, Certificate, U256};
 use clap::Parser;
 use pessimistic_proof::{
     bridge_exit::{NetworkId, TokenInfo},

--- a/crates/pessimistic-proof-test-suite/src/event_data.rs
+++ b/crates/pessimistic-proof-test-suite/src/event_data.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::BufReader};
 
-use agglayer_primitives::U256;
+use agglayer_types::U256;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use pessimistic_proof::bridge_exit::{BridgeExit, TokenInfo};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer};

--- a/crates/pessimistic-proof-test-suite/src/forest.rs
+++ b/crates/pessimistic-proof-test-suite/src/forest.rs
@@ -1,5 +1,4 @@
-use agglayer_primitives::{Address, U256};
-use agglayer_types::{compute_signature_info, Certificate, LocalNetworkStateData};
+use agglayer_types::{compute_signature_info, Address, Certificate, LocalNetworkStateData, U256};
 use ethers_signers::{LocalWallet, Signer};
 use pessimistic_proof::{
     bridge_exit::{BridgeExit, LeafType, NetworkId, TokenInfo},

--- a/crates/pessimistic-proof-test-suite/src/sample_data.rs
+++ b/crates/pessimistic-proof-test-suite/src/sample_data.rs
@@ -2,8 +2,7 @@
 
 use std::path::PathBuf;
 
-use agglayer_primitives::{address, U256};
-use agglayer_types::Certificate;
+use agglayer_types::{address, Certificate, U256};
 use hex_literal::hex;
 use pessimistic_proof::{
     bridge_exit::{BridgeExit, NetworkId, TokenInfo},


### PR DESCRIPTION
Basically two changes:
* Make `aggalyer_primitives` available as `agglayer_types::primitives`.
* Use the re-exported paths where applicable. This eliminates some direct dependencies on `agglayer-primitives`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
