### PR TITLE
fix: wonky quotes in bash command

### DIFF
--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -9,8 +9,8 @@ fuzzers=(
     "agglayer-grpc-types/compat::v1::tests::fuzz_round_trip_epoch_configuration"
 )
 
-printf '%s\0' "${fuzzers[@]}" | parallel --null --bar --joblog fuzz.log bash -c '
-    crate="$(echo {} | cut -d/ -f1)"
-    target="$(echo {} | cut -d/ -f2)"
-    cargo bolero test --rustc-bootstrap -p "$crate" --all-features "$target" -T '"$time"'
-'
+printf '%s\0' "${fuzzers[@]}" | parallel --null --bar --joblog fuzz.log bash -c "
+    crate=\"\$(echo {} | cut -d/ -f1)\"
+    target=\"\$(echo {} | cut -d/ -f2)\"
+    cargo bolero test --rustc-bootstrap -p \"\$crate\" --all-features \"\$target\" -T '$time'
+"


### PR DESCRIPTION
the old quotes were breaking things—messed up variable expansion and escaping.
switched outer quotes to double, escaped the inner ones properly, and kept `$time` safe in singles. now it actually works.  

before:  
```bash
'echo "Time is $time"'
```  

after:  
```bash
"echo \"Time is \$time\""
```  

no more weird errors.