### PR TITLE
refactor: move logic from rpc to a separate component

### DIFF
--- a/crates/agglayer-node/src/kernel/mod.rs
+++ b/crates/agglayer-node/src/kernel/mod.rs
@@ -35,7 +35,7 @@ pub(crate) struct Kernel<RpcProvider> {
 
 /// Errors related to the ZkEVM node proof verification process.
 #[derive(Error, Debug)]
-pub(crate) enum ZkevmNodeVerificationError {
+pub enum ZkevmNodeVerificationError {
     /// The given rollup id is not specified in the configuration.
     #[error("invalid rollup id: {0}")]
     InvalidRollupId(u32),
@@ -154,7 +154,7 @@ where
 
 /// Errors related to signature verification process.
 #[derive(Error, Debug)]
-pub(crate) enum SignatureVerificationError<RpcProvider>
+pub enum SignatureVerificationError<RpcProvider>
 where
     RpcProvider: Middleware,
 {
@@ -178,7 +178,7 @@ where
 
 /// Errors related to settlement process.
 #[derive(Error, Debug)]
-pub(crate) enum SettlementError<RpcProvider>
+pub enum SettlementError<RpcProvider>
 where
     RpcProvider: Middleware,
 {
@@ -196,7 +196,7 @@ where
 }
 
 #[derive(Error, Debug)]
-pub(crate) enum CheckTxStatusError<RpcProvider: Middleware> {
+pub enum CheckTxStatusError<RpcProvider: Middleware> {
     #[error("middleware error: {0}")]
     ProviderError(RpcProvider::Error),
 }

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -10,6 +10,7 @@ mod kernel;
 mod logging;
 mod rate_limiting;
 mod rpc;
+pub mod service;
 mod signed_tx;
 pub mod utils;
 mod zkevm_node_client;

--- a/crates/agglayer-node/src/rpc/mod.rs
+++ b/crates/agglayer-node/src/rpc/mod.rs
@@ -1,41 +1,23 @@
 use std::sync::Arc;
 
-use agglayer_config::epoch::BlockClockConfig;
-use agglayer_config::Config;
-use agglayer_config::Epoch;
-use agglayer_storage::columns::latest_settled_certificate_per_network::SettledCertificate;
-use agglayer_storage::stores::DebugReader;
-use agglayer_storage::stores::DebugWriter;
-use agglayer_storage::stores::PendingCertificateReader;
-use agglayer_storage::stores::PendingCertificateWriter;
-use agglayer_storage::stores::StateReader;
-use agglayer_storage::stores::StateWriter;
-use agglayer_telemetry::KeyValue;
-use agglayer_types::CertificateStatus;
-use agglayer_types::EpochConfiguration;
-use agglayer_types::{Certificate, CertificateHeader, CertificateId, Height, NetworkId};
-use ethers::{
-    contract::{ContractError, ContractRevert},
-    providers::Middleware,
-    types::H256,
+use agglayer_storage::stores::{
+    DebugReader, DebugWriter, PendingCertificateReader, PendingCertificateWriter, StateReader,
+    StateWriter,
 };
-use futures::TryFutureExt;
+use agglayer_types::{
+    Certificate, CertificateHeader, CertificateId, EpochConfiguration, NetworkId,
+};
+use ethers::{providers::Middleware, types::H256};
 use jsonrpsee::{
     core::async_trait,
     proc_macros::rpc,
     server::{middleware::http::ProxyGetRequestLayer, PingConfig, ServerBuilder, ServerHandle},
 };
-use tokio::{sync::mpsc, try_join};
-use tower_http::compression::CompressionLayer;
-use tower_http::cors::CorsLayer;
-use tracing::trace;
-use tracing::{debug, error, info, instrument};
+use tower_http::{compression::CompressionLayer, cors::CorsLayer};
+use tracing::info;
 
-use crate::{
-    kernel::Kernel,
-    rpc::error::{Error, RpcResult, StatusError},
-    signed_tx::SignedTx,
-};
+use self::error::{Error, RpcResult};
+use crate::{service::AgglayerService, signed_tx::SignedTx};
 
 mod error;
 mod rpc_middleware;
@@ -90,12 +72,7 @@ trait Agglayer {
 
 /// The RPC agglayer service implementation.
 pub(crate) struct AgglayerImpl<Rpc, PendingStore, StateStore, DebugStore> {
-    kernel: Kernel<Rpc>,
-    certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
-    pending_store: Arc<PendingStore>,
-    state: Arc<StateStore>,
-    debug_store: Arc<DebugStore>,
-    config: Arc<Config>,
+    service: Arc<AgglayerService<Rpc, PendingStore, StateStore, DebugStore>>,
 }
 
 impl<Rpc, PendingStore, StateStore, DebugStore>
@@ -103,21 +80,9 @@ impl<Rpc, PendingStore, StateStore, DebugStore>
 {
     /// Create an instance of the RPC agglayer service.
     pub(crate) fn new(
-        kernel: Kernel<Rpc>,
-        certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
-        pending_store: Arc<PendingStore>,
-        state: Arc<StateStore>,
-        debug_store: Arc<DebugStore>,
-        config: Arc<Config>,
+        service: Arc<AgglayerService<Rpc, PendingStore, StateStore, DebugStore>>,
     ) -> Self {
-        Self {
-            kernel,
-            certificate_sender,
-            pending_store,
-            state,
-            debug_store,
-            config,
-        }
+        Self { service }
     }
 }
 
@@ -125,7 +90,7 @@ impl<Rpc, PendingStore, StateStore, DebugStore> Drop
     for AgglayerImpl<Rpc, PendingStore, StateStore, DebugStore>
 {
     fn drop(&mut self) {
-        info!("Shutting down the agglayer service");
+        info!("Shutting down the agglayer JsonRPC server");
     }
 }
 
@@ -138,15 +103,7 @@ where
     DebugStore: DebugReader + DebugWriter + 'static,
 {
     pub(crate) async fn start(self) -> anyhow::Result<ServerHandle> {
-        // Create the RPC service
-        let config = self.config.clone();
-        let mut service = self.into_rpc();
-
-        // Register the system_health method to serve health checks.
-        service.register_method(
-            "system_health",
-            |_, _, _| serde_json::json!({ "health": true }),
-        )?;
+        let config = self.service.config();
 
         // Create the RPC server.
         let mut server_builder = ServerBuilder::new()
@@ -191,9 +148,18 @@ where
 
         let server = server_builder
             .set_http_middleware(middleware)
-            .set_rpc_middleware(rpc_middleware::from_config(&config))
+            .set_rpc_middleware(rpc_middleware::from_config(config))
             .build(addr)
             .await?;
+
+        // Create the RPC service
+        let mut service = self.into_rpc();
+
+        // Register the system_health method to serve health checks.
+        service.register_method(
+            "system_health",
+            |_, _, _| serde_json::json!({ "health": true }),
+        )?;
 
         info!("Listening on {addr}");
 
@@ -210,380 +176,70 @@ where
     StateStore: StateReader + StateWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
 {
-    #[instrument(skip(self, tx), fields(hash, rollup_id = tx.tx.rollup_id), level = "info")]
     async fn send_tx(&self, tx: SignedTx) -> RpcResult<H256> {
-        let hash = format!("{:?}", tx.hash());
-        tracing::Span::current().record("hash", &hash);
-
-        info!(
-            hash,
-            "Received transaction {hash} for rollup {}", tx.tx.rollup_id
-        );
-        let rollup_id_str = tx.tx.rollup_id.to_string();
-        let metrics_attrs = &[KeyValue::new("rollup_id", rollup_id_str)];
-
-        agglayer_telemetry::SEND_TX.add(1, metrics_attrs);
-
-        if !self.kernel.check_rollup_registered(tx.tx.rollup_id) {
-            // Return an invalid params error if the rollup is not registered.
-            return Err(Error::rollup_not_registered(tx.tx.rollup_id));
-        }
-
-        self.kernel.verify_signature(&tx).await.map_err(|e| {
-            error!(error = %e, hash, "Failed to verify the signature of transaction {hash}: {e}");
-            Error::signature_mismatch(e)
-        })?;
-
-        agglayer_telemetry::VERIFY_SIGNATURE.add(1, metrics_attrs);
-
-        // Reserve a rate limiting slot.
-        let guard = self
-            .kernel
-            .rate_limiter()
-            .reserve_send_tx(tx.tx.rollup_id, tokio::time::Instant::now())?;
-
-        agglayer_telemetry::CHECK_TX.add(1, metrics_attrs);
-
-        // Run all the verification checks in parallel.
-        try_join!(
-            self.kernel
-                .verify_proof_eth_call(&tx)
-                .map_err(|e| {
-                    let zkevm_error = decode_contract_error::<
-                        _,
-                        agglayer_contracts::polygon_zk_evm::PolygonZkEvmErrors,
-                    >(&e);
-
-                    let rollup_error = decode_contract_error::<
-                        _,
-                        agglayer_contracts::polygon_rollup_manager::PolygonRollupManagerErrors,
-                    >(&e);
-
-                    let error = match (zkevm_error, rollup_error) {
-                        (Some(zkevm_error), _) => zkevm_error,
-                        (_, Some(rollup_error)) => rollup_error,
-                        (_, _) => e.to_string(),
-                    };
-
-                    error!(
-                        error_code = %e,
-                        error,
-                        hash,
-                        "Failed to dry-run the verify_batches_trusted_aggregator for transaction \
-                         {hash}: {error}"
-                    );
-                    Error::dry_run(error)
-                })
-                .map_ok(|_| {
-                    agglayer_telemetry::EXECUTE.add(1, metrics_attrs);
-                }),
-            self.kernel
-                .verify_proof_zkevm_node(&tx)
-                .map_err(|e| {
-                    error!(
-                        error = %e,
-                        hash,
-                        "Failed to verify the batch local_exit_root and state_root of transaction \
-                         {hash}: {e}"
-                    );
-                    Error::root_verification(e)
-                })
-                .map_ok(|_| {
-                    agglayer_telemetry::VERIFY_ZKP.add(1, metrics_attrs);
-                })
-        )?;
-
-        // Settle the proof on-chain and return the transaction hash.
-        let receipt = self.kernel.settle(&tx, guard).await.map_err(|e| {
-            error!(
-                error = %e,
-                hash,
-                "Failed to settle transaction {hash} on L1: {e}"
-            );
-            Error::settlement(e)
-        })?;
-
-        agglayer_telemetry::SETTLE.add(1, metrics_attrs);
-
-        info!(hash, "Successfully settled transaction {hash}");
-
-        Ok(receipt.transaction_hash)
+        Ok(self.service.send_tx(tx).await?)
     }
 
-    #[instrument(skip(self), fields(hash = hash.to_string()), level = "info")]
     async fn get_tx_status(&self, hash: H256) -> RpcResult<TxStatus> {
-        debug!("Received request to get transaction status for hash {hash}");
-        let receipt = self.kernel.check_tx_status(hash).await.map_err(|e| {
-            error!("Failed to get transaction status for hash {hash}: {e}");
-            StatusError::tx_status(e)
-        })?;
-
-        let current_block = self.kernel.current_l1_block_height().await.map_err(|e| {
-            error!("Failed to get current L1 block: {e}");
-            StatusError::l1_block(e)
-        })?;
-
-        let receipt = receipt.ok_or_else(|| StatusError::tx_not_found(hash))?;
-
-        let status = match receipt.block_number {
-            Some(block_number) if block_number < current_block => "done",
-            Some(_) => "pending",
-            None => "not found",
-        };
-        Ok(status.to_string())
+        Ok(self.service.get_tx_status(hash).await?.to_string())
     }
 
-    #[instrument(skip(self, certificate), fields(hash, rollup_id = *certificate.network_id), level = "info")]
     async fn send_certificate(&self, certificate: Certificate) -> RpcResult<CertificateId> {
-        let hash = certificate.hash();
-        tracing::Span::current().record("hash", hash.to_string());
-
-        info!(
-            %hash,
-            "Received certificate {hash} for rollup {} at height {}", *certificate.network_id, certificate.height
-        );
-
-        // TODO: Batch the different queries.
-        // Insert the certificate header into the state store.
-        _ = self
-            .state
-            .insert_certificate_header(&certificate, CertificateStatus::Pending)
-            .map_err(|e| {
-                error!("Failed to insert certificate into state store: {e}");
-                Error::internal(e.to_string())
-            })?;
-
-        // Insert the certificate into the pending store.
-        _ = self
-            .pending_store
-            .insert_pending_certificate(certificate.network_id, certificate.height, &certificate)
-            .map_err(|e| {
-                error!("Failed to insert certificate into pending store: {e}");
-                Error::internal(e.to_string())
-            })?;
-
-        _ = self.debug_store.add_certificate(&certificate).map_err(|e| {
-            error!("Failed to insert certificate into debug store: {e}");
-            Error::internal(e.to_string())
-        });
-
-        if let Err(error) = self
-            .certificate_sender
-            .send((
-                certificate.network_id,
-                certificate.height,
-                certificate.hash(),
-            ))
-            .await
-        {
-            error!("Failed to send certificate: {error}");
-
-            return Err(Error::send_certificate(error));
-        }
-
-        Ok(hash)
+        Ok(self.service.send_certificate(certificate).await?)
     }
 
     async fn get_certificate_header(
         &self,
         certificate_id: CertificateId,
     ) -> RpcResult<CertificateHeader> {
-        trace!("Received request to get certificate header for certificate {certificate_id}");
-        match self.state.get_certificate_header(&certificate_id) {
-            Ok(Some(header)) => Ok(header),
-            Ok(None) => Err(Error::resource_not_found(format!(
-                "Certificate({})",
-                certificate_id
-            ))),
-            Err(error) => {
-                error!("Failed to get certificate header: {}", error);
-
-                Err(Error::internal("Unable to get certificate header"))
-            }
-        }
+        Ok(self.service.get_certificate_header(certificate_id)?)
     }
 
     async fn get_epoch_configuration(&self) -> RpcResult<EpochConfiguration> {
-        info!("Received request to get epoch configuration");
-
-        if let Epoch::BlockClock(BlockClockConfig {
-            epoch_duration,
-            genesis_block,
-        }) = self.config.epoch
-        {
-            Ok(EpochConfiguration {
-                epoch_duration: epoch_duration.into(),
-                genesis_block,
-            })
-        } else {
-            Err(Error::internal(
+        Ok(self.service.get_epoch_configuration().ok_or_else(|| {
+            Error::internal(
                 "AggLayer isn't configured with a BlockClock configuration, thus no \
                  EpochConfiguration is available",
-            ))
-        }
+            )
+        })?)
     }
 
     async fn get_latest_known_certificate_header(
         &self,
         network_id: NetworkId,
     ) -> RpcResult<Option<CertificateHeader>> {
-        debug!(
-            "Received request to get the latest known certificate header for rollup {}",
-            network_id
-        );
-
-        let settled_certificate_id_and_height = self
-            .state
-            .get_latest_settled_certificate_per_network(&network_id)
-            .map_err(|e| {
-                error!("Failed to get latest settled certificate: {e}");
-
-                Error::internal(e.to_string())
-            })?
-            .map(|(_, SettledCertificate(id, height, _, _))| (id, height));
-
-        let proven_certificate_id_and_height = self
-            .pending_store
-            .get_latest_proven_certificate_per_network(&network_id)
-            .map_err(|e| {
-                error!("Failed to get latest proven certificate: {e}");
-                Error::internal(e.to_string())
-            })?
-            .map(|(_, height, id)| (id, height));
-
-        let pending_certificate_id_and_height = self
-            .pending_store
-            .get_latest_pending_certificate_for_network(&network_id)
-            .map_err(|e| {
-                error!("Failed to get latest pending certificate: {e}");
-                Error::internal(e.to_string())
-            })?;
-
-        let certificate_id = [
-            settled_certificate_id_and_height,
-            proven_certificate_id_and_height,
-            pending_certificate_id_and_height,
-        ]
-        .into_iter()
-        .flatten()
-        .max_by(|x, y| x.1.cmp(&y.1))
-        .map(|v| v.0);
-
-        if let Some(certificate_id) = certificate_id {
-            match self.state.get_certificate_header(&certificate_id) {
-                Ok(Some(header)) => Ok(Some(header)),
-                Ok(None) => Err(Error::resource_not_found(format!(
-                    "Certificate({})",
-                    certificate_id
-                ))),
-                Err(error) => {
-                    error!(
-                        hash = certificate_id.to_string(),
-                        "Failed to get certificate header: {}", error
-                    );
-
-                    Err(Error::internal("Unable to get certificate header"))
-                }
-            }
-        } else {
-            Ok(None)
-        }
+        let header = self
+            .service
+            .get_latest_known_certificate_header(network_id)?;
+        Ok(header)
     }
 
     async fn debug_get_certificate(
         &self,
         certificate_id: CertificateId,
     ) -> RpcResult<(Certificate, Option<CertificateHeader>)> {
-        match self.debug_store.get_certificate(&certificate_id) {
-            Ok(Some(cert)) => match self
-                .state
-                .get_certificate_header(&certificate_id)
-                .map(|header| (cert, header))
-            {
-                Ok(result) => Ok(result),
-                Err(error) => {
-                    error!("Failed to get certificate header: {}", error);
-                    Err(Error::internal("Unable to get certificate header"))
-                }
-            },
-            Ok(None) => Err(Error::resource_not_found(format!(
-                "Certificate({})",
-                certificate_id
-            ))),
-            Err(error) => {
-                error!("Failed to get certificate: {}", error);
-
-                Err(Error::internal("Unable to get certificate"))
-            }
-        }
+        Ok(self.service.debug_get_certificate(certificate_id).await?)
     }
 
     async fn get_latest_settled_certificate_header(
         &self,
         network_id: NetworkId,
     ) -> RpcResult<Option<CertificateHeader>> {
-        let id = match self
-            .state
-            .get_latest_settled_certificate_per_network(&network_id)
-        {
-            Ok(Some((_, SettledCertificate(id, _, _, _)))) => id,
-            Ok(None) => {
-                return Ok(None);
-            }
-            Err(e) => {
-                error!("Failed to get latest settled certificate header: {e}");
-                return Err(Error::internal(e.to_string()));
-            }
-        };
-
-        match self.state.get_certificate_header(&id) {
-            Ok(Some(header)) => Ok(Some(header)),
-            Ok(None) => Err(Error::resource_not_found(format!("Certificate({})", id))),
-            Err(e) => {
-                error!("Failed to get certificate header: {e}");
-                Err(Error::internal(e.to_string()))
-            }
-        }
+        let header = self
+            .service
+            .get_latest_settled_certificate_header(network_id)?;
+        Ok(header)
     }
 
     async fn get_latest_pending_certificate_header(
         &self,
         network_id: NetworkId,
     ) -> RpcResult<Option<CertificateHeader>> {
-        let id = match self
-            .pending_store
-            .get_latest_pending_certificate_for_network(&network_id)
-        {
-            Ok(Some((id, _height))) => id,
-            Ok(None) => {
-                return Ok(None);
-            }
-            Err(e) => {
-                error!("Failed to get latest settled certificate header: {e}");
-                return Err(Error::internal(e.to_string()));
-            }
-        };
-
-        match self.state.get_certificate_header(&id) {
-            Ok(Some(CertificateHeader {
-                status: CertificateStatus::Settled,
-                ..
-            })) => Ok(None),
-            Ok(Some(header)) => Ok(Some(header)),
-            Ok(None) => Err(Error::resource_not_found(format!("Certificate({})", id))),
-            Err(e) => {
-                error!("Failed to get certificate header: {e}");
-                Err(Error::internal(e.to_string()))
-            }
-        }
+        let header = self
+            .service
+            .get_latest_pending_certificate_header(network_id)?;
+        Ok(header)
     }
-}
-
-fn decode_contract_error<M: Middleware, E: ContractRevert + std::fmt::Debug>(
-    e: &ContractError<M>,
-) -> Option<String> {
-    e.decode_contract_revert::<E>()
-        .map(|err| format!("{:?}", err))
 }
 
 type TxStatus = String;

--- a/crates/agglayer-node/src/rpc/tests/errors.rs
+++ b/crates/agglayer-node/src/rpc/tests/errors.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+use agglayer_contracts::polygon_rollup_manager::PolygonRollupManagerErrors;
+use agglayer_types::Digest;
 use ethers::{
     providers::ProviderError,
     types::{Bytes, SignatureError as EthSignatureError, H160, H256},
@@ -12,100 +14,121 @@ use crate::{
     kernel::{self, ZkevmNodeVerificationError},
     rate_limiting::{self, component, Component},
     rpc::Error,
+    service,
 };
 
 type RpcProvider = ethers::providers::Provider<ethers::providers::Http>;
+type CheckTxStatusError = kernel::CheckTxStatusError<RpcProvider>;
 type ContractError = ethers::contract::ContractError<RpcProvider>;
-type SignatureError = kernel::SignatureVerificationError<RpcProvider>;
+type SendTxError = service::SendTxError<RpcProvider>;
 type SettlementError = kernel::SettlementError<RpcProvider>;
+type SignatureError = kernel::SignatureVerificationError<RpcProvider>;
+type TxStatusError = service::TxStatusError<RpcProvider>;
 type WallClockLimitedInfo = <component::SendTx as Component>::LimitedInfo;
 
 #[rstest::rstest]
-#[case("rollup_not_reg", Error::rollup_not_registered(1337))]
+#[case("rollup_not_reg", SendTxError::RollupNotRegistered { rollup_id: 1337 })]
 #[case(
     "sig_invalid_len",
-    Error::signature_mismatch(SignatureError::CouldNotRecoverSigner(
+    SendTxError::SignatureError(SignatureError::CouldNotRecoverSigner(
         EthSignatureError::InvalidLength(42)
     ))
 )]
-#[case("sig_verif", Error::signature_mismatch(SignatureError::CouldNotRecoverSigner(
+#[case("sig_verif", SendTxError::SignatureError(SignatureError::CouldNotRecoverSigner(
     EthSignatureError::VerificationError(H160([0x11; 20]), H160([0x22; 20]))
 )))]
 #[case(
     "sig_recov",
-    Error::signature_mismatch(SignatureError::CouldNotRecoverSigner(
+    SendTxError::SignatureError(SignatureError::CouldNotRecoverSigner(
         EthSignatureError::RecoveryError
     ))
 )]
 #[case(
     "sig_signer",
-    Error::signature_mismatch(SignatureError::InvalidSigner{
+    SendTxError::SignatureError(SignatureError::InvalidSigner{
         signer: H160([0x33; 20]),
         trusted_sequencer: H160([0x44; 20]),
     })
 )]
-#[case("sig_contract", Error::signature_mismatch(ContractError::ContractNotDeployed.into()))]
-#[case("dry_run", Error::dry_run("Dry run flopped.".into()))]
+#[case("sig_contract", SendTxError::SignatureError(ContractError::ContractNotDeployed.into()))]
+#[case("dry_run_rollup_man", SendTxError::DryRunRollupManager(
+        PolygonRollupManagerErrors::RevertString("Reverting".into())
+))]
 #[case(
     "root_bad_rollup",
-    Error::root_verification(ZkevmNodeVerificationError::InvalidRollupId(13))
+    SendTxError::RootVerification(ZkevmNodeVerificationError::InvalidRollupId(13))
 )]
 #[case(
     "root_rpc",
-    Error::root_verification(ZkevmNodeVerificationError::RpcError(
+    SendTxError::RootVerification(ZkevmNodeVerificationError::RpcError(
         jsonrpsee::core::client::Error::Custom("Node smells too much".into())
     ))
 )]
 #[case(
     "root_state",
-    Error::root_verification(ZkevmNodeVerificationError::InvalidStateRoot {
+    SendTxError::RootVerification(ZkevmNodeVerificationError::InvalidStateRoot {
         expected: H256([0x55; 32]),
         got: H256([0x66; 32]),
     })
 )]
 #[case(
     "root_exit",
-    Error::root_verification(ZkevmNodeVerificationError::InvalidExitRoot {
+    SendTxError::RootVerification(ZkevmNodeVerificationError::InvalidExitRoot {
         expected: H256([0x77; 32]),
         got: H256([0x88; 32]),
     })
 )]
-#[case("settle_receipt", Error::settlement(SettlementError::NoReceipt))]
+#[case("settle_receipt", SendTxError::Settlement(SettlementError::NoReceipt))]
 #[case(
     "settle_io",
-    Error::settlement(SettlementError::ProviderError(ProviderError::UnsupportedRPC))
+    SendTxError::Settlement(SettlementError::ProviderError(ProviderError::UnsupportedRPC))
 )]
 #[case(
     "settle_contract",
-    Error::settlement(SettlementError::ContractError(ContractError::Revert(
+    SendTxError::Settlement(SettlementError::ContractError(ContractError::Revert(
         Bytes::from_static(b"foo")
     )))
 )]
 #[case(
     "settle_l1_timeout",
-    Error::settlement(SettlementError::Timeout(Duration::from_secs(30 * 60)))
+    SendTxError::Settlement(SettlementError::Timeout(Duration::from_secs(30 * 60)))
 )]
 #[case(
     "rate_disallowed",
-    rate_limiting::RateLimited::SendTxDiabled {}.into()
+    SendTxError::RateLimited(rate_limiting::RateLimited::SendTxDiabled {})
 )]
 #[case(
     "rate_sendtx",
-    rate_limiting::RateLimited::SendTxRateLimited(WallClockLimitedInfo {
+    SendTxError::RateLimited(rate_limiting::RateLimited::SendTxRateLimited(WallClockLimitedInfo {
         max_per_interval: 3,
         time_interval: Duration::from_secs(30 * 60),
         until_next: Some(Duration::from_secs(123)),
-    }).into()
+    }))
 )]
 #[case(
     "rate_sendtx_nonext",
-    rate_limiting::RateLimited::SendTxRateLimited(WallClockLimitedInfo {
+    SendTxError::RateLimited(rate_limiting::RateLimited::SendTxRateLimited(WallClockLimitedInfo {
         max_per_interval: 4,
         time_interval: Duration::from_secs(40 * 60),
         until_next: None,
-    }).into()
+    }))
 )]
-fn rpc_error_rendering(#[case] name: &str, #[case] err: Error) {
+#[case(
+    "txstatus_notfound",
+    TxStatusError::TxNotFound { hash: H256([0x97; 32]) }
+)]
+#[case(
+    "txstatus_check",
+    TxStatusError::StatusCheck(CheckTxStatusError::ProviderError(
+        ProviderError::SignerUnavailable
+    ))
+)]
+#[case(
+    "cert_notfound",
+    service::CertificateRetrievalError::NotFound { certificate_id: Digest([0x51; 32]) }
+)]
+fn rpc_error_rendering(#[case] name: &str, #[case] err: impl Into<Error>) {
+    let err: Error = err.into();
     let debug_str = format!("{err:?}");
     let err_obj = ErrorObjectOwned::from(err);
     let err_json_string = {

--- a/crates/agglayer-node/src/rpc/tests/send_certificate.rs
+++ b/crates/agglayer-node/src/rpc/tests/send_certificate.rs
@@ -9,6 +9,7 @@ use super::next_available_addr;
 use crate::{
     kernel::Kernel,
     rpc::{tests::DummyStore, AgglayerImpl},
+    service::AgglayerService,
 };
 
 #[test_log::test(tokio::test)]
@@ -31,17 +32,16 @@ async fn send_certificate_method_can_be_called() {
 
     let kernel = Kernel::new(Arc::new(provider), config.clone());
 
-    let _server_handle = AgglayerImpl::new(
+    let service = AgglayerService::new(
         kernel,
         certificate_sender,
         Arc::new(DummyStore {}),
         Arc::new(DummyStore {}),
         Arc::new(DummyStore {}),
         config.clone(),
-    )
-    .start()
-    .await
-    .unwrap();
+    );
+
+    let _server_handle = AgglayerImpl::new(Arc::new(service)).start().await.unwrap();
 
     let url = format!("http://{}/", config.rpc_addr());
     let client = HttpClientBuilder::default().build(url).unwrap();
@@ -73,17 +73,16 @@ async fn send_certificate_method_can_be_called_and_fail() {
 
     let kernel = Kernel::new(Arc::new(provider), config.clone());
 
-    let _server_handle = AgglayerImpl::new(
+    let service = AgglayerService::new(
         kernel,
         certificate_sender,
         Arc::new(DummyStore {}),
         Arc::new(DummyStore {}),
         Arc::new(DummyStore {}),
         config.clone(),
-    )
-    .start()
-    .await
-    .unwrap();
+    );
+
+    let _server_handle = AgglayerImpl::new(Arc::new(service)).start().await.unwrap();
 
     let url = format!("http://{}/", config.rpc_addr());
     let client = HttpClientBuilder::default().build(url).unwrap();

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_notfound.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_notfound.snap
@@ -1,0 +1,12 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "ResourceNotFound(\"Certificate(0x5151515151515151515151515151515151515151515151515151515151515151)\")"
+snapshot_kind: text
+---
+{
+  "code": -10008,
+  "data": {
+    "resource-not-found": "Certificate(0x5151515151515151515151515151515151515151515151515151515151515151)"
+  },
+  "message": "Resource not found: Certificate(0x5151515151515151515151515151515151515151515151515151515151515151)"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__dry_run_rollup_man.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__dry_run_rollup_man.snap
@@ -1,0 +1,16 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Validation(DryRun { detail: \"Reverting\" })"
+snapshot_kind: text
+---
+{
+  "code": -10003,
+  "data": {
+    "validation": {
+      "dry-run": {
+        "detail": "Reverting"
+      }
+    }
+  },
+  "message": "Validation failed: Dry run failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__txstatus_check.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__txstatus_check.snap
@@ -1,0 +1,16 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Status(TxStatus { detail: \"middleware error: Attempted to sign a transaction with no available signer. Hint: did you mean to use a SignerMiddleware?\" })"
+snapshot_kind: text
+---
+{
+  "code": -10005,
+  "data": {
+    "status": {
+      "tx-status": {
+        "detail": "middleware error: Attempted to sign a transaction with no available signer. Hint: did you mean to use a SignerMiddleware?"
+      }
+    }
+  },
+  "message": "Status retrieval error: Failed to get tx status"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__txstatus_notfound.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__txstatus_notfound.snap
@@ -1,0 +1,16 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "Status(TxNotFound { hash: 0x9797979797979797979797979797979797979797979797979797979797979797 })"
+snapshot_kind: text
+---
+{
+  "code": -10005,
+  "data": {
+    "status": {
+      "tx-not-found": {
+        "hash": "0x9797979797979797979797979797979797979797979797979797979797979797"
+      }
+    }
+  },
+  "message": "Status retrieval error: Transaction not found"
+}

--- a/crates/agglayer-node/src/service/error.rs
+++ b/crates/agglayer-node/src/service/error.rs
@@ -1,0 +1,94 @@
+//! Error types for the top-level Agglayer service.
+
+use agglayer_contracts::{
+    polygon_rollup_manager::PolygonRollupManagerErrors, polygon_zk_evm::PolygonZkEvmErrors,
+};
+pub use agglayer_storage::error::Error as StorageError;
+pub use agglayer_types::Digest;
+use ethers::{contract::ContractError, providers::Middleware, types::H256};
+
+pub use crate::{
+    kernel::{
+        CheckTxStatusError, SettlementError, SignatureVerificationError, ZkevmNodeVerificationError,
+    },
+    rate_limiting::RateLimited as RateLimitedError,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum CertificateRetrievalError {
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+
+    #[error("Data for certificate {certificate_id} not found")]
+    NotFound { certificate_id: Digest },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CertificateSubmissionError {
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+
+    #[error("Failed to send the certificate to the orchestrator")]
+    OrchestratorNotResponsive,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TxStatusError<Rpc: 'static + Middleware> {
+    #[error("Status retrieval error: {0}")]
+    StatusCheck(CheckTxStatusError<Rpc>),
+
+    #[error("Failed to get L1 block: {0}")]
+    L1BlockRetrieval(CheckTxStatusError<Rpc>),
+
+    #[error("Transaction {hash} not found")]
+    TxNotFound { hash: H256 },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SendTxError<Rpc: 'static + Middleware> {
+    #[error("Rate limited: {0}")]
+    RateLimited(#[from] RateLimitedError),
+
+    #[error(transparent)]
+    SignatureError(#[from] SignatureVerificationError<Rpc>),
+
+    #[error("Rollup {rollup_id} not registered")]
+    RollupNotRegistered { rollup_id: u32 },
+
+    #[error("Zkevm error during dry run: {0:?}")]
+    DryRunZkEvm(PolygonZkEvmErrors),
+
+    #[error("Rollup manager error during dry run: {0:?}")]
+    DryRunRollupManager(PolygonRollupManagerErrors),
+
+    #[error("Error during dry run: {0}")]
+    DryRunOther(ContractError<Rpc>),
+
+    #[error("Failed to verify local exit root or state root: {0}")]
+    RootVerification(ZkevmNodeVerificationError),
+
+    #[error("Settlement failed: {0}")]
+    Settlement(SettlementError<Rpc>),
+}
+
+impl<Rpc: 'static + Middleware> SendTxError<Rpc> {
+    /// Decode the dry run contract errors.
+    pub fn dry_run(err: &ContractError<Rpc>) -> Self {
+        err.decode_contract_revert::<PolygonZkEvmErrors>()
+            .map(Self::DryRunZkEvm)
+            .or_else(|| {
+                err.decode_contract_revert::<PolygonRollupManagerErrors>()
+                    .map(Self::DryRunRollupManager)
+            })
+            .unwrap_or_else(|| Self::dry_run(err))
+    }
+}
+
+impl<Rpc: Middleware> From<SettlementError<Rpc>> for SendTxError<Rpc> {
+    fn from(err: SettlementError<Rpc>) -> Self {
+        match err {
+            SettlementError::RateLimited(e) => e.into(),
+            e => Self::Settlement(e),
+        }
+    }
+}

--- a/crates/agglayer-node/src/service/mod.rs
+++ b/crates/agglayer-node/src/service/mod.rs
@@ -1,0 +1,390 @@
+use std::sync::Arc;
+
+use agglayer_config::{epoch::BlockClockConfig, Config, Epoch};
+use agglayer_storage::{
+    columns::latest_settled_certificate_per_network::SettledCertificate,
+    stores::{
+        DebugReader, DebugWriter, PendingCertificateReader, PendingCertificateWriter, StateReader,
+        StateWriter,
+    },
+};
+use agglayer_telemetry::KeyValue;
+use agglayer_types::{
+    Certificate, CertificateHeader, CertificateId, CertificateStatus, EpochConfiguration, Height,
+    NetworkId,
+};
+use ethers::{providers::Middleware, types::H256};
+use futures::future::try_join;
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, instrument, trace};
+
+pub use self::error::{
+    CertificateRetrievalError, CertificateSubmissionError, SendTxError, TxStatusError,
+};
+use crate::{kernel::Kernel, signed_tx::SignedTx};
+
+pub mod error;
+
+/// The RPC agglayer service implementation.
+pub(crate) struct AgglayerService<Rpc, PendingStore, StateStore, DebugStore> {
+    kernel: Kernel<Rpc>,
+    certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
+    pending_store: Arc<PendingStore>,
+    state: Arc<StateStore>,
+    debug_store: Arc<DebugStore>,
+    config: Arc<Config>,
+}
+
+impl<Rpc, PendingStore, StateStore, DebugStore>
+    AgglayerService<Rpc, PendingStore, StateStore, DebugStore>
+{
+    /// Create an instance of the RPC agglayer service.
+    pub(crate) fn new(
+        kernel: Kernel<Rpc>,
+        certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
+        pending_store: Arc<PendingStore>,
+        state: Arc<StateStore>,
+        debug_store: Arc<DebugStore>,
+        config: Arc<Config>,
+    ) -> Self {
+        Self {
+            kernel,
+            certificate_sender,
+            pending_store,
+            state,
+            debug_store,
+            config,
+        }
+    }
+
+    /// Get access to the configuration.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+}
+
+impl<Rpc, PendingStore, StateStore, DebugStore> Drop
+    for AgglayerService<Rpc, PendingStore, StateStore, DebugStore>
+{
+    fn drop(&mut self) {
+        info!("Shutting down the agglayer service");
+    }
+}
+
+impl<Rpc, PendingStore, StateStore, DebugStore>
+    AgglayerService<Rpc, PendingStore, StateStore, DebugStore>
+where
+    Rpc: Middleware + 'static,
+    PendingStore: PendingCertificateWriter + PendingCertificateReader + 'static,
+    StateStore: StateReader + StateWriter + 'static,
+    DebugStore: DebugReader + DebugWriter + 'static,
+{
+    #[instrument(skip(self, tx), fields(hash, rollup_id = tx.tx.rollup_id), level = "info")]
+    pub async fn send_tx(&self, tx: SignedTx) -> Result<H256, SendTxError<Rpc>> {
+        let hash = format!("{:?}", tx.hash());
+        tracing::Span::current().record("hash", &hash);
+
+        info!(
+            hash,
+            "Received transaction {hash} for rollup {}", tx.tx.rollup_id
+        );
+        let rollup_id_str = tx.tx.rollup_id.to_string();
+        let metrics_attrs = &[KeyValue::new("rollup_id", rollup_id_str)];
+
+        agglayer_telemetry::SEND_TX.add(1, metrics_attrs);
+
+        let rollup_id = tx.tx.rollup_id;
+        if !self.kernel.check_rollup_registered(rollup_id) {
+            // Return an invalid params error if the rollup is not registered.
+            return Err(SendTxError::RollupNotRegistered { rollup_id });
+        }
+
+        self.kernel.verify_signature(&tx).await.inspect_err(|e| {
+            error!(error = %e, hash, "Failed to verify the signature of transaction {hash}: {e}");
+        })?;
+
+        agglayer_telemetry::VERIFY_SIGNATURE.add(1, metrics_attrs);
+
+        // Reserve a rate limiting slot.
+        let guard = self
+            .kernel
+            .rate_limiter()
+            .reserve_send_tx(tx.tx.rollup_id, tokio::time::Instant::now())?;
+
+        agglayer_telemetry::CHECK_TX.add(1, metrics_attrs);
+
+        // Run all the verification checks in parallel.
+        let _ = try_join(
+            async {
+                self.kernel
+                    .verify_proof_eth_call(&tx)
+                    .await
+                    .map_err(|e| {
+                        let error = SendTxError::dry_run(&e);
+                        error!(
+                            error_code = %e,
+                            error = error.to_string(),
+                            hash,
+                            "Failed to dry-run the verify_batches_trusted_aggregator for \
+                             transaction {hash}: {error}"
+                        );
+                        error
+                    })
+                    .inspect(|_| agglayer_telemetry::EXECUTE.add(1, metrics_attrs))
+            },
+            async {
+                self.kernel
+                    .verify_proof_zkevm_node(&tx)
+                    .await
+                    .map_err(|e| {
+                        error!(
+                            error = %e,
+                            hash,
+                            "Failed to verify the batch local_exit_root and state_root of \
+                             transaction {hash}: {e}"
+                        );
+                        SendTxError::RootVerification(e)
+                    })
+                    .inspect(|_| agglayer_telemetry::VERIFY_ZKP.add(1, metrics_attrs))
+            },
+        )
+        .await?;
+
+        // Settle the proof on-chain and return the transaction hash.
+        let receipt = self.kernel.settle(&tx, guard).await.inspect_err(|e| {
+            error!(
+                error = %e,
+                hash,
+                "Failed to settle transaction {hash} on L1: {e}"
+            )
+        })?;
+
+        agglayer_telemetry::SETTLE.add(1, metrics_attrs);
+
+        info!(hash, "Successfully settled transaction {hash}");
+
+        Ok(receipt.transaction_hash)
+    }
+
+    #[instrument(skip(self), fields(hash = hash.to_string()), level = "info")]
+    pub async fn get_tx_status(&self, hash: H256) -> Result<TxStatus, TxStatusError<Rpc>> {
+        debug!("Received request to get transaction status for hash {hash}");
+
+        let receipt = self.kernel.check_tx_status(hash).await.map_err(|e| {
+            error!("Failed to get transaction status for hash {hash}: {e}");
+            TxStatusError::StatusCheck(e)
+        })?;
+
+        let current_block = self.kernel.current_l1_block_height().await.map_err(|e| {
+            error!("Failed to get current L1 block: {e}");
+            TxStatusError::L1BlockRetrieval(e)
+        })?;
+
+        let receipt = receipt.ok_or_else(|| TxStatusError::TxNotFound { hash })?;
+
+        let status = match receipt.block_number {
+            Some(block_number) if block_number < current_block => TxStatus::Done,
+            Some(_) => TxStatus::Pending,
+            None => TxStatus::NotFound,
+        };
+        Ok(status)
+    }
+
+    #[instrument(skip(self, certificate), fields(hash, rollup_id = *certificate.network_id), level = "info")]
+    pub async fn send_certificate(
+        &self,
+        certificate: Certificate,
+    ) -> Result<CertificateId, CertificateSubmissionError> {
+        let hash = certificate.hash();
+        tracing::Span::current().record("hash", hash.to_string());
+
+        info!(
+            %hash,
+            "Received certificate {hash} for rollup {} at height {}", *certificate.network_id, certificate.height
+        );
+
+        // TODO: Batch the different queries.
+        // Insert the certificate header into the state store.
+        self.state
+            .insert_certificate_header(&certificate, CertificateStatus::Pending)
+            .inspect_err(|e| error!("Failed to insert certificate into state store: {e}"))?;
+
+        // Insert the certificate into the pending store.
+        self.pending_store
+            .insert_pending_certificate(certificate.network_id, certificate.height, &certificate)
+            .inspect_err(|e| error!("Failed to insert certificate into pending store: {e}"))?;
+
+        self.debug_store
+            .add_certificate(&certificate)
+            .inspect_err(|e| error!("Failed to insert certificate into debug store: {e}"))?;
+
+        self.certificate_sender
+            .send((
+                certificate.network_id,
+                certificate.height,
+                certificate.hash(),
+            ))
+            .await
+            .map_err(|error| {
+                error!("Failed to send certificate: {error}");
+                CertificateSubmissionError::OrchestratorNotResponsive
+            })?;
+
+        Ok(hash)
+    }
+
+    pub fn get_certificate_header(
+        &self,
+        certificate_id: CertificateId,
+    ) -> Result<CertificateHeader, CertificateRetrievalError> {
+        trace!("Received request to get certificate header for certificate {certificate_id}");
+        self.fetch_certificate_header(certificate_id)
+    }
+
+    pub fn get_epoch_configuration(&self) -> Option<EpochConfiguration> {
+        info!("Received request to get epoch configuration");
+
+        if let Epoch::BlockClock(BlockClockConfig {
+            epoch_duration,
+            genesis_block,
+        }) = self.config.epoch
+        {
+            Some(EpochConfiguration {
+                epoch_duration: epoch_duration.into(),
+                genesis_block,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn get_latest_known_certificate_header(
+        &self,
+        network_id: NetworkId,
+    ) -> Result<Option<CertificateHeader>, CertificateRetrievalError> {
+        debug!(
+            "Received request to get the latest known certificate header for rollup {network_id}",
+        );
+
+        let settled_certificate_id_and_height = self
+            .state
+            .get_latest_settled_certificate_per_network(&network_id)
+            .inspect_err(|e| error!("Failed to get latest settled certificate: {e}"))?
+            .map(|(_, SettledCertificate(id, height, _, _))| (id, height));
+
+        let proven_certificate_id_and_height = self
+            .pending_store
+            .get_latest_proven_certificate_per_network(&network_id)
+            .inspect_err(|e| error!("Failed to get latest proven certificate: {e}"))?
+            .map(|(_, height, id)| (id, height));
+
+        let pending_certificate_id_and_height = self
+            .pending_store
+            .get_latest_pending_certificate_for_network(&network_id)
+            .inspect_err(|e| error!("Failed to get latest pending certificate: {e}"))?;
+
+        let certificate_id = [
+            settled_certificate_id_and_height,
+            proven_certificate_id_and_height,
+            pending_certificate_id_and_height,
+        ]
+        .into_iter()
+        .flatten()
+        .max_by(|x, y| x.1.cmp(&y.1))
+        .map(|v| v.0);
+
+        certificate_id.map_or(Ok(None), |certificate_id| {
+            self.fetch_certificate_header(certificate_id).map(Some)
+        })
+    }
+
+    pub async fn debug_get_certificate(
+        &self,
+        certificate_id: CertificateId,
+    ) -> Result<(Certificate, Option<CertificateHeader>), CertificateRetrievalError> {
+        let cert = self
+            .debug_store
+            .get_certificate(&certificate_id)
+            .inspect_err(|e| error!("Failed to get certificate: {e}"))?
+            .ok_or(CertificateRetrievalError::NotFound { certificate_id })?;
+        let header = self
+            .state
+            .get_certificate_header(&certificate_id)
+            .inspect_err(|e| error!("Failed to get certificate header: {e}"))?;
+
+        Ok((cert, header))
+    }
+
+    pub fn get_latest_settled_certificate_header(
+        &self,
+        network_id: NetworkId,
+    ) -> Result<Option<CertificateHeader>, CertificateRetrievalError> {
+        let id = match self
+            .state
+            .get_latest_settled_certificate_per_network(&network_id)
+            .inspect_err(|e| error!("Failed to get latest settled certificate id: {e}"))?
+        {
+            Some((_, SettledCertificate(id, _, _, _))) => id,
+            None => return Ok(None),
+        };
+
+        self.fetch_certificate_header(id).map(Some)
+    }
+
+    pub fn get_latest_pending_certificate_header(
+        &self,
+        network_id: NetworkId,
+    ) -> Result<Option<CertificateHeader>, CertificateRetrievalError> {
+        let id = match self
+            .pending_store
+            .get_latest_pending_certificate_for_network(&network_id)
+            .inspect_err(|e| error!("Failed to get latest pending certificate id: {e}"))?
+        {
+            Some((id, _height)) => id,
+            None => return Ok(None),
+        };
+
+        self.fetch_certificate_header(id)
+            .map(|header| match header.status {
+                CertificateStatus::Pending
+                | CertificateStatus::Proven
+                | CertificateStatus::Candidate
+                | CertificateStatus::InError { .. } => Some(header),
+                CertificateStatus::Settled => None,
+            })
+    }
+
+    /// Get the certificate header, raising an error if not found.
+    fn fetch_certificate_header(
+        &self,
+        certificate_id: CertificateId,
+    ) -> Result<CertificateHeader, CertificateRetrievalError> {
+        self.state
+            .get_certificate_header(&certificate_id)
+            .inspect_err(|err| error!("Failed to get certificate header: {err}"))?
+            .ok_or(CertificateRetrievalError::NotFound { certificate_id })
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum TxStatus {
+    Done,
+    Pending,
+    NotFound,
+}
+
+impl TxStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TxStatus::Done => "done",
+            TxStatus::Pending => "pending",
+            TxStatus::NotFound => "not found",
+        }
+    }
+}
+
+impl std::fmt::Display for TxStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}


### PR DESCRIPTION
# Description

Move the logic from rpc implementation into a separate component, Agglayer service. This will allow it to be reused when introducing new external interfaces, initially gRPC.

* fixes #544

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
