### PR TITLE
build: update required job on merge_queue

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 

--- a/.github/workflows/mq-test.yml
+++ b/.github/workflows/mq-test.yml
@@ -122,11 +122,3 @@ jobs:
 
       - name: Test
         run: cargo nextest run --workspace -P integrations
-
-  unit:
-    name: Unit Tests
-    runs-on: ubuntu-latest-16-cores
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: ./.github/actions/unit-test

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION
# Description

Required jobs needs to be both on `merge_queue` and `pull_request`.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
