### PR TITLE
fix: github action proto ref for merge_group

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -11,18 +11,33 @@ on:
 permissions:
   contents: read
   pull-requests: write
+
+env:
+  BREAKING_REF: branch=main
+
 jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Define BREAKING_REF for merge_group
+        if: github.event_name == 'merge_group'
+        run: echo "BREAKING_REF=ref=${{ github.event.merge_group.base_sha }}" >> $GITHUB_ENV
+ 
+      - name: Define BREAKING_REF for pull_request
+        if: github.event_name == 'pull_request'
+        run: echo "BREAKING_REF=ref=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+
+      - name: Define BREAKING_REF for main
+        if: github.event_name == 'push'
+        run: echo "BREAKING_REF=ref=${{ github.event.before }}" >> $GITHUB_ENV
+
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
           input: "proto"
-          breaking_against: "${{ github.event.repository.clone_url }}#format=git,ref=${{ github.event.pull_request.base.sha || 'HEAD~1,branch=main' }},subdir=proto"
-          # Run breaking change, lint, and format checks for Protobuf sources against all branches,
-          # 'proto' # subdirectory, then push to the BSR once validated
+          breaking_against: "${{ github.event.repository.clone_url }}#format=git,${{ env.BREAKING_REF }},subdir=proto"
           lint: true
           format: true
           breaking: true

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           token: ${{ secrets.BUF_TOKEN }}
           input: "proto"
-          breaking_against: "${{ github.event.repository.clone_url }}#format=git,ref=${{ github.event.pull_request.base.sha || github.event.before }},subdir=proto"
+          breaking_against: "${{ github.event.repository.clone_url }}#format=git,ref=${{ github.event.pull_request.base.sha || 'HEAD~1,branch=main' }},subdir=proto"
           # Run breaking change, lint, and format checks for Protobuf sources against all branches,
           # 'proto' # subdirectory, then push to the BSR once validated
           lint: true


### PR DESCRIPTION
# Description

Fixes the ref+branch used when triggered in merge_group.


## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
