### PR TITLE
refactor: clean up contract generics

### DIFF
--- a/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
@@ -219,8 +219,6 @@ mockall::mock! {
     L1Rpc {}
     #[async_trait::async_trait]
     impl agglayer_contracts::RollupContract for L1Rpc {
-        type P = alloy::providers::RootProvider<Ethereum>;
-
         async fn get_trusted_sequencer_address(
             &self,
             rollup_id: u32,

--- a/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
@@ -235,8 +235,6 @@ mockall::mock! {
 
     #[async_trait::async_trait]
     impl agglayer_contracts::AggchainContract for L1Rpc {
-        type M = alloy::providers::RootProvider<Ethereum>;
-
         async fn get_aggchain_vkey_hash(
             &self,
             rollup_address: agglayer_types::Address,

--- a/crates/agglayer-aggregator-notifier/src/settlement_client/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/settlement_client/tests.rs
@@ -21,10 +21,9 @@ use crate::settlement_client::RpcSettlementClient;
 
 mockall::mock! {
     L1Rpc {}
+
     #[async_trait::async_trait]
     impl agglayer_contracts::RollupContract for L1Rpc {
-        type P = alloy::providers::RootProvider<alloy::network::Ethereum>;
-
         async fn get_trusted_sequencer_address(
             &self,
             rollup_id: u32,

--- a/crates/agglayer-contracts/src/aggchain.rs
+++ b/crates/agglayer-contracts/src/aggchain.rs
@@ -19,7 +19,6 @@ impl AggchainVkeyHash {
 
 #[async_trait::async_trait]
 pub trait AggchainContract {
-    type M: alloy::providers::Provider;
     async fn get_aggchain_vkey_hash(
         &self,
         rollup_address: Address,
@@ -38,8 +37,6 @@ impl<RpcProvider> AggchainContract for L1RpcClient<RpcProvider>
 where
     RpcProvider: alloy::providers::Provider + Clone + 'static,
 {
-    type M = RpcProvider;
-
     async fn get_aggchain_vkey_hash(
         &self,
         rollup_address: Address,

--- a/crates/agglayer-contracts/src/rollup.rs
+++ b/crates/agglayer-contracts/src/rollup.rs
@@ -32,7 +32,6 @@ const TIME_TO_FINALITY_ETHEREUM: tokio::time::Duration = tokio::time::Duration::
 
 #[async_trait::async_trait]
 pub trait RollupContract {
-    type P: Provider;
     async fn get_trusted_sequencer_address(
         &self,
         rollup_id: u32,
@@ -53,8 +52,6 @@ impl<RpcProvider> RollupContract for L1RpcClient<RpcProvider>
 where
     RpcProvider: alloy::providers::Provider + Clone + 'static,
 {
-    type P = RpcProvider;
-
     /// Returns the first entry of the l1 info tree map in the L1.
     fn default_l1_info_tree_entry(&self) -> (u32, [u8; 32]) {
         self.default_l1_info_tree_entry


### PR DESCRIPTION
A small clean up of contract and settlement generics, consisting of two changes:

* Remove unused associated types in contract traits
* Make `submit_certificate_settlement` and `wait_for_settlement` into standalone methods (called from the original trait implementation). That allows for relaxing some generic bounds on the type parameters, hopefully allowing for simpler testing / mocking setup when only one of these methods needs to be tested.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
