### PR TITLE
fix: grpc always expects to be on the domain root

### DIFF
--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -62,21 +62,27 @@ pub struct Config {
     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
     #[serde(default)]
     pub proof_signers: HashMap<u32, Address>,
+
     /// The log configuration.
     #[serde(default)]
     pub log: Log,
+
     /// The local RPC server configuration.
     #[serde(default)]
     pub rpc: RpcConfig,
+
     /// Rate limiting configuration.
     #[serde(default)]
     pub rate_limiting: RateLimitingConfig,
+
     /// The configuration for every outbound network component.
     #[serde(default)]
     pub outbound: OutboundConfig,
+
     /// The L1 configuration.
     #[serde(default)]
     pub l1: L1,
+
     /// The authentication configuration.
     #[serde(default)]
     pub auth: AuthConfig,
@@ -174,9 +180,14 @@ impl Config {
         }
     }
 
-    /// Get the target RPC socket address from the configuration.
-    pub fn rpc_addr(&self) -> std::net::SocketAddr {
-        std::net::SocketAddr::from((self.rpc.host, self.rpc.port))
+    /// Get the target ReadRPC socket address from the configuration.
+    pub fn readrpc_addr(&self) -> std::net::SocketAddr {
+        std::net::SocketAddr::from((self.rpc.host, self.rpc.readrpc_port))
+    }
+
+    /// Get the target gRPC socket address from the configuration.
+    pub fn grpc_addr(&self) -> std::net::SocketAddr {
+        std::net::SocketAddr::from((self.rpc.host, self.rpc.grpc_port))
     }
 
     /// Get the admin RPC socket address from the configuration.

--- a/crates/agglayer-config/src/rpc.rs
+++ b/crates/agglayer-config/src/rpc.rs
@@ -4,8 +4,12 @@ use jsonrpsee::core::TEN_MB_SIZE_BYTES;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::serde_as;
 
-/// The default port for the local RPC server.
-const DEFAULT_PORT: u16 = 9090;
+/// The default port for the local gRPC server.
+const DEFAULT_GRPC_PORT: u16 = 9089;
+
+/// The default port for the local ReadRPC server.
+const DEFAULT_READRPC_PORT: u16 = 9090;
+
 /// The default port for the local admin RPC server.
 const DEFAULT_ADMIN_PORT: u16 = 9091;
 
@@ -14,12 +18,24 @@ const DEFAULT_ADMIN_PORT: u16 = 9091;
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct RpcConfig {
-    /// If the `PORT` environment variable is set, it will take precedence over
-    /// the configuration file.
-    #[serde(default = "default_port", deserialize_with = "deserialize_port")]
-    pub port: u16,
+    /// The default port for the local gRPC server.
+    /// Overridden by `AGGLAYER_GRPC_PORT` environment variable, defaults to 9089.
+    #[serde(
+        default = "default_grpc_port",
+        deserialize_with = "deserialize_grpc_port"
+    )]
+    pub grpc_port: u16,
 
-    /// The port for `admin` RPC
+    /// The default port for the local ReadRPC server.
+    /// Overridden by `AGGLAYER_READRPC_PORT` environment variable, defaults to 9090.
+    #[serde(
+        default = "default_readrpc_port",
+        deserialize_with = "deserialize_readrpc_port"
+    )]
+    pub readrpc_port: u16,
+
+    /// The default port for the local AdminRPC server.
+    /// Overridden by `AGGLAYER_ADMIN_PORT` environment variable, defaults to 9091.
     #[serde(
         default = "default_admin_port",
         deserialize_with = "deserialize_admin_port"
@@ -64,7 +80,8 @@ pub struct RpcConfig {
 impl Default for RpcConfig {
     fn default() -> Self {
         Self {
-            port: default_port(),
+            grpc_port: default_grpc_port(),
+            readrpc_port: default_readrpc_port(),
             admin_port: default_admin_port(),
             host: default_host(),
             max_request_body_size: default_body_size(),
@@ -87,19 +104,18 @@ fn default_body_size() -> u32 {
     TEN_MB_SIZE_BYTES
 }
 
-/// The default port for the local RPC server.
-/// If the `AGGLAYER_PORT` environment variable is set, it will take precedence
-/// over
-fn default_port() -> u16 {
-    from_env_or_default("AGGLAYER_PORT", DEFAULT_PORT)
+fn default_grpc_port() -> u16 {
+    from_env_or_default("AGGLAYER_GRPC_PORT", DEFAULT_GRPC_PORT)
 }
 
-/// The default port for the local admin RPC server.
-/// If the `AGGLAYER_ADMIN_PORT` environment variable is set, it will take
-/// precedence over
+fn default_readrpc_port() -> u16 {
+    from_env_or_default("AGGLAYER_READRPC_PORT", DEFAULT_READRPC_PORT)
+}
+
 fn default_admin_port() -> u16 {
     from_env_or_default("AGGLAYER_ADMIN_PORT", DEFAULT_ADMIN_PORT)
 }
+
 /// The default host for the local RPC server.
 const fn default_host() -> Ipv4Addr {
     Ipv4Addr::new(0, 0, 0, 0)
@@ -110,13 +126,22 @@ const fn default_request_timeout() -> Duration {
     Duration::from_secs(180)
 }
 
-fn deserialize_port<'de, D>(deserializer: D) -> Result<u16, D::Error>
+fn deserialize_grpc_port<'de, D>(deserializer: D) -> Result<u16, D::Error>
 where
     D: Deserializer<'de>,
 {
     let port = u16::deserialize(deserializer)?;
 
-    Ok(from_env_or_default("AGGLAYER_PORT", port))
+    Ok(from_env_or_default("AGGLAYER_GRPC_PORT", port))
+}
+
+fn deserialize_readrpc_port<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let port = u16::deserialize(deserializer)?;
+
+    Ok(from_env_or_default("AGGLAYER_READRPC_PORT", port))
 }
 
 fn deserialize_admin_port<'de, D>(deserializer: D) -> Result<u16, D::Error>

--- a/crates/agglayer-config/src/rpc.rs
+++ b/crates/agglayer-config/src/rpc.rs
@@ -19,7 +19,8 @@ const DEFAULT_ADMIN_PORT: u16 = 9091;
 #[serde(rename_all = "kebab-case")]
 pub struct RpcConfig {
     /// The default port for the local gRPC server.
-    /// Overridden by `AGGLAYER_GRPC_PORT` environment variable, defaults to 9089.
+    /// Overridden by `AGGLAYER_GRPC_PORT` environment variable, defaults to
+    /// 9089.
     #[serde(
         default = "default_grpc_port",
         deserialize_with = "deserialize_grpc_port"
@@ -27,7 +28,8 @@ pub struct RpcConfig {
     pub grpc_port: u16,
 
     /// The default port for the local ReadRPC server.
-    /// Overridden by `AGGLAYER_READRPC_PORT` environment variable, defaults to 9090.
+    /// Overridden by `AGGLAYER_READRPC_PORT` environment variable, defaults to
+    /// 9090.
     #[serde(
         default = "default_readrpc_port",
         deserialize_with = "deserialize_readrpc_port"
@@ -35,7 +37,8 @@ pub struct RpcConfig {
     pub readrpc_port: u16,
 
     /// The default port for the local AdminRPC server.
-    /// Overridden by `AGGLAYER_ADMIN_PORT` environment variable, defaults to 9091.
+    /// Overridden by `AGGLAYER_ADMIN_PORT` environment variable, defaults to
+    /// 9091.
     #[serde(
         default = "default_admin_port",
         deserialize_with = "deserialize_admin_port"

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_kebab_case.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_kebab_case.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/agglayer-config/tests/auth_config.rs
 expression: config
+snapshot_kind: text
 ---
 prover-entrypoint = "http://127.0.0.1:8080"
 
@@ -17,7 +18,8 @@ outputs = []
 format = "pretty"
 
 [rpc]
-port = 9090
+grpc-port = 9089
+readrpc-port = 9090
 admin-port = 9091
 host = "0.0.0.0"
 request-timeout = "3m"

--- a/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
+++ b/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/agglayer-config/tests/backup.rs
 expression: config
+snapshot_kind: text
 ---
 prover-entrypoint = "http://127.0.0.1:8080"
 
@@ -17,7 +18,8 @@ outputs = []
 format = "pretty"
 
 [rpc]
-port = 9090
+grpc-port = 9089
+readrpc-port = 9090
 admin-port = 9091
 host = "0.0.0.0"
 request-timeout = "3m"

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/agglayer-config/tests/validate_deserialize.rs
 expression: config
+snapshot_kind: text
 ---
 prover-entrypoint = "http://127.0.0.1:8080"
 
@@ -17,7 +18,8 @@ outputs = []
 format = "pretty"
 
 [rpc]
-port = 9090
+grpc-port = 9089
+readrpc-port = 9090
 admin-port = 9091
 host = "0.0.0.0"
 request-timeout = "3m"

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/agglayer-config/tests/validate_deserialize.rs
 expression: config
+snapshot_kind: text
 ---
 prover-entrypoint = "http://127.0.0.1:8080"
 
@@ -17,7 +18,8 @@ outputs = []
 format = "pretty"
 
 [rpc]
-port = 9090
+grpc-port = 9089
+readrpc-port = 9090
 admin-port = 9091
 host = "0.0.0.0"
 request-timeout = "3m"

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/agglayer-config/tests/validate_deserialize.rs
 expression: config
+snapshot_kind: text
 ---
 prover-entrypoint = "http://127.0.0.1:8080"
 
@@ -17,7 +18,8 @@ outputs = []
 format = "pretty"
 
 [rpc]
-port = 9090
+grpc-port = 9089
+readrpc-port = 9090
 admin-port = 9091
 host = "0.0.0.0"
 max-request-body-size = 104857600

--- a/crates/agglayer-jsonrpc-api/src/tests/get_tx_status.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/get_tx_status.rs
@@ -50,7 +50,7 @@ async fn check_tx_status() {
     if let std::net::IpAddr::V4(ip) = addr.ip() {
         config.rpc.host = ip;
     }
-    config.rpc.port = addr.port();
+    config.rpc.readrpc_port = addr.port();
 
     let config = Arc::new(config);
 
@@ -83,7 +83,7 @@ async fn check_tx_status() {
         .await
         .unwrap();
 
-    let listener = tokio::net::TcpListener::bind(config.rpc_addr())
+    let listener = tokio::net::TcpListener::bind(config.readrpc_addr())
         .await
         .unwrap();
     let api_server = axum::serve(listener, router);
@@ -93,7 +93,7 @@ async fn check_tx_status() {
         debug!("Node RPC shutdown requested.");
     });
 
-    let url = format!("http://{}/", config.rpc_addr());
+    let url = format!("http://{}/", config.readrpc_addr());
     let client = HttpClientBuilder::default().build(url).unwrap();
 
     let res: TxStatus = client
@@ -162,7 +162,7 @@ async fn check_tx_status_fail() {
         .await
         .unwrap();
 
-    let listener = tokio::net::TcpListener::bind(config.rpc_addr())
+    let listener = tokio::net::TcpListener::bind(config.readrpc_addr())
         .await
         .unwrap();
     let api_server = axum::serve(listener, router);
@@ -171,7 +171,7 @@ async fn check_tx_status_fail() {
         _ = api_server.await;
         debug!("Node RPC shutdown requested.");
     });
-    let url = format!("http://{}/", config.rpc_addr());
+    let url = format!("http://{}/", config.readrpc_addr());
     let client = HttpClientBuilder::default().build(url).unwrap();
 
     // Try to get status using a non-existent address

--- a/crates/agglayer-jsonrpc-api/src/tests/send_certificate.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/send_certificate.rs
@@ -17,7 +17,7 @@ async fn send_certificate_method_can_be_called_and_succeed() {
 
     let mut context = TestContext::new_with_config(config).await;
 
-    let url = format!("http://{}/", context.config.rpc_addr());
+    let url = format!("http://{}/", context.config.readrpc_addr());
     let client = HttpClientBuilder::default().build(url).unwrap();
     let _: CertificateId = client
         .request(

--- a/crates/agglayer-jsonrpc-api/src/testutils.rs
+++ b/crates/agglayer-jsonrpc-api/src/testutils.rs
@@ -65,12 +65,12 @@ impl TestContext {
 
         let admin_router = raw_rpc.admin_rpc.start().await.unwrap();
 
-        let api_url = format!("http://{}/", raw_rpc.config.rpc_addr());
+        let api_url = format!("http://{}/", raw_rpc.config.readrpc_addr());
         let admin_url = format!("http://{}/", raw_rpc.config.admin_rpc_addr());
         let client = HttpClientBuilder::default().build(api_url).unwrap();
         let admin_client = HttpClientBuilder::default().build(admin_url).unwrap();
 
-        let listener_api = tokio::net::TcpListener::bind(raw_rpc.config.rpc_addr())
+        let listener_api = tokio::net::TcpListener::bind(raw_rpc.config.readrpc_addr())
             .await
             .unwrap();
 
@@ -120,7 +120,7 @@ impl TestContext {
         if let IpAddr::V4(ip) = addr.ip() {
             config.rpc.host = ip;
         }
-        config.rpc.port = addr.port();
+        config.rpc.readrpc_port = addr.port();
         config.rpc.admin_port = admin_addr.port();
 
         let config = Arc::new(config);

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -293,7 +293,7 @@ impl Node {
         let router = axum::Router::new()
             .merge(health_router)
             .merge(json_rpc_router)
-            .nest("/grpc", grpc_router);
+            .merge(grpc_router);
 
         let listener = tokio::net::TcpListener::bind(config.rpc_addr()).await?;
         let admin_listener = tokio::net::TcpListener::bind(config.admin_rpc_addr()).await?;

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -17,7 +17,8 @@ outputs = []
 format = "pretty"
 
 [rpc]
-port = 9090
+grpc-port = 9089
+readrpc-port = 9090
 admin-port = 9091
 host = "0.0.0.0"
 request-timeout = "3m"

--- a/tests/integrations/src/agglayer_setup.rs
+++ b/tests/integrations/src/agglayer_setup.rs
@@ -103,9 +103,11 @@ pub async fn start_agglayer(
 
     let key_path = config_path.join(uuid);
 
-    let addr = next_available_addr();
+    let grpc_addr = next_available_addr();
+    let readrpc_addr = next_available_addr();
     let admin_addr = next_available_addr();
-    config.rpc.port = addr.port();
+    config.rpc.grpc_port = grpc_addr.port();
+    config.rpc.readrpc_port = readrpc_addr.port();
     config.rpc.admin_port = admin_addr.port();
 
     config.telemetry.addr = next_available_addr();
@@ -138,7 +140,7 @@ pub async fn start_agglayer(
         }
         _ = shutdown.send(());
     });
-    let url = format!("ws://{}/", config.rpc_addr());
+    let url = format!("ws://{}/", config.readrpc_addr());
 
     let mut interval = tokio::time::interval(Duration::from_secs(10));
     let mut max_attempts = 20;


### PR DESCRIPTION
See https://stackoverflow.com/questions/40410392/grpc-endpoint-with-non-root-path In particular, the go library seems to not support prefixing calls with `/grpc`.

cc @goran-ethernal as you handled the go part of this investigation
cc @Freyskeyd as you wrote the initial code

Part of #666 

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
