### PR TITLE
chore: make sure CertificateTask always uses the header associated with the certificate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ dotenvy = "0.15.7"
 ethers = "2.0"
 ethers-gcp-kms-signer = "0.1.5"
 ethers-signers = "2.0"
+eyre = "0.6.12"
 fail = { version = "0.5.1", default-features = false }
 futures = "0.3.31"
 hex = "0.4.3"

--- a/crates/agglayer-certificate-orchestrator/src/network_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task.rs
@@ -322,17 +322,6 @@ where
         };
 
         let certificate_id = certificate.hash();
-        let header =
-            if let Some(header) = self.state_store.get_certificate_header(&certificate_id)? {
-                header
-            } else {
-                error!(
-                    hash = certificate_id.to_string(),
-                    "Certificate header not found for {certificate_id}"
-                );
-
-                return Ok(());
-            };
 
         let (sender, mut receiver) = mpsc::channel(1);
 
@@ -344,13 +333,12 @@ where
         let task = tokio::spawn(
             CertificateTask::new(
                 certificate,
-                header,
                 sender,
                 self.state_store.clone(),
                 self.pending_store.clone(),
                 self.certifier_client.clone(),
                 cancellation_token.clone(),
-            )
+            )?
             .process(),
         );
 


### PR DESCRIPTION
Handles delayed https://github.com/agglayer/agglayer/pull/819#discussion_r2152180798