### PR TITLE
feat: confirm certificates’ claimed emitter is allowed to emit

### DIFF
--- a/crates/agglayer-node/src/kernel/mod.rs
+++ b/crates/agglayer-node/src/kernel/mod.rs
@@ -6,7 +6,12 @@ use agglayer_contracts::{
     polygon_rollup_manager::{PolygonRollupManager, RollupIDToRollupDataReturn},
     polygon_zk_evm::PolygonZkEvm,
 };
-use ethers::prelude::*;
+use agglayer_types::Certificate;
+use ethers::{
+    contract::{ContractCall, ContractError},
+    providers::{Middleware, ProviderError},
+    types::{Address, TransactionReceipt, H160, H256, U64},
+};
 use thiserror::Error;
 use tracing::{info, instrument, warn};
 
@@ -158,9 +163,14 @@ pub(crate) enum SignatureVerificationError<RpcProvider>
 where
     RpcProvider: Middleware,
 {
-    /// The signer could not be recovered from the signature.
-    #[error("could not recover signer: {0}")]
-    CouldNotRecoverSigner(SignatureError),
+    /// The signer could not be recovered from the transaction signature.
+    #[error("could not recover transaction signer: {0}")]
+    CouldNotRecoverTxSigner(#[source] ethers::types::SignatureError),
+
+    /// The signer could not be recovered from the certificate signature.
+    #[error("could not recover certificate signer: {0}")]
+    CouldNotRecoverCertSigner(#[source] alloy::primitives::SignatureError),
+
     /// The signer of the proof is not the trusted sequencer for the given
     /// rollup id.
     #[error("invalid signer: expected {trusted_sequencer}, got {signer}")]
@@ -170,6 +180,7 @@ where
         /// The trusted sequencer address.
         trusted_sequencer: Address,
     },
+
     /// Generic network error when attempting to retrieve the trusted sequencer
     /// address from the rollup contract.
     #[error("contract error: {0}")]
@@ -294,7 +305,7 @@ where
     /// Verify that the signer of the given [`SignedTx`] is the trusted
     /// sequencer for the rollup id specified in the proof.
     #[instrument(skip(self), level = "debug")]
-    pub(crate) async fn verify_signature(
+    pub(crate) async fn verify_tx_signer(
         &self,
         signed_tx: &SignedTx,
     ) -> Result<(), SignatureVerificationError<RpcProvider>> {
@@ -304,7 +315,35 @@ where
 
         let signer = signed_tx
             .signer()
-            .map_err(|e| SignatureVerificationError::CouldNotRecoverSigner(e))?;
+            .map_err(SignatureVerificationError::CouldNotRecoverTxSigner)?;
+
+        if signer != sequencer_address {
+            return Err(SignatureVerificationError::InvalidSigner {
+                signer,
+                trusted_sequencer: sequencer_address,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Verify that the signer of the given [`Certificate`] is the trusted
+    /// sequencer for the rollup id it specified.
+    #[instrument(skip(self), level = "debug")]
+    pub(crate) async fn verify_certificate_signer(
+        &self,
+        cert: &Certificate,
+    ) -> Result<(), SignatureVerificationError<RpcProvider>> {
+        let sequencer_address = self
+            .get_trusted_sequencer_address(cert.network_id.to_u32())
+            .await?;
+
+        let signer = cert
+            .signer()
+            .map_err(SignatureVerificationError::CouldNotRecoverCertSigner)?;
+
+        // Convert signer from alloy to ethers
+        let signer = H160::from(signer.0 .0);
 
         if signer != sequencer_address {
             return Err(SignatureVerificationError::InvalidSigner {

--- a/crates/agglayer-node/src/kernel/tests.rs
+++ b/crates/agglayer-node/src/kernel/tests.rs
@@ -214,9 +214,9 @@ async fn interop_executor_verify_zkp_failure() {
     mock.assert_request("eth_call", [tx_verify_batch, block])
         .unwrap();
 }
-/// Test that check if the verify_signature method
+/// Test that checks if the verify_tx_signer method
 #[tokio::test]
-async fn interop_executor_verify_signature() {
+async fn interop_executor_verify_tx_signer() {
     let config = Arc::new(Config::new_for_test());
 
     let (provider, mock) = providers::Provider::mocked();
@@ -238,7 +238,7 @@ async fn interop_executor_verify_signature() {
         push_response!(mock, to_hex: TrustedSequencerReturn(sequencer_address));
         push_response!(mock, response.clone());
 
-        assert!(kernel.verify_signature(&signed_tx).await.is_ok());
+        assert!(kernel.verify_tx_signer(&signed_tx).await.is_ok());
     }
 
     // Wrong signature with different sequencer_address
@@ -247,7 +247,7 @@ async fn interop_executor_verify_signature() {
         push_response!(mock, response);
 
         assert!(matches!(
-            kernel.verify_signature(&signed_tx).await,
+            kernel.verify_tx_signer(&signed_tx).await,
             Err(crate::kernel::SignatureVerificationError::InvalidSigner { signer, trusted_sequencer })
             if signer == sequencer_address && trusted_sequencer == H160::zero()
         ));
@@ -282,9 +282,9 @@ async fn interop_executor_verify_signature() {
         .unwrap();
 }
 
-/// Test that check if the verify_signature method works with proof signer.
+/// Test that checks if the verify_tx_signer method works with proof signer.
 #[tokio::test]
-async fn interop_executor_verify_signature_proof_signer() {
+async fn interop_executor_verify_tx_signer_proof_signer() {
     let mut config = Config::new_for_test();
 
     let sequencer_wallet = LocalWallet::new(&mut rand::thread_rng());
@@ -307,7 +307,7 @@ async fn interop_executor_verify_signature_proof_signer() {
     // valid signature with valid sequencer_address
     {
         push_response!(mock, response);
-        assert!(kernel.verify_signature(&signed_tx).await.is_ok());
+        assert!(kernel.verify_tx_signer(&signed_tx).await.is_ok());
     }
 
     let tx_rollup_data = transaction_request!(

--- a/crates/agglayer-node/src/rpc/tests/errors.rs
+++ b/crates/agglayer-node/src/rpc/tests/errors.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use alloy::{primitives::SignatureError as AlloySignatureError, signers::k256};
 use ethers::{
     providers::ProviderError,
     types::{Bytes, SignatureError as EthSignatureError, H160, H256},
@@ -24,17 +25,23 @@ type WallClockLimitedInfo = <component::SendTx as Component>::LimitedInfo;
 #[case("rollup_not_reg", Error::rollup_not_registered(1337))]
 #[case(
     "sig_invalid_len",
-    Error::signature_mismatch(SignatureError::CouldNotRecoverSigner(
+    Error::signature_mismatch(SignatureError::CouldNotRecoverTxSigner(
         EthSignatureError::InvalidLength(42)
     ))
 )]
-#[case("sig_verif", Error::signature_mismatch(SignatureError::CouldNotRecoverSigner(
+#[case("sig_verif", Error::signature_mismatch(SignatureError::CouldNotRecoverTxSigner(
     EthSignatureError::VerificationError(H160([0x11; 20]), H160([0x22; 20]))
 )))]
 #[case(
     "sig_recov",
-    Error::signature_mismatch(SignatureError::CouldNotRecoverSigner(
+    Error::signature_mismatch(SignatureError::CouldNotRecoverTxSigner(
         EthSignatureError::RecoveryError
+    ))
+)]
+#[case(
+    "cert_sig",
+    Error::signature_mismatch(SignatureError::CouldNotRecoverCertSigner(
+        AlloySignatureError::K256(k256::ecdsa::Error::new())
     ))
 )]
 #[case(

--- a/crates/agglayer-node/src/rpc/tests/mod.rs
+++ b/crates/agglayer-node/src/rpc/tests/mod.rs
@@ -14,6 +14,7 @@ use agglayer_storage::{
 };
 use agglayer_types::{Certificate, CertificateId, CertificateStatus, Digest, Height, NetworkId};
 use ethers::providers::{self, MockProvider, Provider};
+use ethers::signers::Signer;
 use http_body_util::Empty;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
@@ -114,7 +115,14 @@ impl TestContext {
 
     pub(crate) fn get_default_config() -> Config {
         let tmp = TempDBDir::new();
-        Config::new(&tmp.path)
+        let mut cfg = Config::new(&tmp.path);
+        for network_id in 0..10 {
+            cfg.proof_signers.insert(
+                network_id,
+                Certificate::wallet_for_test(NetworkId::new(network_id)).address(),
+            );
+        }
+        cfg
     }
 
     async fn new_raw_rpc() -> RawRpcContext {

--- a/crates/agglayer-node/src/rpc/tests/send_certificate.rs
+++ b/crates/agglayer-node/src/rpc/tests/send_certificate.rs
@@ -1,8 +1,8 @@
 use std::{net::IpAddr, sync::Arc};
 
 use agglayer_config::Config;
-use agglayer_types::{Certificate, CertificateId};
-use ethers::providers;
+use agglayer_types::{Certificate, CertificateId, NetworkId};
+use ethers::{providers, signers::Signer as _};
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 
 use super::next_available_addr;
@@ -18,6 +18,9 @@ async fn send_certificate_method_can_be_called() {
         .try_init();
 
     let mut config = Config::new_for_test();
+    config
+        .proof_signers
+        .insert(1, Certificate::wallet_for_test(NetworkId::new(1)).address());
     let addr = next_available_addr();
     if let IpAddr::V4(ip) = addr.ip() {
         config.rpc.host = ip;
@@ -98,4 +101,53 @@ async fn send_certificate_method_can_be_called_and_fail() {
         .await;
 
     assert!(res.is_err());
+}
+
+#[test_log::test(tokio::test)]
+async fn send_certificate_method_requires_known_signer() {
+    let _ = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let mut config = Config::new_for_test();
+    // Willingly insert a signer that is not the one that’ll be used down below
+    config
+        .proof_signers
+        .insert(1, Certificate::wallet_for_test(NetworkId::new(2)).address());
+    let addr = next_available_addr();
+    if let IpAddr::V4(ip) = addr.ip() {
+        config.rpc.host = ip;
+    }
+    config.rpc.port = addr.port();
+
+    let config = Arc::new(config);
+
+    let (provider, _mock) = providers::Provider::mocked();
+    let (certificate_sender, _certificate_receiver) = tokio::sync::mpsc::channel(1);
+
+    let kernel = Kernel::new(Arc::new(provider), config.clone());
+
+    let _server_handle = AgglayerImpl::new(
+        kernel,
+        certificate_sender,
+        Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
+        Arc::new(DummyStore {}),
+        config.clone(),
+    )
+    .start()
+    .await
+    .unwrap();
+
+    let url = format!("http://{}/", config.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
+
+    let send_request: Result<CertificateId, _> = client
+        .request(
+            "interop_sendCertificate",
+            rpc_params![Certificate::new_for_test(1.into(), 0)],
+        )
+        .await;
+
+    assert!(send_request.is_err());
 }

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_sig.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__cert_sig.snap
@@ -1,0 +1,13 @@
+---
+source: crates/agglayer-node/src/rpc/tests/errors.rs
+expression: "SignatureMismatch { detail: \"could not recover certificate signer: signature error\" }"
+---
+{
+  "code": -10002,
+  "data": {
+    "signature-mismatch": {
+      "detail": "could not recover certificate signer: signature error"
+    }
+  },
+  "message": "Rollup signature verification failed"
+}

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_invalid_len.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_invalid_len.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/agglayer-node/src/rpc/tests/errors.rs
-expression: "SignatureMismatch { detail: \"could not recover signer: invalid signature length, got 42, expected 65\" }"
+expression: "SignatureMismatch { detail: \"could not recover transaction signer: invalid signature length, got 42, expected 65\" }"
 ---
 {
   "code": -10002,
   "data": {
     "signature-mismatch": {
-      "detail": "could not recover signer: invalid signature length, got 42, expected 65"
+      "detail": "could not recover transaction signer: invalid signature length, got 42, expected 65"
     }
   },
   "message": "Rollup signature verification failed"

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_recov.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_recov.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/agglayer-node/src/rpc/tests/errors.rs
-expression: "SignatureMismatch { detail: \"could not recover signer: Public key recovery error\" }"
+expression: "SignatureMismatch { detail: \"could not recover transaction signer: Public key recovery error\" }"
 ---
 {
   "code": -10002,
   "data": {
     "signature-mismatch": {
-      "detail": "could not recover signer: Public key recovery error"
+      "detail": "could not recover transaction signer: Public key recovery error"
     }
   },
   "message": "Rollup signature verification failed"

--- a/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_verif.snap
+++ b/crates/agglayer-node/src/rpc/tests/snapshots/agglayer_node__rpc__tests__errors__sig_verif.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/agglayer-node/src/rpc/tests/errors.rs
-expression: "SignatureMismatch { detail: \"could not recover signer: Signature verification failed. Expected 0x1111…1111, got 0x2222…2222\" }"
+expression: "SignatureMismatch { detail: \"could not recover transaction signer: Signature verification failed. Expected 0x1111…1111, got 0x2222…2222\" }"
 ---
 {
   "code": -10002,
   "data": {
     "signature-mismatch": {
-      "detail": "could not recover signer: Signature verification failed. Expected 0x1111…1111, got 0x2222…2222"
+      "detail": "could not recover transaction signer: Signature verification failed. Expected 0x1111…1111, got 0x2222…2222"
     }
   },
   "message": "Rollup signature verification failed"

--- a/crates/agglayer-telemetry/src/lib.rs
+++ b/crates/agglayer-telemetry/src/lib.rs
@@ -41,6 +41,9 @@ lazy_static! {
     pub static ref VERIFY_SIGNATURE: opentelemetry::metrics::Counter<u64> = global::meter(AGGLAYER_KERNEL_OTEL_SCOPE_NAME)
         .u64_counter("verify_signature")
         .with_description("Number of signature verifications")
+    // TODO: THIS IS WRONG. This is the number of times we checked the signer is the expected signer,
+    // but we never checked these signatures.
+    // Should we rename and adjust that, or are we limited by metrics backward-compat for some alerting?
         .build();
 
     pub static ref CHECK_TX: opentelemetry::metrics::Counter<u64> = global::meter(AGGLAYER_KERNEL_OTEL_SCOPE_NAME)

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use agglayer_primitives::SignatureError;
 use pessimistic_proof::error::ProofVerificationError;
 use pessimistic_proof::global_index::GlobalIndex;
 pub use pessimistic_proof::keccak::digest::Digest;
@@ -31,7 +32,7 @@ pub type Metadata = Digest;
 
 pub use agglayer_primitives as primitives;
 // Re-export common primitives again as agglayer-types root types
-pub use agglayer_primitives::{Address, Signature, SignatureError, B256, U256, U512};
+pub use agglayer_primitives::{Address, Signature, B256, U256, U512};
 pub use pessimistic_proof::bridge_exit::NetworkId;
 pub use pessimistic_proof::proof::Proof;
 
@@ -350,7 +351,7 @@ impl Certificate {
         }
     }
 
-    pub fn signer(&self) -> Option<Address> {
+    pub fn signer(&self) -> Result<Address, SignatureError> {
         // retrieve signer
         let combined_hash = signature_commitment(
             self.new_local_exit_root,
@@ -361,7 +362,6 @@ impl Certificate {
 
         self.signature
             .recover_address_from_prehash(&B256::new(combined_hash.0))
-            .ok()
     }
 }
 


### PR DESCRIPTION
# Description

Validate certificates’ claimed emitter. This does not verify any new additional signature, and renames functions accordingly.

Also, swap the order of pending & state saves to database. I’m not entirely sure why this is required, as I’m not familiar enough with the database yet. Still, did as the task requested.

Fixes https://github.com/agglayer/agglayer/issues/553

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
