### PR TITLE
build: remove sonarcloud job to rely on automode

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,17 +61,6 @@ jobs:
             --ignore '/*' \
             -o coverage.lcov
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.externalIssuesReportPaths=sonar-issues.json
-            -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
-
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5
         continue-on-error: true


### PR DESCRIPTION
# Description

This PR removes the sonarcloud action from the CI to rely on automatic mode.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
