### PR TITLE
revert: make dependabot update prover packages in one PR (#680)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      provers:
-        applies-to: version-updates
-        patterns:
-        - "agglayer-prover"
-        - "agglayer-prover-*"
-        - "prover-config"
       all:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
This reverts commit e241619aa1a434d1deae0e00ca491036cbbe5014.

Sadly, dependabot started failing with "unknown error" since this was merged.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
