### PR TITLE
docs: fix dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Before working with the repository, you’ll need the following:
 
 You’ll need to submit a unique Ethereum address to Succinct for access to their proving network. To get access:
 
-1. Follow the instructions [here](https://docs.succinct.xyz/docs/generating-proofs/prover-network/key-setup) to use Foundry to generate a new private key or retrieve an existing one.
+1. Follow the instructions [here](https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network/key-setup) to use Foundry to generate a new private key or retrieve an existing one.
 2. Apply for access for the public address associated with your private key to Succinct Network [here](https://docs.google.com/forms/d/e/1FAIpQLSd-X9uH7G0bvXH_kjptnQtNil8L4dumrVPpFE4t8Ci1XT1GaQ/viewform).
 
 ### Software Requirements


### PR DESCRIPTION
# Description

Hi! I fixes a dead link in the README.md file. The original link pointing to Succinct's documentation for generating proofs was outdated and has been updated to the correct URL.

## Additions and Changes

Updated the dead link from https://docs.succinct.xyz/docs/generating-proofs/prover-network/key-setup to https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network/key-setup.


## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
