### PR TITLE
chore: fix the `std::io::Error::new` clippy issue

### DIFF
--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -134,8 +134,7 @@ impl Config {
             .parent()
             .ok_or_else(|| ConfigurationError::UnableToReadConfigFile {
                 path: path.to_path_buf(),
-                source: std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                source: std::io::Error::other(
                     "Unable to determine the parent folder of the configuration file",
                 ),
             })?;


### PR DESCRIPTION
Change `std::io::Error::new(ErrorKind::other, x)` to `std::io::Error::other(x)`. Some PRs started failing because of this because clippy is complaining about it.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
