### PR TITLE
feat: use provided l1 info tree leaf count first

### DIFF
--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -408,11 +408,12 @@ impl Certificate {
     /// Corresponds to the highest L1 Info Tree leaf index considered by the
     /// imported bridge exits.
     pub fn l1_info_tree_leaf_count(&self) -> Option<u32> {
-        self.imported_bridge_exits
-            .iter()
-            .map(|i| i.l1_leaf_index() + 1)
-            .max()
-            .or(self.l1_info_tree_leaf_count)
+        self.l1_info_tree_leaf_count.or_else(|| {
+            self.imported_bridge_exits
+                .iter()
+                .map(|i| i.l1_leaf_index() + 1)
+                .max()
+        })
     }
 
     /// Returns the L1 Info Root considered for this [`Certificate`].


### PR DESCRIPTION
# Description

Intermediate solution prior to having a mandatory l1 info tree leaf count introduced by #768 

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
