### PR TITLE
feat: accounting on U512 instead of U256 on balances

### DIFF
--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -6,7 +6,9 @@ use agglayer_interop_types::{
     ImportedBridgeExitCommitmentValues, TokenInfo,
 };
 pub use agglayer_primitives::Digest;
-use agglayer_primitives::{keccak::Keccak256Hasher, FromBool, Hashable, SignatureError};
+use agglayer_primitives::{
+    keccak::Keccak256Hasher, ruint::UintTryFrom, FromBool, Hashable, SignatureError,
+};
 use agglayer_tries::{error::SmtError, roots::LocalExitRoot, smt::Smt};
 use pessimistic_proof::{
     core::{
@@ -619,13 +621,17 @@ impl LocalNetworkStateData {
                 })
                 .collect();
 
-            let mut new_balances = initial_balances.clone();
+            let mut new_balances: BTreeMap<_, _> = initial_balances
+                .iter()
+                .map(|(&token, &balance)| (token, U512::from(balance)))
+                .collect();
+
             for imported_bridge_exit in imported_bridge_exits {
                 let token = imported_bridge_exit.bridge_exit.amount_token_info();
                 new_balances.insert(
                     token,
                     new_balances[&token]
-                        .checked_add(imported_bridge_exit.bridge_exit.amount)
+                        .checked_add(U512::from(imported_bridge_exit.bridge_exit.amount))
                         .ok_or(Error::BalanceOverflow(token))?,
                 );
             }
@@ -635,7 +641,7 @@ impl LocalNetworkStateData {
                 new_balances.insert(
                     token,
                     new_balances[&token]
-                        .checked_sub(bridge_exit.amount)
+                        .checked_sub(U512::from(bridge_exit.amount))
                         .ok_or(Error::BalanceUnderflow(token))?,
                 );
             }
@@ -645,6 +651,9 @@ impl LocalNetworkStateData {
                 .into_iter()
                 .map(|token| {
                     let initial_balance = initial_balances[&token];
+
+                    let new_balance = U256::uint_try_from(new_balances[&token])
+                        .map_err(|_| Error::BalanceOverflow(token))?;
 
                     let balance_proof_error =
                         |source| Error::BalanceProofGenerationFailed { source, token };
@@ -660,7 +669,7 @@ impl LocalNetworkStateData {
                     };
 
                     self.balance_tree
-                        .update(token, new_balances[&token].to_be_bytes().into())
+                        .update(token, new_balance.to_be_bytes().into())
                         .map_err(balance_proof_error)?;
 
                     Ok((token, (initial_balance, path)))

--- a/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
+++ b/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
@@ -165,6 +165,20 @@ fn e2e_local_pp_simple_zero_initial_balances() {
 }
 
 #[test]
+fn e2e_local_pp_overflow_attempt() {
+    e2e_local_pp_simple_helper(
+        [],
+        vec![
+            (USDC, U256::MAX),
+            (USDC, u(3)),
+            (ETH, u(100)),
+            (USDC, u(10)),
+        ],
+        vec![(USDC, u(20)), (ETH, u(50)), (USDC, u(30))],
+    )
+}
+
+#[test]
 fn e2e_local_pp_random() {
     let target = u(u64::MAX);
     let upper = u64::MAX / 10;


### PR DESCRIPTION
# Description

In the circuit, the sum of imported bridge exits is performed using `U512` values before subtracting the bridge exit amount. This allows importing large amounts, as long as enough is consumed in the same state transition to bring the total balance back within valid `U256` limits.

Witness generation currently constrains this sum to `U256`, which can reject transitions that would have been considered valid by the circuit.

This PR removes that constraint to align witness generation with the circuit logic.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
