### PR TITLE
fix: zero rollup contract error

### DIFF
--- a/crates/agglayer-contracts/src/lib.rs
+++ b/crates/agglayer-contracts/src/lib.rs
@@ -89,6 +89,8 @@ pub enum L1RpcError {
     VerifierTypeRetrievalFailed,
     #[error("Unable to retrieve the aggchain hash")]
     AggchainHashFetchFailed,
+    #[error("The rollup contract is either invalid or not set for the specified rollup id {0}")]
+    InvalidRollupContract(u32),
 }
 
 impl<RpcProvider> L1RpcClient<RpcProvider>

--- a/crates/agglayer-contracts/src/rollup.rs
+++ b/crates/agglayer-contracts/src/rollup.rs
@@ -182,6 +182,10 @@ where
                 .await
                 .map_err(|_| L1RpcError::RollupDataRetrievalFailed)?;
 
+            if rollup_data.rollupContract.is_zero() {
+                return Err(L1RpcError::InvalidRollupContract(rollup_id));
+            }
+
             PolygonZkEvm::new(rollup_data.rollupContract, self.rpc.clone())
                 .trustedSequencer()
                 .call()
@@ -198,6 +202,10 @@ where
             .call()
             .await
             .map_err(|_| L1RpcError::RollupDataRetrievalFailed)?;
+
+        if rollup_data.rollupContract.is_zero() {
+            return Err(L1RpcError::InvalidRollupContract(rollup_id));
+        }
 
         Ok(rollup_data.rollupContract.into())
     }


### PR DESCRIPTION
If rollup contract is not set in the rollup data (e.g. for non existing chain), return proper error.

Fixes [2025-05#31](https://github.com/agglayer/security/issues/141)