### PR TITLE
build: update e2e flow to be used as required step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: ./.github/actions/unit-test
 
   isolated-feature-checks:
-    name: 'Isolated feature checks'
+    name: "Isolated feature checks"
     runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v4
@@ -204,6 +204,20 @@ jobs:
             "zkevm_contracts_image": "leovct/zkevm-contracts:v10.0.0-rc.3-fork.12"
           }
         }
+
+  # We use this job to check the result of the E2E tests
+  # As the E2E are running from a reusable workflow,
+  # github doesn't handle the job name when dealing with required jobs.'
+  # see: https://github.com/actions/runner/issues/1917
+  check-e2e-result:
+    name: E2E Tests | Passed
+    needs:
+      - call-cdk-e2e-workflow
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        if: ${{ contains(fromJSON('["failure", "cancelled"]'), needs.call-cdk-e2e-workflow.result) }}
 
   pushing-docker-image:
     name: Docker | Publish image to registry


### PR DESCRIPTION
# Description

This PR update the github workflow to prevent non reportable job result when using reusable workflows.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
