### PR TITLE
ci: use a fixed version of `cargo prove`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Install sp1 toolchain
         run: |
           curl -L https://sp1up.succinct.xyz | bash
-          /home/runner/.sp1/bin/sp1up
+          cargo make install-cargo-prove
           PATH="/home/runner/.sp1/bin:$PATH" cargo prove --version
 
       - name: Build the PP elf

--- a/scripts/make/Makefile.pp.toml
+++ b/scripts/make/Makefile.pp.toml
@@ -35,5 +35,5 @@ args = [
 
 [tasks.install-cargo-prove]
 description = "Install the appropriate version of `cargo prove`"
-command = "$HOME/.sp1/bin/sp1up"
+command = "${HOME}/.sp1/bin/sp1up"
 args = [ "--version", "${CARGO_PROVE_VERSION}" ]

--- a/scripts/make/Makefile.pp.toml
+++ b/scripts/make/Makefile.pp.toml
@@ -1,5 +1,6 @@
 [env]
 SP1_DOCKER_TAG="v4.1.3@sha256:b94d8953d824bd9f80d7176e2eed11fde1f7689fc880f5c1fdd2ed812ead92a8"
+CARGO_PROVE_VERSION="v4.2.1"
 
 [tasks.pp-elf]
 description = "Install pessimistic proof ELF file"
@@ -31,3 +32,8 @@ args = [
     "-ppessimistic-proof-test-suite",
     "--test=cycle-tracker",
 ]
+
+[tasks.install-cargo-prove]
+description = "Install the appropriate version of `cargo prove`"
+command = "$HOME/.sp1/bin/sp1up"
+args = [ "--version", "${CARGO_PROVE_VERSION}" ]


### PR DESCRIPTION
# Description

Use a fixed version of cargo prove in CI. While the docker image provides stable environment, `cargo prove` specifies the build arguments. These have changed in sp1 v5. Since the CI just sets up cargo prove in the latest version, these got out of sync, resulting in CI failures.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
