### PR TITLE
resolving issue with logging of websocket url with sensitive api key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "tracing",
  "tracing-capture",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,3 +122,4 @@ agglayer-tries = { git = "https://github.com/agglayer/interop.git" }
 agglayer-interop = { git = "https://github.com/agglayer/interop.git" }
 unified-bridge = { git = "https://github.com/agglayer/interop.git" }
 agglayer-interop-types = { git = "https://github.com/agglayer/interop.git" }
+

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -50,6 +50,7 @@ agglayer-storage.workspace = true
 agglayer-telemetry.workspace = true
 agglayer-types.workspace = true
 pessimistic-proof.workspace = true
+url = "2"
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["full", "node-bindings"] }

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -9,6 +9,7 @@ mod logging;
 
 mod epoch_synchronizer;
 mod node;
+mod utils;
 
 use agglayer_telemetry::ServerBuilder as MetricsBuilder;
 

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -34,8 +34,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::epoch_synchronizer::EpochSynchronizer;
-
 pub(crate) mod api;
+
+use crate::utils::sanitize_ws_url;
 
 pub(crate) struct Node {
     pub(crate) rpc_handle: JoinHandle<()>,
@@ -138,7 +139,7 @@ impl Node {
             Epoch::BlockClock(cfg) => {
                 info!(
                     "Starting BlockClock with provider: {}",
-                    config.l1.ws_node_url
+                    sanitize_ws_url(config.l1.ws_node_url.as_str())
                 );
 
                 let clock = BlockClock::new_with_ws(

--- a/crates/agglayer-node/src/utils.rs
+++ b/crates/agglayer-node/src/utils.rs
@@ -1,0 +1,20 @@
+use url::Url;
+
+pub(crate) fn sanitize_ws_url(url: &str) -> String {
+    let parsed = Url::parse(url);
+    match parsed {
+        Ok(mut u) => {
+            let mut segments: Vec<_> = u.path_segments().map(|c| c.collect()).unwrap_or_default();
+
+            if !segments.is_empty() {
+                segments.pop(); // remove the last segment (e.g., a secret token)
+                segments.push("xxxxx...");
+                let sanitized_path = segments.join("/");
+                u.set_path(&sanitized_path);
+            }
+
+            u.to_string()
+        }
+        Err(_) => "invalid_url".to_string(),
+    }
+}


### PR DESCRIPTION
Fixes #803
### Description

When a user runs the agglayer-node, the logs may include the full WebSocket connection URL — including an embedded secret or token as the last path segment. This becomes a security/privacy risk when users share logs to support team for troubleshooting and help or even to community channel like discord for other developers to help resolve issue, unaware that the secret is being exposed.

### Example

Logs currently show something like: {"message":"Starting BlockClock with provider: wss://websocket-url/secret-key"}


This can leak sensitive credentials unintentionally.

### Expected Behavior

Sensitive tokens in URLs should be redacted in logs. For example:  {"message":"Starting BlockClock with provider: wss://websocket-url/xxxx..."}



### Recommendation

Use a sanitizer (e.g., `sanitize_ws_url`) before printing any WebSocket URLs to the console or log. Ensure this is applied consistently across all modules that output connection details.

### Impact

- Leaks secrets in public/shared logs
- Users may unknowingly compromise their node setup
- Affects troubleshooting and security hygiene

### Additional Context

This can be mitigated by adopting a standard log-sanitizing wrapper or utility for sensitive data.