### PR TITLE
build: more granular dependabot groups, take 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,31 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
     groups:
-      all:
+      provers:
         applies-to: version-updates
         patterns:
-        - "*"
+          - "aggchain-proof-*"
+          - "aggkig-prover"
+          - "aggkit-prover-*"
+          - "agglayer-prover"
+          - "agglayer-prover-*"
+          - "proposer-*"
+          - "prover-*"
+
+      sp1:
+        applies-to: version-updates
+        patterns:
+          - "sp1-*"
+
+      external:
+        applies-to: version-updates
+        patterns:
+          - "*"
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Three groups have been introduced:
* `provers` for keeping up to date with the `agglayer/provers` repo
* `sp1` for which we have a different update policy from other external dependencies, and updating it often fails, making dependabot PRs way less useful
* `external`, previously called `all`, for the remaining external dependencies. Major version updates still get separate PRs.

Looking at the dependabot logs, the failures we've seen may not have been a result of #680 (reverted #685), so I think this calls for another attempt. I have also changed the indentation a bit to be in line with most yaml syntax examples online, and possibly friendlier to parsers.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
