### PR TITLE
refactor: switch vkey to big endian

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6551,6 +6551,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.8 (git+https://github.com/sp1-patches/RustCrypto-hashes.git?tag=patch-sha2-0.10.8-sp1-4.0.0)",
+ "sp1-primitives",
  "sp1-verifier",
  "sp1-zkvm",
  "thiserror 2.0.12",

--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -375,8 +375,8 @@ where
 
                 let agglayer_types::aggchain_proof::Proof::SP1Stark(sp1_reduce_proof) = proof;
 
-                let proof_vk_hash = agglayer_contracts::aggchain::AggchainVkeyHash::from_u32_array(
-                    sp1_reduce_proof.vk.hash_u32(),
+                let proof_vk_hash = agglayer_contracts::aggchain::AggchainVkeyHash::new(
+                    sp1_reduce_proof.vk.hash_bytes(),
                 );
 
                 if aggchain_vkey != proof_vk_hash {
@@ -386,7 +386,7 @@ where
                     });
                 }
 
-                Some(aggchain_vkey.as_u32_array())
+                Some(sp1_reduce_proof.vk.hash_u32())
             }
         };
 

--- a/crates/agglayer-contracts/src/aggchain.rs
+++ b/crates/agglayer-contracts/src/aggchain.rs
@@ -1,5 +1,4 @@
 use ethers::{providers::Middleware, types::Address};
-use sp1_primitives::consts::{bytes_to_words_le, words_to_bytes_le};
 use tracing::error;
 
 use crate::{aggchain_base::AggchainBase, L1RpcClient, L1RpcError};
@@ -10,14 +9,6 @@ pub struct AggchainVkeyHash([u8; 32]);
 impl AggchainVkeyHash {
     pub fn new(vkey: [u8; 32]) -> Self {
         Self(vkey)
-    }
-
-    pub fn from_u32_array(hash: [u32; 8]) -> Self {
-        Self(words_to_bytes_le(&hash))
-    }
-
-    pub fn as_u32_array(&self) -> [u32; 8] {
-        bytes_to_words_le(&self.0)
     }
 
     pub fn to_hex(&self) -> String {

--- a/crates/agglayer-primitives/src/lib.rs
+++ b/crates/agglayer-primitives/src/lib.rs
@@ -3,3 +3,14 @@ pub use alloy_primitives::{address, ruint, Address, SignatureError, B256, U256, 
 pub use crate::signature::Signature;
 
 mod signature;
+
+/// Utility method for converting u32 words to bytes in big endian.
+pub fn words_to_bytes_be(words: &[u32; 8]) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    for i in 0..8 {
+        let word_bytes = words[i].to_be_bytes();
+        bytes[i * 4..(i + 1) * 4].copy_from_slice(&word_bytes);
+    }
+
+    bytes
+}

--- a/crates/pessimistic-proof-core/Cargo.toml
+++ b/crates/pessimistic-proof-core/Cargo.toml
@@ -20,6 +20,7 @@ tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch
     "keccak",
 ] }
 rand = { version = "0.9.0", optional = true }
+sp1-primitives = "=4.1.2"
 sp1-verifier = { version = "=4.1.2" }
 sp1-zkvm = { version = "=4.1.2", features = ["verify"] }
 

--- a/crates/pessimistic-proof-core/src/aggchain_proof.rs
+++ b/crates/pessimistic-proof-core/src/aggchain_proof.rs
@@ -5,10 +5,9 @@
 //!
 //! For now, this is constraint to be either one ECDSA signature, or one SP1
 //! stark proof proving a specified statement which can be abstracted here.
-use agglayer_primitives::{Address, Signature};
+use agglayer_primitives::{words_to_bytes_be, Address, Signature};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as Sha256Digest, Sha256};
-use sp1_zkvm::lib::utils::words_to_bytes_le;
 
 use crate::keccak::{digest::Digest, keccak256_combine};
 
@@ -53,7 +52,7 @@ impl AggchainData {
                 aggchain_vkey,
             } => keccak256_combine([
                 &(ConsensusType::Generic as u32).to_be_bytes(),
-                words_to_bytes_le(aggchain_vkey).as_slice(),
+                words_to_bytes_be(aggchain_vkey).as_slice(),
                 aggchain_params.as_slice(),
             ]),
         }


### PR DESCRIPTION
# Description

Refactorisation of how we proceed `aggchain-vkey` to match and have a standard format accros various vkeys.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
