### PR TITLE
feat: append 0x prefix to vkey and vkey selector

### DIFF
--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -39,14 +39,15 @@ fn main() -> anyhow::Result<()> {
             }
         }
         cli::Commands::Vkey => {
-            let vkey = agglayer_prover::compute_program_vkey(ELF);
-            println!("{}", vkey);
+            let vkey = agglayer_prover::compute_program_vkey(ELF).trim_start_matches("0x");
+            println!("0x{vkey}");
         }
 
         cli::Commands::VkeySelector => {
             let vkey_selector =
-                hex::encode(pessimistic_proof::core::PESSIMISTIC_PROOF_PROGRAM_SELECTOR);
-            println!("{vkey_selector}");
+                hex::encode(pessimistic_proof::core::PESSIMISTIC_PROOF_PROGRAM_SELECTOR)
+                    .trim_start_matches("0x");
+            println!("0x{vkey_selector}");
         }
 
         cli::Commands::Backup(cli::Backup::List { config_path: cfg }) => {


### PR DESCRIPTION
# Description

This PR standardizes the vkey and vkey-selector commands between agglayer and aggkit-prover.

Right now, `agglayer vkey` returns a hash with a `0x` prefix, but the others don't. To keep things consistent, this update adds the `0x` prefix to the agglayer vkey-selector output.

```bash
$ docker run --rm -it ghcr.io/agglayer/aggkit-prover:0.1.0-rc.20 bash
root@7eda38d77fff:/# aggkit-prover vkey
1f3df68a258f9d6748b291dd35faf80065af7cc11ef8b5fc6db2a4d958ea62d2
root@7eda38d77fff:/# aggkit-prover vkey-selector
00000001

$ docker run --rm -it ghcr.io/agglayer/agglayer:0.3.0-rc.16 bash
root@9ffb07528adf:/# agglayer vkey
0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7
root@9ffb07528adf:/# agglayer vkey-selector
00000001
```
