### PR TITLE
ci: use stable toolchain for `doc` and `clippy`

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -18,12 +18,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
 
       - uses: taiki-e/install-action@protoc
 
       - name: Build Documentation
-        run: cargo +nightly doc --no-deps --all --all-features
+        run: cargo doc --no-deps --all --all-features
 
       - name: Add index file
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -26,7 +26,6 @@ dependencies = [
 
 [tasks.ci-clippy-workspace]
 category = "CI - CHECK"
-toolchain = "nightly"
 command = "cargo"
 args = ["clippy", "--workspace", "--tests", "--", "-D", "warnings"]
 


### PR DESCRIPTION
Attempt to resolve the recent CI failures on an `sp1`-related package with nightly toolchain.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
