### PR TITLE
fix: fixing backup config format

### DIFF
--- a/crates/agglayer-config/src/storage/backup.rs
+++ b/crates/agglayer-config/src/storage/backup.rs
@@ -11,7 +11,7 @@ pub enum BackupConfig {
     Disabled,
 
     /// Backups are enabled.
-    #[serde(untagged)]
+    #[serde(untagged, rename_all = "kebab-case")]
     Enabled {
         /// Path to the directory where backups are stored.
         path: PathBuf,

--- a/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
+++ b/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
@@ -64,5 +64,5 @@ db-path = "/tmp/agglayer/tests/fixtures/valide_config/storage"
 
 [storage.backup]
 path = "./test/"
-state_max_backup_count = 100
-pending_max_backup_count = 100
+state-max-backup-count = 100
+pending-max-backup-count = 100


### PR DESCRIPTION
# Description

This PR is fixing the format of the backup config, switching from `snake_case` to `kebab-case`.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
