### PR TITLE
feat: await for the l1 info tree entry to be finalized (#501)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "mockall",
  "thiserror 2.0.11",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -278,34 +278,50 @@ where
             .await
             .map_err(|_| CertificationError::TrustedSequencerNotFound(network_id))?;
 
-        let l1_info_leaf_count = certificate
-            .l1_info_tree_leaf_count()
-            .unwrap_or_else(|| self.l1_rpc.default_l1_info_tree_entry().0);
-
-        let l1_info_root = self
-            .l1_rpc
-            .get_l1_info_root(l1_info_leaf_count)
-            .await
-            .map_err(|_| {
-                CertificationError::L1InfoRootNotFound(certificate_id, l1_info_leaf_count)
-            })?
-            .into();
-
         let declared_l1_info_root = certificate
             .l1_info_root()
             .map_err(|source| CertificationError::Types { source })?;
 
-        if let Some(declared) = declared_l1_info_root {
-            if declared != l1_info_root {
-                return Err(CertificationError::Types {
-                    source: agglayer_types::Error::L1InfoRootIncorrect {
-                        declared,
-                        retrieved: l1_info_root,
-                        leaf_count: l1_info_leaf_count,
-                    },
-                });
+        let declared_l1_info_leaf_count = certificate.l1_info_tree_leaf_count();
+
+        let l1_info_root = match (declared_l1_info_leaf_count, declared_l1_info_root) {
+            // Use the default corresponding to the entry set by the event `InitL1InfoRootMap`
+            (None, None) => self.l1_rpc.default_l1_info_tree_entry().1.into(),
+            // Retrieve the event corresponding to the declared entry and await for finalization
+            (Some(declared_leaf), Some(declared_root)) => {
+                // Retrieve from contract and await for finalization
+                let retrieved_root = self
+                    .l1_rpc
+                    .get_l1_info_root(declared_leaf)
+                    .await
+                    .map_err(|_| {
+                        CertificationError::L1InfoRootNotFound(certificate_id, declared_leaf)
+                    })?
+                    .into();
+
+                // Check that the retrieve l1 info root is equal to the declared one
+                if declared_root != retrieved_root {
+                    return Err(CertificationError::Types {
+                        source: agglayer_types::Error::L1InfoRootIncorrect {
+                            declared: declared_root,
+                            retrieved: retrieved_root,
+                            leaf_count: declared_leaf,
+                        },
+                    });
+                }
+
+                retrieved_root
             }
-        }
+            // Inconsistent declared L1 info tree entry
+            (l1_leaf, l1_info_root) => {
+                return Err(CertificationError::Types {
+                    source: agglayer_types::Error::InconsistentL1InfoTreeInformation {
+                        l1_leaf,
+                        l1_info_root,
+                    },
+                })
+            }
+        };
 
         let initial_state = LocalNetworkState::from(state.clone());
 

--- a/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, thread, time::Duration};
 
 use agglayer_certificate_orchestrator::Certifier;
 use agglayer_config::Config;
-use agglayer_contracts::Settler;
+use agglayer_contracts::{L1RpcError, Settler};
 use agglayer_prover::fake::FakeProver;
 use agglayer_storage::tests::{mocks::MockPendingStore, TempDBDir};
 use agglayer_types::{LocalNetworkStateData, NetworkId};
@@ -65,11 +65,6 @@ async fn happy_path() {
         .once()
         .with(eq(certificate_id), always())
         .return_once(|_, _| Ok(()));
-
-    l1_rpc
-        .expect_get_l1_info_root()
-        .once()
-        .returning(move |_| Ok(Default::default()));
 
     l1_rpc
         .expect_get_trusted_sequencer_address()
@@ -172,11 +167,6 @@ async fn prover_timeout() {
         .returning(move |_, _| Ok(signer));
 
     l1_rpc
-        .expect_get_l1_info_root()
-        .once()
-        .returning(move |_| Ok(Default::default()));
-
-    l1_rpc
         .expect_default_l1_info_tree_entry()
         .once()
         .returning(|| (0u32, [1u8; 32]));
@@ -217,7 +207,7 @@ mockall::mock! {
             proof_signers: std::collections::HashMap<u32,ethers::types::Address> ,
         ) -> Result<ethers::types::Address, ()>;
 
-        async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], ()>;
+        async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], L1RpcError>;
         fn default_l1_info_tree_entry(&self) -> (u32, [u8; 32]);
     }
     #[async_trait::async_trait]

--- a/crates/agglayer-aggregator-notifier/src/packer/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/packer/tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use agglayer_certificate_orchestrator::EpochPacker;
 use agglayer_config::outbound::OutboundRpcSettleConfig;
-use agglayer_contracts::Settler;
+use agglayer_contracts::{L1RpcError, Settler};
 use agglayer_storage::tests::mocks::{MockPendingStore, MockPerEpochStore, MockStateStore};
 use agglayer_types::{CertificateHeader, Proof};
 use arc_swap::ArcSwap;
@@ -30,7 +30,7 @@ mockall::mock! {
             proof_signers: std::collections::HashMap<u32,ethers::types::Address> ,
         ) -> Result<ethers::types::Address, ()>;
 
-        async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], ()>;
+        async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], L1RpcError>;
         fn default_l1_info_tree_entry(&self) -> (u32, [u8; 32]);
     }
     #[async_trait::async_trait]

--- a/crates/agglayer-contracts/Cargo.toml
+++ b/crates/agglayer-contracts/Cargo.toml
@@ -12,6 +12,7 @@ ethers.workspace = true
 ethers-contract = "2.0.14"
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/agglayer-contracts/src/lib.rs
+++ b/crates/agglayer-contracts/src/lib.rs
@@ -6,7 +6,7 @@ use ethers::prelude::*;
 use ethers::providers::Middleware;
 use ethers_contract::{ContractCall, ContractError};
 use polygon_rollup_manager::{PolygonRollupManagerErrors, RollupIDToRollupDataReturn};
-
+use tracing::{debug, error};
 
 #[rustfmt::skip]
 #[allow(warnings)]
@@ -35,10 +35,17 @@ pub trait RollupContract {
         proof_signers: HashMap<u32, Address>,
     ) -> Result<Address, ()>;
 
-    async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], ()>;
+    async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], L1RpcError>;
 
     fn default_l1_info_tree_entry(&self) -> (u32, [u8; 32]);
 }
+
+/// Polling tick interval used to check for one block to be finalized.
+const CHECK_BLOCK_FINALIZED_TICK_INTERVAL: tokio::time::Duration =
+    tokio::time::Duration::from_secs(10);
+
+/// Conservative time for finality on Ethereum.
+const TIME_TO_FINALITY_ETHEREUM: tokio::time::Duration = tokio::time::Duration::from_secs(30 * 60);
 
 pub struct L1RpcClient<RpcProvider> {
     rpc: Arc<RpcProvider>,
@@ -54,6 +61,22 @@ pub enum L1RpcInitializationError {
     InitL1InfoRootMapEventNotFound(String),
     #[error("Event InitL1InfoRootMap returned null value for L1 info root, leaf count: {0}")]
     InvalidL1InfoRootFromEvent(u32),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum L1RpcError {
+    #[error("Failed to get the `UpdateL1InfoTreeV2` events: {0}")]
+    UpdateL1InfoTreeV2EventFailure(String),
+    #[error("Unable to find `UpdateL1InfoTreeV2` events")]
+    UpdateL1InfoTreeV2EventNotFound,
+    #[error("Unable to fetch the latest finalized block")]
+    LatestFinalizedBlockNotFound,
+    #[error("Timeout exceeded while waiting for block {0} to be finalized.")]
+    FinalizationTimeoutExceeded(u64),
+    #[error("L1 Reorg detected for block number {0}")]
+    ReorgDetected(u64),
+    #[error("Cannot get the block hash for the block number {0}")]
+    BlockHashNotFound(u64),
 }
 
 impl<RpcProvider> L1RpcClient<RpcProvider>
@@ -100,6 +123,12 @@ where
                 ));
             }
 
+            debug!(
+                "Retrieved the default L1 Info Tree entry. leaf_count: {}, root: {}",
+                l1_leaf_count,
+                H256::from_slice(l1_info_root.as_slice())
+            );
+
             // Use this entry as default
             (l1_leaf_count, l1_info_root)
         };
@@ -125,11 +154,109 @@ where
         self.default_l1_info_tree_entry
     }
 
-    async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], ()> {
-        self.l1_info_tree
-            .l_1_info_root_map(l1_leaf_count)
+    async fn get_l1_info_root(&self, l1_leaf_count: u32) -> Result<[u8; 32], L1RpcError> {
+        // Get `UpdateL1InfoTreeV2` event for the given leaf count from the latest block
+        let filter = Filter::new()
+            .address(self.l1_info_tree.address())
+            .event("UpdateL1InfoTreeV2(bytes32,uint32,uint256,uint64)")
+            .topic1(U256::from_big_endian(&l1_leaf_count.to_be_bytes()))
+            .from_block(BlockNumber::Earliest);
+
+        let events = self
+            .l1_info_tree
+            .client()
+            .get_logs(&filter)
             .await
-            .map_err(|_| ())
+            .map_err(|e| L1RpcError::UpdateL1InfoTreeV2EventFailure(e.to_string()))?;
+
+        // Extract event details
+        let (l1_info_root, event_block_number, event_block_hash) = events
+            .first()
+            .and_then(|log| {
+                match PolygonZkEVMGlobalExitRootV2Events::decode_log(&log.clone().into()).ok()? {
+                    PolygonZkEVMGlobalExitRootV2Events::UpdateL1InfoTreeV2Filter(event) => Some((
+                        event.current_l1_info_root,
+                        log.block_number?,
+                        log.block_hash?,
+                    )),
+                    _ => None,
+                }
+            })
+            .ok_or(L1RpcError::UpdateL1InfoTreeV2EventNotFound)?;
+
+        debug!(
+            "Retrieved UpdateL1InfoTreeV2 event from block {}. L1 info tree leaf count: {}, root: \
+             {}",
+            event_block_number,
+            l1_leaf_count,
+            H256::from_slice(l1_info_root.as_slice())
+        );
+
+        // Await for the related block to be finalized
+        // NOTE: Cannot use block subscription because the provider is not websocket
+        {
+            let mut tick = tokio::time::interval(CHECK_BLOCK_FINALIZED_TICK_INTERVAL);
+            let mut finalized_block_number: U64 = 0.into();
+
+            _ = tokio::time::timeout(TIME_TO_FINALITY_ETHEREUM, async {
+                loop {
+                    tick.tick().await;
+
+                    finalized_block_number = self
+                        .rpc
+                        .get_block(BlockNumber::Finalized)
+                        .await
+                        .ok()
+                        .flatten()
+                        .and_then(|block| block.number)
+                        .ok_or(L1RpcError::LatestFinalizedBlockNotFound)?;
+
+                    debug!(
+                        "Awaiting L1 info tree leaf count ({}) set at block {} to be finalized. \
+                         Latest finalized block: {}",
+                        l1_leaf_count, event_block_number, finalized_block_number,
+                    );
+
+                    // Check whether the block number containing the event is now finalized.
+                    if finalized_block_number >= event_block_number {
+                        // Verify that the hash of the block containing
+                        // the event did not change due to potential reorg
+                        let retrieved_block_hash = self
+                            .rpc
+                            .get_block(BlockId::Number(event_block_number.into()))
+                            .await
+                            .ok()
+                            .flatten()
+                            .and_then(|block| block.hash)
+                            .ok_or(L1RpcError::BlockHashNotFound(event_block_number.as_u64()))?;
+
+                        if retrieved_block_hash != event_block_hash {
+                            error!(
+                                "Reorg detected! Retrieved block hash ({:?}) does not match \
+                                 expected event block hash ({:?}).",
+                                retrieved_block_hash, event_block_hash
+                            );
+                            return Err(L1RpcError::ReorgDetected(event_block_number.as_u64()));
+                        }
+
+                        break;
+                    }
+                }
+
+                Ok(())
+            })
+            .await
+            .map_err(|_| {
+                error!(
+                    "Timeout occurred while waiting for block {} to be finalized. Latest \
+                     finalized block: {}",
+                    event_block_number, finalized_block_number
+                );
+                L1RpcError::FinalizationTimeoutExceeded(event_block_number.as_u64())
+            })??;
+        }
+
+        Ok(l1_info_root)
     }
 
     async fn get_trusted_sequencer_address(
@@ -240,7 +367,7 @@ mod tests {
             .unwrap(),
         );
 
-        let (default_leaf_count, default_l1_info_root) = l1_rpc.default_l1_info_tree_entry;
+        let (default_leaf_count, _default_l1_info_root) = l1_rpc.default_l1_info_tree_entry;
         let expected_leaf_count = 48445; // bali: 335
 
         assert_eq!(
@@ -249,7 +376,8 @@ mod tests {
             default_leaf_count, expected_leaf_count,
         );
 
-        let l1_info_root_from_map = l1_rpc.get_l1_info_root(default_leaf_count).await.unwrap();
-        assert_eq!(l1_info_root_from_map, default_l1_info_root);
+        // check that the awaiting for finalization is done as expected
+        let latest_l1_leaf = 73587;
+        let _l1_info_root = l1_rpc.get_l1_info_root(latest_l1_leaf).await.unwrap();
     }
 }

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -120,6 +120,14 @@ pub enum Error {
         declared: Digest,
         retrieved: Digest,
     },
+    #[error(
+        "Incorrect declared L1 Info Tree information: l1_leaf: {l1_leaf:?}, l1_root: \
+         {l1_info_root:?}"
+    )]
+    InconsistentL1InfoTreeInformation {
+        l1_leaf: Option<u32>,
+        l1_info_root: Option<Digest>,
+    },
     /// The operation cannot be applied on the smt.
     #[error(transparent)]
     InvalidSmtOperation(#[from] SmtError),


### PR DESCRIPTION

# Description

This PR is porting back to main the changes made for 0.2.2 in PR #501

(cherry picked from commit abc4e530e2d9c1d92aee4ebb520ba9f8f3e33e02)

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
