### PR TITLE
chore: introduce send_to_network_task helper

### DIFF
--- a/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
@@ -305,10 +305,10 @@ where
 
     async fn send_to_network_task(
         &self,
-        msg: NetworkTaskMessage,
+        message: NetworkTaskMessage,
     ) -> Result<(), CertificateStatusError> {
-        trace!(?msg, "Sending message to network task");
-        self.network_task.send(msg).await.map_err(send_err)
+        trace!(?message, "Sending message to network task");
+        self.network_task.send(message).await.map_err(send_err)
     }
 }
 

--- a/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
@@ -95,17 +95,15 @@ where
                 error!(?error, "Failed to update certificate status in database");
             };
 
-            self.network_task
-                .send(NetworkTaskMessage::CertificateErrored {
-                    height: self.header.height,
-                    certificate_id: self.header.certificate_id,
-                    error,
-                })
-                .await
-                .map_err(send_err)
-                .unwrap_or_else(|error| {
-                    error!(?error, "Failed to send certificate error message");
-                });
+            self.send_to_network_task(NetworkTaskMessage::CertificateErrored {
+                height: self.header.height,
+                certificate_id: self.header.certificate_id,
+                error,
+            })
+            .await
+            .unwrap_or_else(|error| {
+                error!(?error, "Failed to send certificate error message");
+            });
         }
     }
 
@@ -155,10 +153,11 @@ where
             // Retrieve local network state
             trace!("Retrieving local network state");
             let (response, state) = oneshot::channel();
-            self.network_task
-                .send(NetworkTaskMessage::GetLocalNetworkStateBeforeHeight { height, response })
-                .await
-                .map_err(send_err)?;
+            self.send_to_network_task(NetworkTaskMessage::GetLocalNetworkStateBeforeHeight {
+                height,
+                response,
+            })
+            .await?;
             let state = state.await.map_err(recv_err)??;
 
             // Actually certify
@@ -171,21 +170,17 @@ where
 
             // Record the certification success
             self.set_status(CertificateStatus::Proven)?;
-            self.network_task
-                .send(NetworkTaskMessage::CertificateExecuted {
-                    height,
-                    certificate_id,
-                    new_state: Box::new(certifier_output.new_state),
-                })
-                .await
-                .map_err(send_err)?;
-            self.network_task
-                .send(NetworkTaskMessage::CertificateProven {
-                    height,
-                    certificate_id,
-                })
-                .await
-                .map_err(send_err)?;
+            self.send_to_network_task(NetworkTaskMessage::CertificateExecuted {
+                height,
+                certificate_id,
+                new_state: Box::new(certifier_output.new_state),
+            })
+            .await?;
+            self.send_to_network_task(NetworkTaskMessage::CertificateProven {
+                height,
+                certificate_id,
+            })
+            .await?;
         } else {
             // TODO: once we store network_id -> height -> state and not just network_id ->
             // state, we should not need this any longer, because the state will
@@ -194,10 +189,11 @@ where
             // Retrieve local network state
             trace!("Retrieving local network state");
             let (response, state) = oneshot::channel();
-            self.network_task
-                .send(NetworkTaskMessage::GetLocalNetworkStateBeforeHeight { height, response })
-                .await
-                .map_err(send_err)?;
+            self.send_to_network_task(NetworkTaskMessage::GetLocalNetworkStateBeforeHeight {
+                height,
+                response,
+            })
+            .await?;
             let mut state = state.await.map_err(recv_err)??;
 
             // Execute the witness generation to retrieve the new local network state
@@ -217,14 +213,12 @@ where
             // valid if we had multiple certificates inflight. Thankfully, until
             // we update the storage we cannot have multiple certificates
             // inflight, so we should be fine until then.
-            self.network_task
-                .send(NetworkTaskMessage::CertificateExecuted {
-                    height,
-                    certificate_id,
-                    new_state: state,
-                })
-                .await
-                .map_err(send_err)?;
+            self.send_to_network_task(NetworkTaskMessage::CertificateExecuted {
+                height,
+                certificate_id,
+                new_state: state,
+            })
+            .await?;
         }
 
         // Second, submit settlement to L1
@@ -236,14 +230,12 @@ where
         if self.header.status < CertificateStatus::Candidate {
             debug!("Submitting certificate for settlement");
             let (settlement_submitted_notifier, settlement_submitted) = oneshot::channel();
-            self.network_task
-                .send(NetworkTaskMessage::CertificateReadyForSettlement {
-                    height,
-                    certificate_id,
-                    settlement_submitted_notifier,
-                })
-                .await
-                .map_err(send_err)?;
+            self.send_to_network_task(NetworkTaskMessage::CertificateReadyForSettlement {
+                height,
+                certificate_id,
+                settlement_submitted_notifier,
+            })
+            .await?;
 
             let settlement_tx_hash = settlement_submitted.await.map_err(recv_err)??;
             fail::fail_point!("certificate_task::process_impl::about_to_record_candidate");
@@ -269,15 +261,13 @@ where
                 )
             })?;
             let (settlement_complete_notifier, settlement_complete) = oneshot::channel();
-            self.network_task
-                .send(NetworkTaskMessage::CertificateWaitingForSettlement {
-                    height,
-                    certificate_id,
-                    settlement_tx_hash,
-                    settlement_complete_notifier,
-                })
-                .await
-                .map_err(send_err)?;
+            self.send_to_network_task(NetworkTaskMessage::CertificateWaitingForSettlement {
+                height,
+                certificate_id,
+                settlement_tx_hash,
+                settlement_complete_notifier,
+            })
+            .await?;
 
             let (epoch_number, certificate_index) =
                 settlement_complete.await.map_err(recv_err)??;
@@ -289,14 +279,12 @@ where
                 ?settled_certificate,
                 "Certificate settlement completed"
             );
-            self.network_task
-                .send(NetworkTaskMessage::CertificateSettled {
-                    height,
-                    certificate_id,
-                    settled_certificate,
-                })
-                .await
-                .map_err(send_err)?;
+            self.send_to_network_task(NetworkTaskMessage::CertificateSettled {
+                height,
+                certificate_id,
+                settled_certificate,
+            })
+            .await?;
         }
 
         if self.header.status != CertificateStatus::Settled {
@@ -313,6 +301,14 @@ where
             .update_certificate_header_status(&self.header.certificate_id, &status)?;
         self.header.status = status;
         Ok(())
+    }
+
+    async fn send_to_network_task(
+        &self,
+        msg: NetworkTaskMessage,
+    ) -> Result<(), CertificateStatusError> {
+        trace!(?msg, "Sending message to network task");
+        self.network_task.send(msg).await.map_err(send_err)
     }
 }
 

--- a/crates/agglayer-certificate-orchestrator/src/network_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task.rs
@@ -29,6 +29,7 @@ pub(crate) struct NewCertificate {
 #[allow(dead_code)] // TODO: Once we have implemented storage properly, all the fields should become used
 /// Enum listing all the potential messages that can be sent to the network
 /// task.
+#[derive(Debug)]
 pub enum NetworkTaskMessage {
     /// Get the local network state before a given height.
     GetLocalNetworkStateBeforeHeight {


### PR DESCRIPTION
Handle delayed https://github.com/agglayer/agglayer/pull/819#discussion_r2124732959

Also trace all messages sent to network task, as it could always be useful