### PR TITLE
fix: update instrumentation to skip request in submit_certificate

### DIFF
--- a/crates/agglayer-grpc-api/src/certificate_submission_service/mod.rs
+++ b/crates/agglayer-grpc-api/src/certificate_submission_service/mod.rs
@@ -33,7 +33,7 @@ where
     DebugStore: DebugReader + DebugWriter + 'static,
     L1Rpc: RollupContract + L1TransactionFetcher + Send + Sync + 'static,
 {
-    #[instrument(skip(self), level = "debug", fields(certificate_id = tracing::field::Empty))]
+    #[instrument(skip(self, request), level = "debug", fields(certificate_id = tracing::field::Empty))]
     async fn submit_certificate(
         &self,
         request: tonic::Request<SubmitCertificateRequest>,


### PR DESCRIPTION
# Description

To avoid dumping a lot of info in logs, this PR is removing the `request` from the `span`.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
