### PR TITLE
feat: prepare ci for enabling merge queues

### DIFF
--- a/.github/workflows/commit-checking.yml
+++ b/.github/workflows/commit-checking.yml
@@ -1,0 +1,22 @@
+name: Checking commit message
+
+on:
+  push:
+    branches:
+      - main
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  commits:
+    name: Validate PR commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/cycle-tracker.yml
+++ b/.github/workflows/cycle-tracker.yml
@@ -2,10 +2,8 @@ name: Cycle tracker
 
 on:
   workflow_dispatch:
-    branches:
-      - "**"
   schedule:
-    - cron: '0 13 * * 3'
+    - cron: "0 13 * * 3"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -46,7 +44,7 @@ jobs:
       - name: Set up rust cache
         uses: Swatinem/rust-cache@v2
         with:
-            cache-on-failure: true
+          cache-on-failure: true
 
       - name: Cycle tracker report
         env:

--- a/.github/workflows/pr-checking.yml
+++ b/.github/workflows/pr-checking.yml
@@ -1,4 +1,4 @@
-name: Checking PR semantic
+name: Checking PR title
 
 on:
   pull_request_target:
@@ -23,12 +23,3 @@ jobs:
         with:
           ignoreLabels: |
             release
-
-  commits:
-    name: Validate PR commits
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,8 +8,7 @@ on:
     branches:
       - "**"
   workflow_dispatch:
-    branches:
-      - "**"
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,7 @@ on:
     branches:
       - "**"
   workflow_dispatch:
-    branches:
-      - "**"
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test:e2e.yml
+++ b/.github/workflows/test:e2e.yml
@@ -8,8 +8,7 @@ on:
     branches:
       - "**"
   workflow_dispatch:
-    branches:
-      - "**"
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test:elf.yml
+++ b/.github/workflows/test:elf.yml
@@ -8,8 +8,7 @@ on:
     branches:
       - "**"
   workflow_dispatch:
-    branches:
-      - "**"
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
# Description

Enable all required tests for merge queues.

Once this lands, we’ll still need to configure merge queues in the github admin interface, as per [the documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#managing-a-merge-queue).

Incidentally, removed syntax errors from `workflow_dispatch` triggers.

## PR Checklist:

- [x] I have performed a self-review of my code
