### PR TITLE
feat: update extra signature and adapt commitment versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,7 @@ dependencies = [
  "hex",
  "pessimistic-proof",
  "rand 0.9.1",
+ "rstest",
  "serde",
  "serde_with",
  "sp1-core-machine",

--- a/crates/agglayer-jsonrpc-api/src/kernel/mod.rs
+++ b/crates/agglayer-jsonrpc-api/src/kernel/mod.rs
@@ -377,19 +377,7 @@ where
             .get_trusted_sequencer_address(u32::from(cert.network_id))
             .await?;
 
-        let signer: Address = cert
-            .signer()
-            .map_err(SignatureVerificationError::CouldNotRecoverCertSigner)?;
-
-        // ECDSA-k256 signature verification works by recovering the public key from the
-        // signature, and then checking that it is the expected one.
-        if signer != sequencer_address {
-            return Err(SignatureVerificationError::InvalidSigner {
-                signer,
-                trusted_sequencer: sequencer_address,
-            });
-        }
-
-        Ok(())
+        cert.verify_cert_signature(sequencer_address)
+            .map_err(SignatureVerificationError::from_signer_error)
     }
 }

--- a/crates/agglayer-rpc/src/lib.rs
+++ b/crates/agglayer-rpc/src/lib.rs
@@ -309,22 +309,8 @@ where
                 SignatureVerificationError::UnableToRetrieveTrustedSequencerAddress(cert.network_id)
             })?;
 
-        let signer = cert
-            .signer()
-            .map_err(SignatureVerificationError::from_signer_error)?
-            .into_array()
-            .into();
-
-        // ECDSA-k256 signature verification works by recovering the public key from the
-        // signature, and then checking that it is the expected one.
-        if signer != sequencer_address {
-            return Err(SignatureVerificationError::InvalidSigner {
-                signer,
-                trusted_sequencer: sequencer_address,
-            });
-        }
-
-        Ok(())
+        cert.verify_cert_signature(sequencer_address)
+            .map_err(SignatureVerificationError::from_signer_error)
     }
 
     /// Verify the extra [`Certificate`] signature.
@@ -337,22 +323,9 @@ where
     ) -> Result<(), SignatureVerificationError> {
         match (extra_signer, extra_signature) {
             // Extra signature expected and provided
-            (Some(&expected_extra_signer), Some(extra_signature)) => {
-                // Retrieve the signer from the extra signature
-                let retrieved_extra_signer = certificate
-                    .signer_from_signature(extra_signature)
-                    .map_err(SignatureVerificationError::from_signer_error)?
-                    .into_array()
-                    .into();
-
-                // Verify that the signature is performed by the expected authority
-                if retrieved_extra_signer != expected_extra_signer {
-                    return Err(SignatureVerificationError::InvalidExtraSignature {
-                        expected: expected_extra_signer,
-                        got: retrieved_extra_signer,
-                    });
-                }
-            }
+            (Some(&expected_extra_signer), Some(extra_signature)) => certificate
+                .verify_extra_signature(expected_extra_signer, extra_signature)
+                .map_err(SignatureVerificationError::from_signer_error)?,
             // Extra signature is expected but missing
             (Some(&expected_signer), None) => {
                 return Err(SignatureVerificationError::MissingExtraSignature {
@@ -387,15 +360,7 @@ where
         );
         self.validate_pre_existing_certificate(&certificate).await?;
 
-        // Verify the involved signatures
-        // TODO: For now both commitments are enforced to be the V2 version.
-        // Ideally we want the aggsender to sign the V3 version.
-        // Consequently, we'll need to
-        //   - return the commitment version of the signed message for both signatures
-        //   - verify that they are both considering the exact same message (and so same
-        //     commitment version)
-        //   - verify that the commitment version is the expected one from the last PP
-        //     root in L1 (same as what is done in the witness generation)
+        // Verify the extra certificate signature
         self.verify_extra_cert_signature(
             &certificate,
             self.config()
@@ -411,10 +376,14 @@ where
             CertificateSubmissionError::SignatureError(error)
         })?;
 
+        // Verify the certificate signature
         self.verify_cert_signature(&certificate)
             .await
             .map_err(|error| {
-                error!(?error, "Failed to verify the signature of certificate");
+                error!(
+                    ?error,
+                    "Failed to verify the signature within the certificate"
+                );
                 CertificateSubmissionError::SignatureError(error)
             })?;
 

--- a/crates/agglayer-storage/src/stores/state/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/tests.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
-use agglayer_types::primitives::Hashable as _;
-use agglayer_types::{Certificate, CertificateId, CertificateIndex, Digest, EpochNumber, Height, LocalNetworkStateData, NetworkId, PessimisticRootInput};
-use pessimistic_proof::unified_bridge::CommitmentVersion;
-use pessimistic_proof::{core::generate_pessimistic_proof, LocalNetworkState};
+use agglayer_types::{
+    primitives::Hashable as _, Certificate, CertificateId, CertificateIndex, Digest, EpochNumber,
+    Height, LocalNetworkStateData, NetworkId, PessimisticRootInput,
+};
+use pessimistic_proof::{
+    core::generate_pessimistic_proof, unified_bridge::CommitmentVersion, LocalNetworkState,
+};
 use rstest::{fixture, rstest};
 use tracing::info;
 
@@ -28,7 +31,12 @@ fn can_retrieve_list_of_network() {
 
     db.put::<LatestSettledCertificatePerNetworkColumn>(
         &1.into(),
-        &SettledCertificate(CertificateId::new([0; 32].into()), Height::ZERO, EpochNumber::ZERO, CertificateIndex::ZERO),
+        &SettledCertificate(
+            CertificateId::new([0; 32].into()),
+            Height::ZERO,
+            EpochNumber::ZERO,
+            CertificateIndex::ZERO,
+        ),
     )
     .expect("Unable to put certificate into storage");
     assert!(store.get_active_networks().unwrap().len() == 1);
@@ -166,7 +174,7 @@ fn can_read(network_id: NetworkId, store: StateStore) {
             certificate.bridge_exits.len(),
         );
 
-        let signer = certificate.signer().unwrap();
+        let signer = certificate.retrieve_signer(CommitmentVersion::V2).unwrap();
         let l1_info_root = certificate.l1_info_root().unwrap().unwrap_or_default();
 
         let multi_batch_header = lns
@@ -262,7 +270,7 @@ fn import_native_tokens() {
             certificate.bridge_exits.len(),
         );
 
-        let signer = certificate.signer().unwrap();
+        let signer = certificate.retrieve_signer(CommitmentVersion::V2).unwrap();
         let l1_info_root = certificate.l1_info_root().unwrap().unwrap_or_default();
 
         let multi_batch_header = lns

--- a/crates/agglayer-types/Cargo.toml
+++ b/crates/agglayer-types/Cargo.toml
@@ -29,3 +29,4 @@ rand.workspace = true
 
 [dev-dependencies]
 agglayer-types = { path = ".", features = ["testutils"] }
+rstest.workspace = true

--- a/crates/agglayer-types/src/certificate/mod.rs
+++ b/crates/agglayer-types/src/certificate/mod.rs
@@ -191,11 +191,6 @@ impl Certificate {
             .ok_or(SignerError::InvalidPessimisticProofSignature { expected_signer })
     }
 
-    #[deprecated(since = "0.1.0", note = "use retrieve signer")]
-    pub fn signer(&self) -> Result<Address, SignerError> {
-        self.retrieve_signer(CommitmentVersion::V2)
-    }
-
     /// Retrieve the signer from the certificate signature.
     pub fn retrieve_signer(&self, version: CommitmentVersion) -> Result<Address, SignerError> {
         let (signature, commitment) = match &self.aggchain_data {

--- a/crates/agglayer-types/src/certificate/mod.rs
+++ b/crates/agglayer-types/src/certificate/mod.rs
@@ -149,8 +149,7 @@ impl Certificate {
             .ok_or(SignerError::InvalidExtraSignature { expected_signer })
     }
 
-    /// Verify the signature on the PP commitment and returns the [`Address`]
-    /// upon success.
+    /// Verify the signature on the PP commitment.
     pub fn verify_cert_signature(&self, expected_signer: Address) -> Result<(), SignerError> {
         let pp_commitment_values = SignatureCommitmentValues::from(self);
 

--- a/crates/agglayer-types/src/error.rs
+++ b/crates/agglayer-types/src/error.rs
@@ -1,5 +1,5 @@
 use agglayer_interop_types::LocalExitRoot;
-use agglayer_primitives::SignatureError;
+use agglayer_primitives::{Address, SignatureError};
 use agglayer_tries::error::SmtError;
 use pessimistic_proof::{error::ProofVerificationError, ProofError};
 use serde::{Deserialize, Serialize};
@@ -141,4 +141,16 @@ pub enum SignerError {
 
     #[error("Signature recovery error")]
     Recovery(#[source] SignatureError),
+
+    #[error(
+        "Invalid extra signature either due to wrong signer or commitment. expected signer: \
+         {expected_signer}"
+    )]
+    InvalidExtraSignature { expected_signer: Address },
+
+    #[error(
+        "Invalid PP signature either due to wrong signer or commitment. expected signer: \
+         {expected_signer}"
+    )]
+    InvalidPessimisticProofSignature { expected_signer: Address },
 }

--- a/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
+++ b/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
@@ -2,10 +2,7 @@ use std::{path::PathBuf, time::Instant};
 
 use agglayer_types::{Address, Certificate, NetworkId, PessimisticRootInput, U256};
 use clap::Parser;
-use pessimistic_proof::{
-    unified_bridge::{CommitmentVersion, TokenInfo},
-    PessimisticProofOutput,
-};
+use pessimistic_proof::{unified_bridge::TokenInfo, PessimisticProofOutput};
 use pessimistic_proof_test_suite::{
     runner::Runner,
     sample_data::{self as data},
@@ -13,6 +10,7 @@ use pessimistic_proof_test_suite::{
 use serde::{Deserialize, Serialize};
 use sp1_sdk::HashableKey;
 use tracing::{info, warn};
+use unified_bridge::CommitmentVersion;
 use uuid::Uuid;
 
 /// The arguments for the pp generator.

--- a/crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
+++ b/crates/pessimistic-proof-test-suite/tests/cycle-tracker.rs
@@ -24,7 +24,9 @@ fn cycles_on_sample_inputs(
     bridge_exits: impl IntoIterator<Item = BridgeExit>,
 ) {
     let old_state = state.local_state();
-    let certificate = state.clone().apply_bridge_exits([], bridge_exits);
+    let certificate = state
+        .clone()
+        .apply_bridge_exits([], bridge_exits, CommitmentVersion::V2);
 
     let multi_batch_header = state
         .state_b

--- a/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
+++ b/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
@@ -21,7 +21,7 @@ fn u(x: u64) -> U256 {
     x.try_into().unwrap()
 }
 
-pub struct VersionConsistencyChecker {
+struct VersionConsistencyChecker {
     /// Initial state
     initial_state: LocalNetworkStateData,
     /// Certificate

--- a/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
+++ b/crates/pessimistic-proof-test-suite/tests/e2e_local_pp.rs
@@ -1,12 +1,11 @@
-use agglayer_types::{primitives::U256, Digest, Error, PessimisticRootInput};
+use agglayer_types::{
+    primitives::U256, Certificate, Digest, Error, LocalNetworkStateData, PessimisticRootInput,
+};
 use pessimistic_proof::{
-    core::{
-        commitment::{PessimisticRoot, SignatureCommitmentValues, StateCommitment},
-        generate_pessimistic_proof, AggchainData,
-    },
+    core::{commitment::PessimisticRoot, generate_pessimistic_proof, AggchainData},
     local_state::LocalNetworkState,
     unified_bridge::{CommitmentVersion, TokenInfo},
-    NetworkState, PessimisticProofOutput, ProofError,
+    NetworkState, ProofError,
 };
 use pessimistic_proof_test_suite::{
     forest::Forest,
@@ -22,104 +21,131 @@ fn u(x: u64) -> U256 {
     x.try_into().unwrap()
 }
 
-fn pp_root_migration_helper(
-    previous_version: CommitmentVersion,
-    new_version: CommitmentVersion,
-) -> (
-    Result<(PessimisticProofOutput, StateCommitment), ProofError>,
-    Digest,
-    Digest,
-) {
+pub struct VersionConsistencyChecker {
+    /// Initial state
+    initial_state: LocalNetworkStateData,
+    /// Certificate
+    certificate: Certificate,
+    /// Commitment version of the settled PP root, indicates the latest settled
+    /// commitment version.
+    last_settled_pp_root_version: CommitmentVersion,
+    /// Version used to sign the commitment contained in the Certificate,
+    /// indicates the desired next commitment version.
+    certificate_signature_version: CommitmentVersion,
+}
+
+fn state_transition(
+    certificate_signature_version: CommitmentVersion,
+) -> (LocalNetworkStateData, Certificate) {
     let mut forest = Forest::new(vec![(USDC, u(100)), (ETH, u(200))]);
     let imported_bridge_events = vec![(USDC, u(50)), (ETH, u(100)), (USDC, u(10))];
     let bridge_events = vec![(USDC, u(20)), (ETH, u(50)), (USDC, u(130))];
 
     let initial_state = forest.state_b.clone();
-    let certificate = forest.apply_events(&imported_bridge_events, &bridge_events);
-    let l1_info_root = certificate.l1_info_root().unwrap().unwrap_or_default();
-    let mut multi_batch_header = initial_state
-        .make_multi_batch_header(
-            &certificate,
-            forest.get_signer(),
-            l1_info_root,
-            PessimisticRootInput::Computed(CommitmentVersion::V2),
-            None,
-        )
-        .unwrap();
+    let certificate = forest.apply_events_with_version(
+        &imported_bridge_events,
+        &bridge_events,
+        certificate_signature_version,
+    );
 
-    let new_state = {
-        let mut state = initial_state.clone();
-        state
-            .apply_certificate(
-                &certificate,
-                forest.get_signer(),
+    (initial_state, certificate)
+}
+
+impl VersionConsistencyChecker {
+    fn check(&self) -> Result<(), ProofError> {
+        let l1_info_root = self.certificate.l1_info_root().unwrap().unwrap_or_default();
+        let signer = self
+            .certificate
+            .retrieve_signer(self.certificate_signature_version)
+            .unwrap();
+
+        self.certificate.verify_cert_signature(signer).unwrap();
+
+        // Previous state settled in L1
+        let expected_prev_pp_root = PessimisticRoot {
+            balance_root: self.initial_state.balance_tree.root.into(),
+            nullifier_root: self.initial_state.nullifier_tree.root.into(),
+            ler_leaf_count: self.initial_state.exit_tree.leaf_count(),
+            height: self.certificate.height.as_u64(),
+            origin_network: self.certificate.network_id,
+        }
+        .compute_pp_root(self.last_settled_pp_root_version);
+
+        let multi_batch_header = self
+            .initial_state
+            .make_multi_batch_header(
+                &self.certificate,
+                signer,
                 l1_info_root,
-                PessimisticRootInput::Computed(CommitmentVersion::V2),
+                PessimisticRootInput::Fetched(expected_prev_pp_root),
                 None,
             )
             .unwrap();
-        state
-    };
 
-    // Previous state settled in L1
-    let prev_pp_root = PessimisticRoot {
-        balance_root: initial_state.balance_tree.root.into(),
-        nullifier_root: initial_state.nullifier_tree.root.into(),
-        ler_leaf_count: initial_state.exit_tree.leaf_count(),
-        height: certificate.height.as_u64(),
-        origin_network: certificate.network_id,
-    };
+        let new_state = {
+            let mut state = self.initial_state.clone();
+            state
+                .apply_certificate(
+                    &self.certificate,
+                    signer,
+                    l1_info_root,
+                    PessimisticRootInput::Fetched(expected_prev_pp_root),
+                    None,
+                )
+                .unwrap();
+            state
+        };
 
-    // Signed transition
-    let signature_data = SignatureCommitmentValues::from(&certificate);
+        // New state about to be settled in L1
+        let expected_new_pp_root = PessimisticRoot {
+            balance_root: new_state.balance_tree.root.into(),
+            nullifier_root: new_state.nullifier_tree.root.into(),
+            ler_leaf_count: new_state.exit_tree.leaf_count(),
+            height: self.certificate.height.as_u64() + 1,
+            origin_network: self.certificate.network_id,
+        }
+        .compute_pp_root(self.certificate_signature_version);
 
-    // New state about to be settled in L1
-    let new_pp_root = PessimisticRoot {
-        balance_root: new_state.balance_tree.root.into(),
-        nullifier_root: new_state.nullifier_tree.root.into(),
-        ler_leaf_count: new_state.exit_tree.leaf_count(),
-        height: certificate.height.as_u64() + 1,
-        origin_network: certificate.network_id,
-    };
+        let (pv, _) =
+            generate_pessimistic_proof(self.initial_state.clone().into(), &multi_batch_header)?;
 
-    multi_batch_header.prev_pessimistic_root = prev_pp_root.compute_pp_root(previous_version);
-    let (signature, signer) = forest.sign(signature_data.commitment(new_version)).unwrap();
-    multi_batch_header.aggchain_proof = AggchainData::ECDSA { signer, signature };
+        assert_eq!(expected_prev_pp_root, pv.prev_pessimistic_root);
+        assert_eq!(expected_new_pp_root, pv.new_pessimistic_root);
 
-    (
-        generate_pessimistic_proof(initial_state.into(), &multi_batch_header),
-        prev_pp_root.compute_pp_root(previous_version),
-        new_pp_root.compute_pp_root(new_version),
-    )
+        Ok(())
+    }
 }
 
 #[rstest]
-#[case(CommitmentVersion::V2, CommitmentVersion::V2)] // pre-migration
-#[case(CommitmentVersion::V2, CommitmentVersion::V3)] // migration
-#[case(CommitmentVersion::V3, CommitmentVersion::V3)] // post-migration
+// pre-migration: from V2 to V2 is ok
+#[case(CommitmentVersion::V2, CommitmentVersion::V2, Ok(()))]
+// migration: from V2 to V3 is ok
+#[case(CommitmentVersion::V2, CommitmentVersion::V3, Ok(()))]
+// post-migration: from V3 to V3 is ok
+#[case(CommitmentVersion::V3, CommitmentVersion::V3, Ok(()))]
+// rollback: from V3 to V2 is forbidden and lead to an inconsistent signed payload error
+#[case(
+    CommitmentVersion::V3,
+    CommitmentVersion::V2,
+    Err(ProofError::InconsistentSignedPayload)
+)]
 fn pp_root_migration(
     #[case] prev_version: CommitmentVersion,
     #[case] new_version: CommitmentVersion,
+    #[case] expected_result: Result<(), ProofError>,
 ) {
-    let (result, expected_prev_pp_root, expected_new_pp_root) =
-        pp_root_migration_helper(prev_version, new_version);
+    let (initial_state, certificate) = state_transition(new_version);
 
-    let PessimisticProofOutput {
-        prev_pessimistic_root,
-        new_pessimistic_root,
-        ..
-    } = result.unwrap().0;
-
-    assert_eq!(expected_prev_pp_root, prev_pessimistic_root);
-    assert_eq!(expected_new_pp_root, new_pessimistic_root);
-}
-
-#[test]
-fn forbidden_pp_root_transition() {
-    assert!(matches!(
-        pp_root_migration_helper(CommitmentVersion::V3, CommitmentVersion::V2).0,
-        Err(ProofError::InconsistentSignedPayload)
-    ));
+    assert_eq!(
+        VersionConsistencyChecker {
+            certificate_signature_version: new_version,
+            last_settled_pp_root_version: prev_version,
+            initial_state,
+            certificate
+        }
+        .check(),
+        expected_result
+    );
 }
 
 fn e2e_local_pp_simple_helper(


### PR DESCRIPTION
Follow up of the first iteration done with #882 

- Update the extra signature commitment on the certificate id and the l1 info tree leaf count
- Adapt the verification of the PP signature to accept either a V2 or a V3 commitment
  - Note that the verification on whether the version is the expected one as per what is settled in the L1 is only done at the witness generation step
- Adapt the tests
