### PR TITLE
fix: use absolute path in a macro

### DIFF
--- a/tests/integrations/src/agglayer_setup.rs
+++ b/tests/integrations/src/agglayer_setup.rs
@@ -39,7 +39,7 @@ macro_rules! wait_for_settlement_or_error {
                         break;
                     }
                     _ => {
-                        tokio::time::sleep(Duration::from_millis(1000)).await;
+                        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
                     }
                 }
             }


### PR DESCRIPTION
The macro otherwise breaks if used from a module where the correct `Duration` is not imported.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
