### PR TITLE
fix: update cert header status on pending removal

### DIFF
--- a/crates/agglayer-jsonrpc-api/src/admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/admin.rs
@@ -361,8 +361,10 @@ where
             self.pending_store
                 .remove_generated_proof(&certificate_id)
                 .map_err(|error| {
-                    error!("Failed to remove certificate header: {}", error);
-                    Error::internal("Unable to remove certificate header")
+                    error!( %certificate_id, ?error, "Failed to remove generated proof");
+                    Error::internal(format!(
+                        "Failed to remove generated proof for certificate_id: {certificate_id}"
+                    ))
                 })?;
         }
 


### PR DESCRIPTION
On pending removal, update header status.


Fixes [#142](https://github.com/agglayer/security/issues/142)
