### PR TITLE
feat: add handling for l1_info_root without imported bridge exits

### DIFF
--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -308,6 +308,9 @@ where
         let l1_info_root = match (declared_l1_info_leaf_count, declared_l1_info_root) {
             // Use the default corresponding to the entry set by the event `InitL1InfoRootMap`
             (None, None) => self.l1_rpc.default_l1_info_tree_entry().1.into(),
+            // In this situation, it means that we have a l1_info_root defined without imported
+            // bridge exits.
+            (None, Some(l1_info_root)) => l1_info_root,
             // Retrieve the event corresponding to the declared entry and await for finalization
             (Some(declared_leaf), Some(declared_root)) => {
                 // Retrieve from contract and await for finalization

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -423,7 +423,8 @@ impl Certificate {
             .first()
             .map(|imported_bridge_exit| imported_bridge_exit.l1_info_root())
         else {
-            return Ok(None);
+            // In case of no imported bridge exists, return the provided l1_info_root
+            return Ok(self.l1_info_root);
         };
 
         if self


### PR DESCRIPTION
# Description

This PR is adding the `l1_info_root` check during the certification.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
