### PR TITLE
perf: Improve pessimistic-proof program to reduce # of cycles

### DIFF
--- a/crates/pessimistic-proof-core/src/bridge_exit.rs
+++ b/crates/pessimistic-proof-core/src/bridge_exit.rs
@@ -70,18 +70,18 @@ const EMPTY_METADATA_HASH: Digest = Digest(hex!(
 
 pub fn bridge_exit_hasher(
     leaf_type: u8,
-    origin_network: u32,
+    origin_network: u16,
     origin_token_address: Address,
-    dest_network: u32,
+    dest_network: u16,
     dest_address: Address,
     amount: U256,
     metadata: Option<Digest>,
 ) -> Digest {
     keccak256_combine([
         [leaf_type].as_slice(),
-        &u32::to_be_bytes(origin_network),
+        &u16::to_be_bytes(origin_network),
         origin_token_address.as_slice(),
-        &u32::to_be_bytes(dest_network),
+        &u16::to_be_bytes(dest_network),
         dest_address.as_slice(),
         &amount.to_be_bytes::<32>(),
         &metadata.unwrap_or(EMPTY_METADATA_HASH).0,
@@ -94,9 +94,9 @@ impl BridgeExit {
     pub fn hash(&self) -> Digest {
         bridge_exit_hasher(
             self.leaf_type as u8,
-            self.token_info.origin_network,
+            self.token_info.origin_network as u16,
             self.token_info.origin_token_address,
-            self.dest_network,
+            self.dest_network as u16,
             self.dest_address,
             self.amount,
             self.metadata,

--- a/crates/pessimistic-proof-core/src/local_balance_tree.rs
+++ b/crates/pessimistic-proof-core/src/local_balance_tree.rs
@@ -11,9 +11,9 @@ use crate::{
     ProofError,
 };
 
-/// The key is [`TokenInfo`] which can be packed into 192 bits (32 for network
+/// The key is [`TokenInfo`] which can be packed into 176 bits (16 for network
 /// id and 160 for token address).
-pub const LOCAL_BALANCE_TREE_DEPTH: usize = 192;
+pub const LOCAL_BALANCE_TREE_DEPTH: usize = 176;
 
 // TODO: This is basically the same as the nullifier tree, consider refactoring
 /// A commitment to the set of per-network nullifier trees maintained by the

--- a/crates/pessimistic-proof-core/src/local_exit_tree/mod.rs
+++ b/crates/pessimistic-proof-core/src/local_exit_tree/mod.rs
@@ -26,6 +26,11 @@ where
     /// computed by log2(leaf_count). After that, all values are zeroed out.
     #[serde_as(as = "[_; TREE_DEPTH]")]
     pub frontier: [H::Digest; TREE_DEPTH],
+
+    /// `empty_hash_at_height[i]` is the root of an empty Merkle tree of depth
+    /// `i`.
+    #[serde_as(as = "[_; TREE_DEPTH]")]
+    pub empty_hash_at_height: [H::Digest; TREE_DEPTH],
 }
 
 #[derive(Clone, Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
@@ -82,16 +87,13 @@ where
         // `root` is the hash of the node we’re going to fill next.
         // Here, we compute the root, starting from the next (yet unfilled) leaf hash.
         let mut root = H::Digest::default();
-        let mut empty_hash_at_height = H::Digest::default();
 
         for height in 0..TREE_DEPTH {
             if get_bit_at(self.leaf_count, height) == 1 {
                 root = H::merge(&self.frontier[height], &root);
             } else {
-                root = H::merge(&root, &empty_hash_at_height);
+                root = H::merge(&root, &self.empty_hash_at_height[height]);
             }
-
-            empty_hash_at_height = H::merge(&empty_hash_at_height, &empty_hash_at_height);
         }
 
         root

--- a/crates/pessimistic-proof-core/src/local_state.rs
+++ b/crates/pessimistic-proof-core/src/local_state.rs
@@ -90,7 +90,6 @@ impl NetworkState {
             });
         }
 
-        // TODO: benchmark if BTreeMap is the best choice in terms of SP1 cycles
         let mut new_balances = BTreeMap::new();
         for (k, v) in &multi_batch_header.balances_proofs {
             if new_balances.insert(*k, U512::from(v.0)).is_some() {

--- a/crates/pessimistic-proof-core/src/nullifier_tree.rs
+++ b/crates/pessimistic-proof-core/src/nullifier_tree.rs
@@ -46,13 +46,14 @@ pub struct NullifierKey {
 
 impl ToBits<64> for NullifierKey {
     fn to_bits(&self) -> [bool; 64] {
-        std::array::from_fn(|i| {
-            if i < 32 {
-                (self.network_id >> i) & 1 == 1
-            } else {
-                (self.let_index >> (i - 32)) & 1 == 1
-            }
-        })
+        let mut bits = [false; 64];
+        for i in 0..32 {
+            bits[i] = (self.network_id >> i) & 1 == 1;
+        }
+        for i in 32..64 {
+            bits[i] = (self.let_index >> (i - 32)) & 1 == 1;
+        }
+        bits
     }
 }
 

--- a/crates/pessimistic-proof-core/src/nullifier_tree.rs
+++ b/crates/pessimistic-proof-core/src/nullifier_tree.rs
@@ -11,10 +11,8 @@ use crate::{
     ProofError,
 };
 
-// 32 bits for the network id and 32 bits for the LET index
-// TODO: consider using less than 32 bits for the network id - unlikely that
-// we'll have 4 billion chains :)
-pub const NULLIFIER_TREE_DEPTH: usize = 64;
+// 16 bits for the network id and 32 bits for the LET index
+pub const NULLIFIER_TREE_DEPTH: usize = 48;
 
 // TODO: This is basically the same as the local balance tree, consider
 // refactoring TODO: Consider using an Indexed Merkle Tree instead of an SMT. See https://docs.aztec.network/aztec/concepts/storage/trees/indexed_merkle_tree.
@@ -44,14 +42,14 @@ pub struct NullifierKey {
     pub let_index: u32,
 }
 
-impl ToBits<64> for NullifierKey {
-    fn to_bits(&self) -> [bool; 64] {
-        let mut bits = [false; 64];
-        for i in 0..32 {
+impl ToBits<48> for NullifierKey {
+    fn to_bits(&self) -> [bool; 48] {
+        let mut bits = [false; 48];
+        for i in 0..16 {
             bits[i] = (self.network_id >> i) & 1 == 1;
         }
-        for i in 32..64 {
-            bits[i] = (self.let_index >> (i - 32)) & 1 == 1;
+        for i in 16..48 {
+            bits[i] = (self.let_index >> (i - 16)) & 1 == 1;
         }
         bits
     }

--- a/crates/pessimistic-proof-core/src/proof.rs
+++ b/crates/pessimistic-proof-core/src/proof.rs
@@ -204,8 +204,16 @@ pub fn generate_pessimistic_proof(
     // empty roots of the different trees involved. Therefore, we do
     // one mapping of empty tree hash <> 0x00..0 on the public inputs.
     let (prev_local_exit_root, prev_pessimistic_root) = (
-        if prev_ler == EMPTY_LER { [0; 32].into() } else { prev_ler },
-        if prev_pessimistic_root == EMPTY_PP_ROOT { [0; 32].into() } else { prev_pessimistic_root },
+        if prev_ler == EMPTY_LER {
+            [0; 32].into()
+        } else {
+            prev_ler
+        },
+        if prev_pessimistic_root == EMPTY_PP_ROOT {
+            [0; 32].into()
+        } else {
+            prev_pessimistic_root
+        },
     );
 
     Ok(PessimisticProofOutput {

--- a/crates/pessimistic-proof-core/src/utils/smt.rs
+++ b/crates/pessimistic-proof-core/src/utils/smt.rs
@@ -82,8 +82,7 @@ where
         hash == root
     }
 
-    pub fn verify_with_bits(&self, bits: [bool; DEPTH], value: H::Digest, root: H::Digest) -> bool
-    {
+    pub fn verify_with_bits(&self, bits: [bool; DEPTH], value: H::Digest, root: H::Digest) -> bool {
         let mut hash = value;
         for i in 0..DEPTH {
             hash = if bits[DEPTH - i - 1] {
@@ -169,8 +168,7 @@ where
         bits: [bool; DEPTH],
         root: H::Digest,
         empty_hash_at_height: &[H::Digest; DEPTH],
-    ) -> bool
-    {
+    ) -> bool {
         if self.siblings.len() > DEPTH {
             return false;
         }

--- a/crates/pessimistic-proof-core/src/utils/smt.rs
+++ b/crates/pessimistic-proof-core/src/utils/smt.rs
@@ -12,20 +12,21 @@ pub trait ToBits<const NUM_BITS: usize> {
 
 impl ToBits<192> for TokenInfo {
     fn to_bits(&self) -> [bool; 192] {
-        let address_bytes = self.origin_token_address.0;
-        // Security: We assume here that `address_bytes` is a fixed-size array of
-        // 20 bytes. The following code could panic otherwise.
-        std::array::from_fn(|i| {
-            if i < 32 {
-                (self.origin_network >> i) & 1 == 1
-            } else {
-                ((address_bytes[(i - 32) / 8]) >> (i % 8)) & 1 == 1
-            }
-        })
+        let mut bits = [false; 192];
+        for i in 0..32 {
+            bits[i] = (self.origin_network >> i) & 1 == 1;
+        }
+        for i in 32..192 {
+            let byte_index = (i - 32) / 8;
+            let bit_index = i % 8;
+            bits[i] = (self.origin_token_address.0[byte_index] >> bit_index) & 1 == 1;
+        }
+        bits
     }
 }
 
 impl ToBits<8> for u8 {
+    #[inline]
     fn to_bits(&self) -> [bool; 8] {
         std::array::from_fn(|i| (self >> i) & 1 == 1)
     }

--- a/crates/pessimistic-proof-core/src/utils/smt.rs
+++ b/crates/pessimistic-proof-core/src/utils/smt.rs
@@ -10,14 +10,14 @@ pub trait ToBits<const NUM_BITS: usize> {
     fn to_bits(&self) -> [bool; NUM_BITS];
 }
 
-impl ToBits<192> for TokenInfo {
-    fn to_bits(&self) -> [bool; 192] {
-        let mut bits = [false; 192];
-        for i in 0..32 {
+impl ToBits<176> for TokenInfo {
+    fn to_bits(&self) -> [bool; 176] {
+        let mut bits = [false; 176];
+        for i in 0..16 {
             bits[i] = (self.origin_network >> i) & 1 == 1;
         }
-        for i in 32..192 {
-            let byte_index = (i - 32) / 8;
+        for i in 16..176 {
+            let byte_index = (i - 16) / 8;
             let bit_index = i % 8;
             bits[i] = (self.origin_token_address.0[byte_index] >> bit_index) & 1 == 1;
         }

--- a/crates/pessimistic-proof/src/bridge_exit.rs
+++ b/crates/pessimistic-proof/src/bridge_exit.rs
@@ -85,9 +85,9 @@ impl Hashable for BridgeExit {
     fn hash(&self) -> Digest {
         pessimistic_proof_core::bridge_exit::bridge_exit_hasher(
             self.leaf_type as u8,
-            self.token_info.origin_network,
+            self.token_info.origin_network as u16,
             self.token_info.origin_token_address,
-            *self.dest_network,
+            *self.dest_network as u16,
             self.dest_address,
             self.amount,
             self.metadata,
@@ -124,6 +124,8 @@ impl Display for NetworkId {
 impl NetworkId {
     pub const BITS: usize = u32::BITS as usize;
 
+    // TODO: Change type of `NetworkId` directly to hold a `u16`?
+    /// `NetworkId` must fit in 16 bits.
     pub const fn new(value: u32) -> Self {
         Self(value)
     }
@@ -135,6 +137,7 @@ impl NetworkId {
 
 impl From<u32> for NetworkId {
     fn from(value: u32) -> Self {
+        assert_eq!(value, (value as u16) as u32); // `NetworkId` must fit in 16 bits.
         Self(value)
     }
 }

--- a/crates/pessimistic-proof/src/local_exit_tree/mod.rs
+++ b/crates/pessimistic-proof/src/local_exit_tree/mod.rs
@@ -72,10 +72,17 @@ where
 {
     /// Creates a new empty [`LocalExitTree`].
     pub fn new() -> Self {
+        let mut empty_hash_at_height = [H::Digest::default(); TREE_DEPTH];
+        for i in 1..TREE_DEPTH {
+            empty_hash_at_height[i] =
+                H::merge(&empty_hash_at_height[i - 1], &empty_hash_at_height[i - 1]);
+        }
+
         Self {
             inner: pessimistic_proof_core::local_exit_tree::LocalExitTree {
                 leaf_count: 0,
                 frontier: [H::Digest::default(); TREE_DEPTH],
+                empty_hash_at_height,
             },
         }
     }
@@ -104,10 +111,17 @@ where
     /// Creates a new [`LocalExitTree`] from its parts: leaf count, and
     /// frontier.
     pub fn from_parts(leaf_count: u32, frontier: [H::Digest; TREE_DEPTH]) -> Self {
+        let mut empty_hash_at_height = [H::Digest::default(); TREE_DEPTH];
+        for i in 1..TREE_DEPTH {
+            empty_hash_at_height[i] =
+                H::merge(&empty_hash_at_height[i - 1], &empty_hash_at_height[i - 1]);
+        }
+
         Self {
             inner: pessimistic_proof_core::local_exit_tree::LocalExitTree {
                 leaf_count,
                 frontier,
+                empty_hash_at_height,
             },
         }
     }


### PR DESCRIPTION
# Description

Introduces several improvements to the PP program in order to reduce the number of cycle counts. Below is a snapshot of the # of cycles for main VS this branch, for different number of (I) imported bridge exits and (E) bridge exits (3 runs each):

| Branch  | 10 E / 20 I | 10 E / 50 I | 30 E / 50 I | 100 E / 200 I |
| -------- | ------- | ------- | ------- | ------- |
| Old  | 8701768 | 19894737 | 20019004 | 77819172 |
| New | 7324101 | 16677887 | 16801915 | 65342788 |
| Improvement | 15.83% | 16.17% | 16.07% | 16.03% |

## Additions and Changes

The list of changes is the following:

- removed recomputation of `to_bits`: this was being called twice in `verify_and_update()`, it's now being computed once and reused
- added some `inlining` to reduce function call overhead for tiny methods
- tweaked very lightly some functions to remove branching (minor speedup) 
- precomputed `empty_hash_at_height` instead of recomputing them at every call of `get_root()`
- changed `NetworkId` to be 16-bit long instead of 32 bits: there was a comment already mentioning this. Bringing it down to 16 bits (i.e. 65536 possible chains) does remove a consequent number of `keccak` permutations when hashing the tries due to their smaller depth, yielding important savings

The last change (`NetworkId` implicit inner type as `u16`) hasn't been fully propagated to the rest of the codebase, given this has a _major_ impact on the API. Happy to pursue this / tackle it differently if needed.

Unrelated to other improvement suggestions (#586 and #587)

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
