### PR TITLE
feat: make docker image rebuilds 3x as fast

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,13 +43,13 @@ COPY --from=planner /app/recipe.json recipe.json
 # Notice that we are specifying the --target flag!
 RUN cargo chef cook --release --recipe-path recipe.json
 
-COPY --link crates crates
-COPY --link Cargo.toml Cargo.toml
-COPY --link Cargo.lock Cargo.lock
-
 RUN mkdir -p /root/.sp1/circuits/${CIRCUIT_TYPE}/${CIRCUIT_VERSION}
 RUN curl -s -o /tmp/circuits.tar.gz ${CIRCUIT_ARTIFACTS_URL_BASE}/${CIRCUIT_VERSION}-${CIRCUIT_TYPE}.tar.gz \
     && tar -Pxzf/tmp/circuits.tar.gz -C /root/.sp1/circuits/${CIRCUIT_TYPE}/${CIRCUIT_VERSION}
+
+COPY --link crates crates
+COPY --link Cargo.toml Cargo.toml
+COPY --link Cargo.lock Cargo.lock
 
 RUN cargo build --release --bin agglayer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN ARCHITECTURE=$(uname -m | sed -e "s/arm64/arm_64/g" | sed -e "s/aarch64/aarch_64/g") \
-    && curl -LOs "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-$ARCHITECTURE.zip" \
+    && curl -LOs --proto "=https" "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-$ARCHITECTURE.zip" \
     && unzip -o "protoc-${PROTOC_VERSION}-linux-$ARCHITECTURE.zip" -d /usr/local bin/protoc \
     && unzip -o "protoc-${PROTOC_VERSION}-linux-$ARCHITECTURE.zip" -d /usr/local 'include/*' \
     && chmod +x "/usr/local/bin/protoc" \


### PR DESCRIPTION
# Description

Before this change, each code change triggers a re-download of the SP1 circuits. After this change, a code change will only re-run `cargo build`. On my machine and network, with a small change, this brings the docker rebuild time down from 90s to 30s.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
