### PR TITLE
Temporarily update Succinct Prover Network key setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Before working with the repository, you’ll need the following:
 
 You’ll need to submit a unique Ethereum address to Succinct for access to their proving network. To get access:
 
-1. Follow the instructions [here](https://docs.succinct.xyz/docs/prover-network/key-setup) to use Foundry to generate a new private key or retrieve an existing one.
+1. Follow the instructions in the Succinct Discord (#prover-network channel) to use Foundry to generate a new private key or retrieve an existing one: https://discord.gg/succinct
 2. Apply for access for the public address associated with your private key to Succinct Network [here](https://docs.google.com/forms/d/e/1FAIpQLSd-X9uH7G0bvXH_kjptnQtNil8L4dumrVPpFE4t8Ci1XT1GaQ/viewform).
 
 ### Software Requirements


### PR DESCRIPTION
Replaced the outdated Succinct Prover Network key setup URL with a note and a link to the official Discord, as the documentation page is currently unavailable. Users are advised to check the Discord for the latest instructions.