### PR TITLE
fix: adding set latest proven/pending method on admin RPC

### DIFF
--- a/crates/agglayer-node/src/rpc/admin.rs
+++ b/crates/agglayer-node/src/rpc/admin.rs
@@ -14,7 +14,7 @@ use jsonrpsee::{
     server::{ServerBuilder, ServerHandle},
 };
 use tower_http::{compression::CompressionLayer, cors::CorsLayer};
-use tracing::{error, info, instrument};
+use tracing::{error, info, instrument, warn};
 
 use super::error::RpcResult;
 use crate::rpc::{error::Error, rpc_middleware};
@@ -33,6 +33,9 @@ pub(crate) trait AdminAgglayer {
         certificate: Certificate,
         status: CertificateStatus,
     ) -> RpcResult<()>;
+
+    #[method(name = "setLatestPendingCertificate")]
+    async fn set_latest_pending_certificate(&self, certificate_id: CertificateId) -> RpcResult<()>;
 
     #[method(name = "setLatestProvenCertificate")]
     async fn set_latest_proven_certificate(&self, certificate_id: CertificateId) -> RpcResult<()>;
@@ -188,6 +191,12 @@ where
         certificate: Certificate,
         status: CertificateStatus,
     ) -> RpcResult<()> {
+        warn!(
+            hash = certificate.hash().to_string(),
+            ?certificate,
+            "(ADMIN) Forcing push of pending certificate: {}",
+            certificate.hash()
+        );
         match self.pending_store.insert_pending_certificate(
             certificate.network_id,
             certificate.height,
@@ -209,9 +218,50 @@ where
             }
         }
     }
+    #[instrument(skip(self, certificate_id), level = "debug")]
+    async fn set_latest_pending_certificate(&self, certificate_id: CertificateId) -> RpcResult<()> {
+        warn!(
+            hash = certificate_id.to_string(),
+            "(ADMIN) Setting latest pending certificate: {}", certificate_id
+        );
+        let certificate = if let Some(certificate) = self
+            .state
+            .get_certificate_header(&certificate_id)
+            .map_err(|error| {
+                error!("Failed to get certificate header: {}", error);
+                Error::internal("Unable to get certificate header")
+            })? {
+            certificate
+        } else {
+            return Err(Error::resource_not_found(format!(
+                "CertificateHeader({})",
+                certificate_id
+            )));
+        };
+
+        match self
+            .pending_store
+            .set_latest_pending_certificate_per_network(
+                &certificate.network_id,
+                &certificate.height,
+                &certificate.certificate_id,
+            ) {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                error!("Failed to update latest pending certificate: {}", error);
+                Err(Error::internal(
+                    "Unable to update latest pending certificate",
+                ))
+            }
+        }
+    }
 
     #[instrument(skip(self, certificate_id), level = "debug")]
     async fn set_latest_proven_certificate(&self, certificate_id: CertificateId) -> RpcResult<()> {
+        warn!(
+            hash = certificate_id.to_string(),
+            "(ADMIN) Setting latest proven certificate: {}", certificate_id
+        );
         let certificate = if let Some(certificate) = self
             .state
             .get_certificate_header(&certificate_id)
@@ -246,6 +296,10 @@ where
 
     #[instrument(skip(self), level = "debug")]
     async fn remove_pending_proof(&self, certificate_id: CertificateId) -> RpcResult<()> {
+        warn!(
+            hash = certificate_id.to_string(),
+            "(ADMIN) Removing pending proof: {}", certificate_id
+        );
         self.pending_store
             .remove_generated_proof(&certificate_id)
             .map_err(|error| {
@@ -261,6 +315,10 @@ where
         height: Height,
         remove_proof: bool,
     ) -> RpcResult<()> {
+        warn!(
+            "(ADMIN) Removing pending certificate for network {} at height {}",
+            network_id, height
+        );
         let certificate_id = if let Some(certificate) = self
             .pending_store
             .get_certificate(network_id, height)

--- a/crates/agglayer-node/src/rpc/mod.rs
+++ b/crates/agglayer-node/src/rpc/mod.rs
@@ -547,9 +547,9 @@ where
             })?;
 
         let certificate_id = [
-            settled_certificate_id_and_height,
-            proven_certificate_id_and_height,
             pending_certificate_id_and_height,
+            proven_certificate_id_and_height,
+            settled_certificate_id_and_height,
         ]
         .into_iter()
         .flatten()

--- a/crates/agglayer-node/src/rpc/tests/get_latest_known_certificate_header.rs
+++ b/crates/agglayer-node/src/rpc/tests/get_latest_known_certificate_header.rs
@@ -320,6 +320,91 @@ async fn returns_no_certificate_header() {
 }
 
 #[test_log::test(tokio::test)]
+async fn returns_the_highest_height() {
+    let path = TempDBDir::new();
+
+    let config = Config::new(&path.path);
+    let pending_db = Arc::new(
+        DB::open_cf(&config.storage.pending_db_path, pending_db_cf_definitions())
+            .expect("unable to open pending db"),
+    );
+    let state_db = Arc::new(
+        DB::open_cf(&config.storage.state_db_path, state_db_cf_definitions())
+            .expect("unable to open state db"),
+    );
+
+    let state_db = StateStore::new(state_db, BackupClient::noop());
+    let pending_db = PendingStore::new(pending_db);
+    let network_id = 1.into();
+
+    let settled_certificate = Certificate::new_for_test(network_id, 10);
+    let pending_certificate = Certificate::new_for_test(network_id, 3);
+
+    state_db
+        .insert_certificate_header(&settled_certificate, CertificateStatus::Settled)
+        .expect("unable to insert settled certificate header");
+    state_db
+        .insert_certificate_header(&pending_certificate, CertificateStatus::Pending)
+        .expect("unable to insert pending certificate header");
+
+    state_db
+        .set_latest_settled_certificate_for_network(
+            &network_id,
+            &10,
+            &settled_certificate.hash(),
+            &0,
+            &0,
+        )
+        .expect("unable to set latest settled certificate");
+
+    pending_db
+        .insert_pending_certificate(network_id, 3, &pending_certificate)
+        .expect("unable to insert pending certificate");
+
+    drop(pending_db);
+    drop(state_db);
+
+    let context = TestContext::new_with_config(config).await;
+
+    let payload: CertificateHeader = context
+        .client
+        .request(
+            "interop_getLatestKnownCertificateHeader",
+            rpc_params![network_id],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(payload.certificate_id, settled_certificate.hash());
+    assert_eq!(payload.status, CertificateStatus::Settled);
+    assert_eq!(payload.height, 10);
+
+    drop(context);
+
+    // Have some delayu to ensure that the server has been stopped
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let config = Config::new(&path.path);
+    // Restarting the server in raw mode
+    let raw_rpc = TestContext::new_raw_rpc_with_config(config).await;
+    let rpc = raw_rpc.rpc.into_rpc();
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "method": "interop_getLatestKnownCertificateHeader",
+        "params": vec![network_id],
+        "id": 0
+    });
+    let (response, _) = rpc
+        .raw_json_request(&serde_json::to_string(&payload).unwrap(), 1)
+        .await
+        .unwrap();
+    let json = serde_json::from_str::<serde_json::Value>(&response).unwrap();
+    let json = serde_json::to_string_pretty(&json).unwrap();
+
+    assert_snapshot!("get_latest_known_certificate_header::highest_height", json);
+}
+
+#[test_log::test(tokio::test)]
 async fn returns_the_settled_one_at_same_height() {
     let path = TempDBDir::new();
 


### PR DESCRIPTION
# Description

This PR allows an admin to update the latest proven certificate and latest pending certificate.
It also includes a little fix on the ordering of `latestKnownCertificate` when all value are the same, we prioritize the settled one.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
