### PR TITLE
fix: skipped L1 blocks should not tear down the node [v0.3.3]

### DIFF
--- a/crates/agglayer-clock/src/block.rs
+++ b/crates/agglayer-clock/src/block.rs
@@ -13,8 +13,8 @@ use alloy::{
         fillers::{BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller},
         Identity, Provider, ProviderBuilder, RootProvider, WsConnect,
     },
-    pubsub::{ConnectionHandle, PubSubConnect},
-    rpc::client::ClientBuilder,
+    pubsub::{ConnectionHandle, PubSubConnect, Subscription},
+    rpc::{client::ClientBuilder, types::Header},
     transports::{impl_future, TransportErrorKind, TransportResult},
 };
 use backoff::ExponentialBackoff;
@@ -136,8 +136,8 @@ pub enum BlockClockError {
     UnableToNotifyStart,
     #[error("Transport initialization: {0}")]
     Transport(#[from] alloy::transports::RpcError<TransportErrorKind>),
-    #[error("Transport error: {0}")]
-    TransportError(#[from] tokio::sync::broadcast::error::RecvError),
+    #[error("L1 block channel unexpectedly closed")]
+    L1BlockChannelClosed,
 }
 
 impl<P> BlockClock<P>
@@ -173,7 +173,7 @@ where
         debug!("Successfully subscribed to the L1 Block stream");
 
         while self.latest_seen_block < self.genesis_block {
-            let header = stream.recv().await?;
+            let header = Self::recv_block(&mut stream).await?;
             self.latest_seen_block = header.number;
 
             debug!("Current L1 Block number: {}", self.latest_seen_block);
@@ -217,7 +217,7 @@ where
                     warn!("Clock task cancelled");
                     break;
                 }
-                block_result = stream.recv() => {
+                block_result = Self::recv_block(&mut stream) => {
                     let block = block_result?;
                     if block.number <= self.latest_seen_block {
                         trace!("Skipping block: number={}, latest_seen_block={}", block.number, self.latest_seen_block);
@@ -248,6 +248,36 @@ where
         debug!("Clock task stopped");
 
         Ok(())
+    }
+
+    async fn recv_block(stream: &mut Subscription<Header>) -> Result<Header, BlockClockError> {
+        #[cfg(test)]
+        {
+            // The default sleep fail point directive issues a blocking sleep.
+            // That does not play nice with code that is meant to be executed
+            // in an async runtime. Here, we abuse the return value injection
+            // to specify the timeout and use the tokio sleep instead.
+            fn get_delay() -> Duration {
+                fail::fail_point!("block_clock::BlockClock::recv_block::before", |d| {
+                    d.map(|d| Duration::from_secs(d.parse().unwrap()))
+                        .unwrap_or_default()
+                });
+                Duration::default()
+            }
+            tokio::time::sleep(get_delay()).await;
+        }
+
+        loop {
+            match stream.recv().await {
+                Ok(block) => break Ok(block),
+                Err(broadcast::error::RecvError::Closed) => {
+                    break Err(BlockClockError::L1BlockChannelClosed)
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!("Block clock L1 block subscription lagged by {n} messages");
+                }
+            }
+        }
     }
 
     fn update_and_notify(

--- a/crates/agglayer-clock/src/block/tests.rs
+++ b/crates/agglayer-clock/src/block/tests.rs
@@ -435,7 +435,7 @@ async fn skipped_blocks_are_handled(#[case] lag_cfg: &str) {
 
     // After 25 seconds, we should be at epoch 7. This should be independent
     // of the lag as the clock should have recovered from it by this point.
-    assert_eq!(last_epoch, EpochNumber::new(7));
+    assert_eq!(last_epoch, 7);
 
     scenario.teardown();
 }

--- a/crates/agglayer-clock/src/block/tests.rs
+++ b/crates/agglayer-clock/src/block/tests.rs
@@ -386,3 +386,56 @@ async fn can_catchup_on_disconnection() {
     .expect("Timeout");
     scenario.teardown();
 }
+
+#[rstest::rstest]
+// The test should still work without a lag.
+#[case("off")]
+// Anvil bounds its broadcast channel size to 16 by default.
+// At one block per second, we need over 16 seconds for it to start lagging.
+#[case("1*return(20)")]
+// This one is fine during initialization but lags later on.
+#[case("4*off->1*return(20)")]
+// Limit the total running time.
+#[timeout(Duration::from_secs(60))]
+#[test_log::test(tokio::test)]
+async fn skipped_blocks_are_handled(#[case] lag_cfg: &str) {
+    let scenario = FailScenario::setup();
+
+    fail::cfg("block_clock::BlockClock::recv_block::before", lag_cfg).unwrap();
+
+    let anvil = Anvil::new().block_time(1u64).spawn();
+    let ws = WsConnect::new(anvil.ws_endpoint());
+
+    let clock = BlockClock::new_with_ws(ws, 0, NonZeroU64::new(3).unwrap(), Duration::from_secs(1))
+        .await
+        .unwrap();
+    let token = CancellationToken::new();
+
+    let start = tokio::time::Instant::now();
+    let clock_ref = clock.spawn(token.clone()).await.unwrap();
+    let mut recv = clock_ref.subscribe().unwrap();
+
+    tokio::time::sleep_until(start + Duration::from_secs(25)).await;
+
+    let Event::EpochEnded(last_epoch) = {
+        let mut last_epoch = None;
+        loop {
+            match recv.try_recv() {
+                Ok(epoch) => last_epoch = Some(epoch),
+                Err(broadcast::error::TryRecvError::Lagged(_)) => (),
+                Err(broadcast::error::TryRecvError::Empty) => {
+                    break last_epoch.expect("Nothing in the epoch broadcast channel")
+                }
+                Err(broadcast::error::TryRecvError::Closed) => {
+                    panic!("Clock channel unexpectedly closed; the clock is probably dead")
+                }
+            }
+        }
+    };
+
+    // After 25 seconds, we should be at epoch 7. This should be independent
+    // of the lag as the clock should have recovered from it by this point.
+    assert_eq!(last_epoch, EpochNumber::new(7));
+
+    scenario.teardown();
+}


### PR DESCRIPTION
* backport of #902 to 0.3.3

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
