### PR TITLE
build: improve dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,15 @@ updates:
       interval: "weekly"
 
     groups:
-      provers:
+      agglayer:
         applies-to: version-updates
         patterns:
-          - "aggchain-proof-*"
-          - "aggkig-prover"
-          - "aggkit-prover-*"
-          - "agglayer-prover"
-          - "agglayer-prover-*"
+          - "aggchain-*"
+          - "aggkit-*"
+          - "agglayer-*"
           - "proposer-*"
           - "prover-*"
+          - "unified-bridge"
 
       sp1:
         applies-to: version-updates


### PR DESCRIPTION
Some recent developments, such as addition of the `interop` repo, have caused the dependabot group definitions to be no longer a good match. Here are some improvements.

* The `provers` group becomes `agglayer` group, containing updates from both the `provers` repo and the `interop` repo.
* Generalized and updated some patterns to match the new crate names.
* Fixed a typo in a pattern.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
