### PR TITLE
ci: push docker images when updaing `main`

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,6 +61,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build${{ inputs.push == true && '-Push' || '' }}
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,7 +61,6 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build${{ inputs.push == true && '-Push' || '' }}
         uses: docker/build-push-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,42 +213,6 @@ jobs:
       - run: exit 1
         if: ${{ contains(fromJSON('["failure", "cancelled"]'), needs.call-cdk-e2e-workflow.result) }}
 
-  pushing-docker-image:
-    name: Docker | Publish image to registry
-    runs-on: ubuntu-latest
-    if: ${{ contains('["merge_group", "workflow_dispatch"]', github.event_name) }}
-    permissions:
-      packages: write
-    needs:
-      - docker-build-local
-      - check-e2e-result
-      - check_elf
-      - unit
-      - integrations
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: "docker-image"
-          path: "/tmp"
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Load image
-        run: |
-          echo ${{ needs.docker-build-local.outputs.tags }}
-          docker load --input /tmp/docker-image.tar
-
-      - name: Publishing image
-        env:
-          DOCKER_IMAGE: ${{ needs.docker-build-local.outputs.tags }}
-        run: docker push ${{ env.DOCKER_IMAGE }}
-
   check_elf:
     runs-on: ubuntu-latest-16-cores
     if: ${{ contains('["merge_group", "workflow_dispatch"]', github.event_name) }}
@@ -297,3 +261,39 @@ jobs:
           echo "Commited vKey=$ORIGINAL_VKEY"
           echo "Calculated vKey=$CALCULATED_VKEY"
           diff <(echo $CALCULATED_VKEY) <( echo $ORIGINAL_VKEY )
+
+  pushing-docker-image:
+    name: Docker | Publish image to registry
+    runs-on: ubuntu-latest
+    if: ${{ contains('["merge_group", "workflow_dispatch"]', github.event_name) }}
+    permissions:
+      packages: write
+    needs:
+      - docker-build-local
+      - check-e2e-result
+      - check_elf
+      - unit
+      - integrations
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "docker-image"
+          path: "/tmp"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load image
+        run: |
+          echo ${{ needs.docker-build-local.outputs.tags }}
+          docker load --input /tmp/docker-image.tar
+
+      - name: Publishing image
+        env:
+          DOCKER_IMAGE: ${{ needs.docker-build-local.outputs.tags }}
+        run: docker push ${{ env.DOCKER_IMAGE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,7 +172,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     secrets: inherit
     with:
-      push: false
+      push: true
       local-artifact-name: "docker-image"
       local-artifact-dir: "/tmp"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,7 +173,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     secrets: inherit
     with:
-      push: true
+      push: false
       local-artifact-name: "docker-image"
       local-artifact-dir: "/tmp"
 
@@ -217,7 +217,7 @@ jobs:
   pushing-docker-image:
     name: Docker | Publish image to registry
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || ( github.event_name == 'workflow_dispatch' ) || github.ref == 'refs/heads/ci/docker-push-main'
+    if: ( github.event_name == 'workflow_dispatch' ) || github.ref == 'refs/heads/ci/docker-push-main'
     permissions:
       packages: write
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,6 +274,7 @@ jobs:
       - check_elf
       - unit
       - integrations
+      - isolated-feature-checks
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "ci/docker-push-main"
   merge_group:
   pull_request:
     branches:
@@ -168,7 +169,7 @@ jobs:
 
   docker-build-local:
     name: E2E Tests | Docker build
-    if: ${{ contains('["merge_group", "workflow_dispatch"]', github.event_name) }} # skip-merge queue
+    if: ${{ contains('["merge_group", "workflow_dispatch", "push"]', github.event_name) }} # skip-merge queue
     uses: ./.github/workflows/docker-build.yml
     secrets: inherit
     with:
@@ -216,7 +217,7 @@ jobs:
   pushing-docker-image:
     name: Docker | Publish image to registry
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || ( github.event_name == 'workflow_dispatch' )
+    if: github.ref == 'refs/heads/main' || ( github.event_name == 'workflow_dispatch' ) || github.ref == 'refs/heads/ci/docker-push-main'
     permissions:
       packages: write
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,6 +222,7 @@ jobs:
     needs:
       - docker-build-local
       - check-e2e-result
+      - check_elf
       - unit
       - integrations
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,12 +216,14 @@ jobs:
   pushing-docker-image:
     name: Docker | Publish image to registry
     runs-on: ubuntu-latest
-    if: ${{ contains('["merge_group", "workflow_dispatch"]', github.event_name) }} # skip-merge queue
+    if: ${{ contains('["merge_group", "workflow_dispatch"]', github.event_name) }}
     permissions:
       packages: write
     needs:
       - docker-build-local
       - call-cdk-e2e-workflow
+      - unit
+      - integrations
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
   pushing-docker-image:
     name: Docker | Publish image to registry
     runs-on: ubuntu-latest
-    if: ( github.event_name == 'workflow_dispatch' ) || github.ref == 'refs/heads/ci/docker-push-main'
+    if: ${{ contains('["merge_group", "workflow_dispatch", "push"]', github.event_name) }} # skip-merge queue
     permissions:
       packages: write
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,7 @@ jobs:
       packages: write
     needs:
       - docker-build-local
-      - call-cdk-e2e-workflow
+      - check-e2e-result
       - unit
       - integrations
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "ci/docker-push-main"
   merge_group:
   pull_request:
     branches:
@@ -169,7 +168,7 @@ jobs:
 
   docker-build-local:
     name: E2E Tests | Docker build
-    if: ${{ contains('["merge_group", "workflow_dispatch", "push"]', github.event_name) }} # skip-merge queue
+    if: ${{ contains('["merge_group", "workflow_dispatch"]', github.event_name) }} # skip-merge queue
     uses: ./.github/workflows/docker-build.yml
     secrets: inherit
     with:
@@ -217,7 +216,7 @@ jobs:
   pushing-docker-image:
     name: Docker | Publish image to registry
     runs-on: ubuntu-latest
-    if: ${{ contains('["merge_group", "workflow_dispatch", "push"]', github.event_name) }} # skip-merge queue
+    if: ${{ contains('["merge_group", "workflow_dispatch"]', github.event_name) }} # skip-merge queue
     permissions:
       packages: write
     needs:


### PR DESCRIPTION
Here are some CI updates. There are two changes, pretty much independent of each other. We can pick which we want.

I am not able to test them properly. Running the workflow manually on this branch runs into an image upload permission issue. Running it manually on main works but that does not include the changes from this PR.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
