### PR TITLE
feat: update imported hash

### DIFF
--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -43,6 +43,7 @@ pub use pessimistic_proof::imported_bridge_exit::{
     L1InfoTreeLeafInner, MerkleProof,
 };
 pub use pessimistic_proof::proof::Proof;
+pub use pessimistic_poof_core::imported_bridge_exit::commit_imported_bridge_exits;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExecutionMode {
@@ -326,7 +327,7 @@ pub fn compute_signature_info(
 
     let combined_hash = pessimistic_proof::multi_batch_header::signature_commitment(
         new_local_exit_root,
-        imported_bridge_exits.iter().map(|exit| (exit.global_index, exit.bridge_exit.hash())),
+        commit_imported_bridge_exits(imported_bridge_exits)
     );
 
     let signature = wallet.sign_hash(combined_hash.0.into()).unwrap();

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -326,7 +326,7 @@ pub fn compute_signature_info(
 
     let combined_hash = pessimistic_proof::multi_batch_header::signature_commitment(
         new_local_exit_root,
-        imported_bridge_exits.iter().map(|exit| exit.global_index),
+        imported_bridge_exits.iter().map(|exit| (exit.global_index, exit.bridge_exit.hash())),
     );
 
     let signature = wallet.sign_hash(combined_hash.0.into()).unwrap();
@@ -435,7 +435,7 @@ impl Certificate {
                     self.new_local_exit_root,
                     self.imported_bridge_exits
                         .iter()
-                        .map(|exit| exit.global_index),
+                        .map(|exit| (exit.global_index, exit.bridge_exit.hash())),
                 );
 
                 signature

--- a/crates/pessimistic-proof-core/src/imported_bridge_exit.rs
+++ b/crates/pessimistic-proof-core/src/imported_bridge_exit.rs
@@ -238,6 +238,8 @@ impl ImportedBridgeExit {
     }
 }
 
-pub fn commit_imported_bridge_exits(iter: impl Iterator<Item = GlobalIndex>) -> Digest {
-    keccak256_combine(iter.map(|global_index| global_index.hash()))
+pub fn commit_imported_bridge_exits(iter: impl Iterator<Item = (GlobalIndex, Digest)>) -> Digest {
+    keccak256_combine(iter.map(|(global_index, bridge_exit_hash)| {
+        keccak256_combine([global_index.hash(), bridge_exit_hash])
+    }))
 }

--- a/crates/pessimistic-proof-core/src/local_state/mod.rs
+++ b/crates/pessimistic-proof-core/src/local_state/mod.rs
@@ -230,7 +230,7 @@ impl NetworkState {
 
         // Verify the aggchain proof which can be either one signature or one sp1 proof.
         // NOTE: The STARK is verified exclusively within the SP1 VM.
-        let target_pp_root_version = match &multi_batch_header.aggchain_proof {
+        let target_pp_root_version: PPRootVersion = match &multi_batch_header.aggchain_proof {
             AggchainData::ECDSA { signer, signature } => {
                 let verify_signature = |digest: Digest, signature: &Signature| {
                     signature

--- a/crates/pessimistic-proof-core/src/local_state/mod.rs
+++ b/crates/pessimistic-proof-core/src/local_state/mod.rs
@@ -225,7 +225,7 @@ impl NetworkState {
             multi_batch_header
                 .imported_bridge_exits
                 .iter()
-                .map(|(exit, _)| exit.global_index),
+                .map(|(exit, _)| (exit.global_index, exit.bridge_exit.hash())),
         );
 
         // Verify the aggchain proof which can be either one signature or one sp1 proof.

--- a/crates/pessimistic-proof-core/src/multi_batch_header.rs
+++ b/crates/pessimistic-proof-core/src/multi_batch_header.rs
@@ -59,7 +59,7 @@ where
 
 pub fn signature_commitment(
     new_local_exit_root: Digest,
-    imported_bridge_exits: impl Iterator<Item = GlobalIndex>,
+    imported_bridge_exits: impl Iterator<Item = (GlobalIndex, Digest)>,
 ) -> Digest {
     let imported_hash = commit_imported_bridge_exits(imported_bridge_exits);
     keccak256_combine([new_local_exit_root.as_slice(), imported_hash.as_slice()])

--- a/crates/pessimistic-proof-core/src/multi_batch_header.rs
+++ b/crates/pessimistic-proof-core/src/multi_batch_header.rs
@@ -59,8 +59,7 @@ where
 
 pub fn signature_commitment(
     new_local_exit_root: Digest,
-    imported_bridge_exits: impl Iterator<Item = (GlobalIndex, Digest)>,
+    imported_hash: Digest,
 ) -> Digest {
-    let imported_hash = commit_imported_bridge_exits(imported_bridge_exits);
     keccak256_combine([new_local_exit_root.as_slice(), imported_hash.as_slice()])
 }

--- a/crates/pessimistic-proof-test-suite/src/forest.rs
+++ b/crates/pessimistic-proof-test-suite/src/forest.rs
@@ -252,7 +252,7 @@ impl Forest {
                     certificate
                         .imported_bridge_exits
                         .iter()
-                        .map(|i| i.global_index),
+                        .map(|i| (i.global_index, i.bridge_exit.hash())),
                 ),
                 prev_local_exit_root: *certificate.prev_local_exit_root,
                 new_local_exit_root: *certificate.new_local_exit_root,

--- a/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
+++ b/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
@@ -70,7 +70,7 @@ fn pp_root_migration_helper(
             multi_batch_header
                 .imported_bridge_exits
                 .iter()
-                .map(|ib| (ib.global_index, ib.bridge_exit.hash())),
+                .map(|ib| (ib.0.global_index, ib.0.bridge_exit.hash())),
         ),
         height: certificate.height,
     };

--- a/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
+++ b/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
@@ -70,7 +70,7 @@ fn pp_root_migration_helper(
             multi_batch_header
                 .imported_bridge_exits
                 .iter()
-                .map(|ib| ib.0.global_index),
+                .map(|ib| (ib.global_index, ib.bridge_exit.hash())),
         ),
         height: certificate.height,
     };


### PR DESCRIPTION
# Description

Update the imported hash, to add the `bridge_exit.hash` to have a more constrained and better security guarantee within the bridge-proof

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
