### PR TITLE
feat: certificate versioning

### DIFF
--- a/crates/agglayer-jsonrpc-api/src/tests/send_certificate.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/send_certificate.rs
@@ -93,8 +93,8 @@ async fn pending_certificate_in_error_can_be_replaced() {
     let network_id = 1.into();
 
     let pending_certificate = Certificate::new_for_test(network_id, Height::ZERO);
-    let mut second_pending = Certificate::new_for_test(network_id, Height::ZERO);
-    second_pending.metadata = Metadata::new([1; 32].into());
+    let mut second_pending = Certificate::new_for_test(network_id, Height::ZERO)
+        .with_metadata(Metadata::new([1; 32].into()));
 
     assert_ne!(pending_certificate.hash(), second_pending.hash());
     context

--- a/crates/agglayer-storage/src/columns/certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/certificate_per_network/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{CertificateId, Height};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, CERTIFICATE_PER_NETWORK_CF};
+use super::{ColumnSchema, CERTIFICATE_PER_NETWORK_CF};
 
 #[cfg(test)]
 mod tests;
@@ -21,7 +21,7 @@ pub struct Key {
     pub(crate) height: Height,
 }
 
-impl Codec for Key {}
+impl_codec_using_bincode_for!(Key);
 
 impl ColumnSchema for CertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/latest_pending_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_pending_certificate_per_network/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{CertificateId, Height, NetworkId};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, LATEST_PENDING_CERTIFICATE_PER_NETWORK_CF};
+use super::{ColumnSchema, LATEST_PENDING_CERTIFICATE_PER_NETWORK_CF};
 
 /// Column family for the latest pending certificate per network.
 /// The key is the network_id and the value is the certificateID and
@@ -19,7 +19,7 @@ pub struct PendingCertificate(pub CertificateId, pub Height);
 
 pub type Key = NetworkId;
 
-impl Codec for PendingCertificate {}
+impl_codec_using_bincode_for!(PendingCertificate);
 
 impl ColumnSchema for LatestPendingCertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/latest_proven_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_proven_certificate_per_network/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{CertificateId, Height, NetworkId};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, LATEST_PROVEN_CERTIFICATE_PER_NETWORK_CF};
+use super::{ColumnSchema, LATEST_PROVEN_CERTIFICATE_PER_NETWORK_CF};
 
 /// Column family for the latest proven certificate per network.
 /// The key is the network_id and the value is the certificateID and
@@ -19,7 +19,7 @@ pub struct ProvenCertificate(pub CertificateId, pub NetworkId, pub Height);
 
 pub type Key = NetworkId;
 
-impl Codec for ProvenCertificate {}
+impl_codec_using_bincode_for!(ProvenCertificate);
 
 impl ColumnSchema for LatestProvenCertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/latest_settled_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_settled_certificate_per_network/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{CertificateId, CertificateIndex, EpochNumber, Height, NetworkId};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, LATEST_SETTLED_CERTIFICATE_PER_NETWORK_CF};
+use super::{ColumnSchema, LATEST_SETTLED_CERTIFICATE_PER_NETWORK_CF};
 
 #[cfg(test)]
 mod tests;
@@ -27,7 +27,7 @@ pub struct SettledCertificate(
 
 pub type Key = NetworkId;
 
-impl Codec for SettledCertificate {}
+impl_codec_using_bincode_for!(SettledCertificate);
 
 impl ColumnSchema for LatestSettledCertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/local_exit_tree_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/local_exit_tree_per_network/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, LOCAL_EXIT_TREE_PER_NETWORK_CF};
+use super::{ColumnSchema, LOCAL_EXIT_TREE_PER_NETWORK_CF};
 
 /// Column family for the local exit tree per network.
 ///
@@ -33,8 +33,7 @@ pub enum Value {
     Frontier([u8; 32]),
 }
 
-impl Codec for Key {}
-impl Codec for Value {}
+impl_codec_using_bincode_for!(Key, Value);
 
 impl ColumnSchema for LocalExitTreePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/mod.rs
+++ b/crates/agglayer-storage/src/columns/mod.rs
@@ -1,5 +1,4 @@
 use agglayer_types::bincode;
-use serde::{de::DeserializeOwned, Serialize};
 
 #[derive(Debug, thiserror::Error)]
 pub enum CodecError {
@@ -50,14 +49,10 @@ pub const PROOF_PER_CERTIFICATE_CF: &str = "proof_per_certificate_cf";
 // debug CFs
 pub const DEBUG_CERTIFICATES_CF: &str = "debug_certificates";
 
-pub trait Codec: Sized + Serialize + DeserializeOwned {
-    fn encode(&self) -> Result<Vec<u8>, CodecError> {
-        Ok(bincode_codec().serialize(self)?)
-    }
+pub trait Codec: Sized {
+    fn encode(&self) -> Result<Vec<u8>, CodecError>;
 
-    fn decode(buf: &[u8]) -> Result<Self, CodecError> {
-        Ok(bincode_codec().deserialize(buf)?)
-    }
+    fn decode(buf: &[u8]) -> Result<Self, CodecError>;
 }
 
 pub trait ColumnSchema {

--- a/crates/agglayer-storage/src/columns/pending_queue/mod.rs
+++ b/crates/agglayer-storage/src/columns/pending_queue/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{Certificate, Height, NetworkId};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, PENDING_QUEUE_CF};
+use super::{ColumnSchema, PENDING_QUEUE_CF};
 
 /// Column family containing the pending certificates queue.
 ///
@@ -15,7 +15,7 @@ pub(crate) struct PendingQueueColumn;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PendingQueueKey(pub(crate) NetworkId, pub(crate) Height);
 
-impl Codec for PendingQueueKey {}
+impl_codec_using_bincode_for!(PendingQueueKey);
 
 impl ColumnSchema for PendingQueueColumn {
     type Key = PendingQueueKey;

--- a/crates/agglayer-storage/src/lib.rs
+++ b/crates/agglayer-storage/src/lib.rs
@@ -1,3 +1,19 @@
+macro_rules! impl_codec_using_bincode_for {
+    ($($type:ty),* $(,)?) => {
+        $(
+            impl $crate::columns::Codec for $type {
+                fn encode(&self) -> Result<Vec<u8>, $crate::columns::CodecError> {
+                    Ok($crate::columns::bincode_codec().serialize(self)?)
+                }
+
+                fn decode(buf: &[u8]) -> Result<Self, $crate::columns::CodecError> {
+                    Ok($crate::columns::bincode_codec().deserialize(buf)?)
+                }
+            }
+        )*
+    };
+}
+
 // Physical storage
 #[rustfmt::skip]
 pub mod storage;
@@ -5,6 +21,7 @@ pub mod storage;
 #[rustfmt::skip]
 pub mod stores;
 
+#[macro_use]
 #[rustfmt::skip]
 pub mod columns;
 #[rustfmt::skip]

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -159,7 +159,8 @@ impl StateWriter for StateStore {
                 prev_local_exit_root: certificate.prev_local_exit_root,
                 new_local_exit_root: certificate.new_local_exit_root,
                 status: status.clone(),
-                metadata: certificate.metadata,
+                // TODO make header enum too
+                metadata: certificate.metadata().copied().unwrap_or_default(),
                 settlement_tx_hash: None,
             },
         )?;

--- a/crates/agglayer-storage/src/types/certificate/tests/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/tests/mod.rs
@@ -167,8 +167,8 @@ impl CertificateV1<'static> {
     }
 }
 
-impl CertificateV1<'_> {
-    fn into_owned(self) -> CertificateV1<'static> {
+impl CertificateV2<'_> {
+    fn into_owned(self) -> CertificateV2<'static> {
         let Self {
             version,
             network_id,
@@ -178,12 +178,12 @@ impl CertificateV1<'_> {
             bridge_exits,
             imported_bridge_exits,
             aggchain_data,
-            metadata,
             custom_chain_data,
             l1_info_tree_leaf_count,
+            extra_fields,
         } = self;
 
-        CertificateV1 {
+        CertificateV2 {
             version,
             network_id,
             height,
@@ -221,9 +221,9 @@ impl CertificateV1<'_> {
                     public_values: Cow::Owned(public_values.into_owned()),
                 },
             },
-            metadata,
             custom_chain_data: Cow::Owned(custom_chain_data.into_owned()),
             l1_info_tree_leaf_count,
+            extra_fields: Cow::Owned(extra_fields.into_owned()),
         }
     }
 }
@@ -241,7 +241,7 @@ fn encoding_starts_with(#[case] cert: impl Serialize, #[case] start: &[u8]) {
 #[case(CertificateV0::test0())]
 #[case(CertificateV1::test0())]
 #[case(CertificateV1::test1())]
-#[case(CertificateV1::from(&Certificate::new_for_test(74.into(), Height::new(998))).into_owned())]
+#[case(CertificateV2::from(&Certificate::new_for_test(74.into(), Height::new(998))).into_owned())]
 fn encoding_roundtrip_consistent_with_into(#[case] orig: impl Into<Certificate> + Serialize) {
     let bytes = bincode_codec().serialize(&orig).unwrap();
     let decoded = Certificate::decode(&bytes).unwrap();

--- a/crates/agglayer-storage/src/types/mod.rs
+++ b/crates/agglayer-storage/src/types/mod.rs
@@ -1,17 +1,10 @@
 use agglayer_types::{
-    primitives::Digest, CertificateHeader, CertificateId, CertificateIndex, EpochNumber, Height, NetworkId, Proof
+    primitives::Digest, CertificateHeader, CertificateId, CertificateIndex, EpochNumber, Height,
+    NetworkId, Proof,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::columns::Codec;
-
 mod certificate;
-
-macro_rules! default_codec_impl {
-    ($($ident: ident),+) => {
-        $(impl crate::columns::Codec for $ident {})+
-    };
-}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MetadataKey {
@@ -55,10 +48,7 @@ pub enum SmtValue {
     Leaf(Digest),
 }
 
-impl Codec for SmtKey {}
-impl Codec for SmtValue {}
-
-default_codec_impl!(
+impl_codec_using_bincode_for!(
     u64,
     u32,
     CertificateId,
@@ -71,5 +61,7 @@ default_codec_impl!(
     NetworkId,
     PerEpochMetadataKey,
     PerEpochMetadataValue,
-    Proof
+    Proof,
+    SmtKey,
+    SmtValue,
 );

--- a/crates/agglayer-types/src/certificate/common.rs
+++ b/crates/agglayer-types/src/certificate/common.rs
@@ -1,0 +1,217 @@
+//! Stuff common to certificates across multiple versions.
+
+use agglayer_interop_types::{aggchain_proof::AggchainData, LocalExitRoot};
+use agglayer_primitives::{Address, Digest, Hashable, Signature, B256};
+use pessimistic_proof::{core::commitment::SignatureCommitmentValues, keccak::keccak256_combine};
+use unified_bridge::{
+    BridgeExit, CommitmentVersion, ImportedBridgeExit, ImportedBridgeExitCommitmentValues,
+    NetworkId,
+};
+
+use super::{CertificateId, Height, Version};
+use crate::{Error, SignerError};
+
+/// Core certificate fields common to all versions.
+//
+// TODO: This could be broken down into multiple more granular structs
+// with different subsets of fields based on overlap between certificate
+// version features. Or turned into a number of traits.
+pub struct Fields<'a> {
+    pub version: Version,
+    pub network_id: NetworkId,
+    pub height: Height,
+    pub prev_local_exit_root: &'a LocalExitRoot,
+    pub new_local_exit_root: &'a LocalExitRoot,
+    pub bridge_exits: &'a [BridgeExit],
+    pub imported_bridge_exits: &'a [ImportedBridgeExit],
+    pub aggchain_data: &'a AggchainData,
+    pub l1_info_tree_leaf_count: Option<u32>,
+}
+
+impl Fields<'_> {
+    pub(crate) fn hash<const N: usize>(&self, extra: [&[u8]; N]) -> CertificateId {
+        // Version 1+ fills the original position of network_id and height
+        // with (u32::MAX, u64::MAX) and adds version.
+        let commit_version_1plus = {
+            let mut prefix = [0xff; 16];
+            prefix[12..16].copy_from_slice(&self.version.as_u32().to_be_bytes());
+            prefix
+        };
+
+        let commit_version: &[u8] = match self.version {
+            // Backwards compatible, V0 is without a prefix.
+            Version::V0 => &[],
+            _ => &commit_version_1plus,
+        };
+
+        let commit_bridge_exits =
+            keccak256_combine(self.bridge_exits.iter().map(|exit| exit.hash()));
+        let commit_imported_bridge_exits =
+            keccak256_combine(self.imported_bridge_exits.iter().map(|exit| exit.hash()));
+
+        let network_id_bytes = self.network_id.to_be_bytes();
+        let height_bytes = self.height.as_u64().to_be_bytes();
+
+        let fields = [
+            commit_version,
+            network_id_bytes.as_slice(),
+            height_bytes.as_slice(),
+            self.prev_local_exit_root.as_ref(),
+            self.new_local_exit_root.as_ref(),
+            commit_bridge_exits.as_slice(),
+            commit_imported_bridge_exits.as_slice(),
+        ];
+
+        CertificateId::new(keccak256_combine(fields.into_iter().chain(extra)))
+    }
+
+    /// Returns the L1 Info Tree leaf count considered for this [`Certificate`].
+    /// Corresponds to the highest L1 Info Tree leaf index considered by the
+    /// imported bridge exits.
+    pub fn l1_info_tree_leaf_count(&self) -> Option<u32> {
+        self.l1_info_tree_leaf_count.or_else(|| {
+            self.imported_bridge_exits
+                .iter()
+                .map(|i| i.l1_leaf_index() + 1)
+                .max()
+        })
+    }
+
+    /// Returns the L1 Info Root considered for this [`Certificate`].
+    /// Fails if multiple L1 Info Root are considered among the inclusion proofs
+    /// of the imported bridge exits.
+    pub fn l1_info_root(&self) -> Result<Option<Digest>, Error> {
+        let Some(l1_info_root) = self
+            .imported_bridge_exits
+            .first()
+            .map(|imported_bridge_exit| imported_bridge_exit.l1_info_root())
+        else {
+            return Ok(None);
+        };
+
+        if self
+            .imported_bridge_exits
+            .iter()
+            .all(|exit| exit.l1_info_root() == l1_info_root)
+        {
+            Ok(Some(l1_info_root))
+        } else {
+            Err(Error::MultipleL1InfoRoot)
+        }
+    }
+
+    pub fn signature_commitment_values(&self) -> SignatureCommitmentValues {
+        SignatureCommitmentValues {
+            new_local_exit_root: *self.new_local_exit_root,
+            commit_imported_bridge_exits: ImportedBridgeExitCommitmentValues {
+                claims: self
+                    .imported_bridge_exits
+                    .iter()
+                    .map(|exit| exit.to_indexed_exit_hash())
+                    .collect(),
+            },
+            height: self.height.as_u64(),
+        }
+    }
+
+    /// Verify the signature on the PP commitment.
+    pub fn verify_cert_signature(&self, expected_signer: Address) -> Result<(), SignerError> {
+        let pp_commitment_values = self.signature_commitment_values();
+
+        let recovered_expected_signer = match &self.aggchain_data {
+            // Verify if one of the commitment version is signed.
+            // NOTE: The legitimacy of the version is verified during the witness generation,
+            // especially in order to forbid version rollback by the chain.
+            AggchainData::ECDSA { signature } => [CommitmentVersion::V3, CommitmentVersion::V2]
+                .iter()
+                .any(|version| {
+                    let commitment = B256::new(pp_commitment_values.commitment(*version).0);
+                    match signature.recover_address_from_prehash(&commitment) {
+                        Ok(recovered) => recovered == expected_signer,
+                        Err(_) => false,
+                    }
+                }),
+            AggchainData::Generic {
+                signature,
+                aggchain_params,
+                ..
+            } => {
+                let signature = signature.as_ref().ok_or(SignerError::Missing)?;
+                let commitment = B256::new(
+                    pp_commitment_values
+                        .aggchain_proof_commitment(aggchain_params)
+                        .0,
+                );
+                let recovered = signature
+                    .recover_address_from_prehash(&commitment)
+                    .map_err(SignerError::Recovery)?;
+
+                recovered == expected_signer
+            }
+        };
+
+        recovered_expected_signer
+            .then_some(())
+            .ok_or(SignerError::InvalidPessimisticProofSignature { expected_signer })
+    }
+
+    /// Retrieve the signer from the certificate signature.
+    pub fn retrieve_signer(&self, version: CommitmentVersion) -> Result<Address, SignerError> {
+        let commitment_values = self.signature_commitment_values();
+
+        let (signature, commitment) = match &self.aggchain_data {
+            AggchainData::ECDSA { signature } => {
+                let commitment = commitment_values.commitment(version);
+                (signature, commitment)
+            }
+            AggchainData::Generic {
+                signature,
+                aggchain_params,
+                ..
+            } => {
+                let signature = signature.as_ref().ok_or(SignerError::Missing)?;
+                let commitment = commitment_values.aggchain_proof_commitment(aggchain_params);
+                (signature.as_ref(), commitment)
+            }
+        };
+
+        signature
+            .recover_address_from_prehash(&B256::new(commitment.0))
+            .map_err(SignerError::Recovery)
+    }
+}
+
+/// Computes the commitment used to verify the extra signature on the
+/// agglayer only.
+/// The commitment is expected to be on the certificate id and the optional
+/// l1 info tree leaf count.
+fn extra_signature_commitment(
+    certificate_id: CertificateId,
+    l1_info_tree_leaf_count: Option<u32>,
+) -> Digest {
+    match l1_info_tree_leaf_count {
+        Some(leaf_count) => keccak256_combine([
+            certificate_id.as_digest().as_slice(),
+            leaf_count.to_le_bytes().as_slice(),
+        ]),
+        None => *certificate_id,
+    }
+}
+
+/// Verify the extra certificate signature.
+pub fn verify_extra_signature(
+    certificate_id: CertificateId,
+    l1_info_tree_leaf_count: Option<u32>,
+    expected_signer: Address,
+    signature: Signature,
+) -> Result<(), SignerError> {
+    let expected_commitment = extra_signature_commitment(certificate_id, l1_info_tree_leaf_count);
+
+    let retrieved_signer = signature
+        .recover_address_from_prehash(&B256::new(expected_commitment.0))
+        .map_err(SignerError::Recovery)?;
+
+    (expected_signer == retrieved_signer)
+        .then_some(())
+        .ok_or(SignerError::InvalidExtraSignature { expected_signer })
+}

--- a/crates/agglayer-types/src/certificate/mod.rs
+++ b/crates/agglayer-types/src/certificate/mod.rs
@@ -1,9 +1,13 @@
-use agglayer_primitives::{Address, Digest, Signature};
-use unified_bridge::CommitmentVersion;
+use agglayer_interop_types::{aggchain_proof::AggchainData, LocalExitRoot};
+use agglayer_primitives::{Address, Hashable, Signature, B256};
+use pessimistic_proof::{core::commitment::SignatureCommitmentValues, keccak::keccak256_combine};
+use unified_bridge::{
+    BridgeExit, CommitmentVersion, ImportedBridgeExit, ImportedBridgeExitCommitmentValues,
+    NetworkId,
+};
 
-use crate::{Error, SignerError};
+use crate::{Digest, Error, SignerError};
 
-mod common;
 mod header;
 mod height;
 mod id;
@@ -14,7 +18,6 @@ mod testutils;
 mod v0;
 mod v1;
 
-pub use common::Fields;
 pub use header::{CertificateHeader, CertificateStatus, SettlementTxHash};
 pub use height::Height;
 pub use id::CertificateId;
@@ -22,47 +25,156 @@ pub use index::CertificateIndex;
 pub use metadata::Metadata;
 #[cfg(feature = "testutils")]
 pub use testutils::compute_signature_info;
-pub use v0::CertificateV0;
-pub use v1::CertificateV1;
+pub use v0::FieldsV0;
+pub use v1::FieldsV1;
 
-// Make V0 as the current certificate for now.
-// Should be eventually replaced with CertificateVx.
-pub type Certificate = CertificateV0;
-
-/// Certificate of any supported version
-#[derive(Clone, Debug, derive_more::From)]
-pub enum CertificateVx {
-    V0(CertificateV0),
-    V1(CertificateV1),
+/// Holds certificate fields that are specific to particular version(s).
+#[derive(Clone, Debug, derive_more::From, serde::Serialize, serde::Deserialize)]
+pub enum VersionFields {
+    V0(v0::FieldsV0),
+    V1(v1::FieldsV1),
 }
 
-impl CertificateVx {
-    pub fn version(&self) -> Version {
+impl VersionFields {
+    pub const fn metadata(&self) -> Option<&Metadata> {
         match self {
-            Self::V0(_) => Version::V0,
-            Self::V1(_) => Version::V1,
+            Self::V0(FieldsV0 { metadata }) => Some(metadata),
+            Self::V1(FieldsV1 {}) => None,
         }
     }
 
-    pub fn hash(&self) -> CertificateId {
+    fn metadata_slice(&self) -> &[u8] {
+        self.metadata().map_or(&[], |m| m.as_slice())
+    }
+
+    const fn id_preimage_prefix(&self) -> &[u8] {
         match self {
-            Self::V0(cert) => cert.hash(),
-            Self::V1(cert) => cert.hash(),
+            Self::V0(_) => FieldsV0::ID_PREIMAGE_PREFIX,
+            Self::V1(_) => FieldsV1::ID_PREIMAGE_PREFIX,
         }
+    }
+}
+
+/// Represents the data submitted by the chains to the AggLayer.
+///
+/// The bridge exits plus the imported bridge exits define
+/// the state transition, resp. the amount that goes out and the amount that
+/// comes in.
+///
+/// The bridge exits refer to the [`BridgeExit`] emitted by
+/// the origin network of the [`Certificate`].
+///
+/// The imported bridge exits refer to the [`BridgeExit`] received and imported
+/// by the origin network of the [`Certificate`].
+///
+/// Note: be mindful to update the [`Self::hash`] method accordingly
+/// upon modifying the fields of this structure.
+#[derive(Clone, Debug)]
+pub struct Certificate {
+    /// NetworkID of the origin network.
+    pub network_id: NetworkId,
+    /// Simple increment to count the Certificate per network.
+    pub height: Height,
+    /// Previous local exit root.
+    pub prev_local_exit_root: LocalExitRoot,
+    /// New local exit root.
+    pub new_local_exit_root: LocalExitRoot,
+    /// List of bridge exits included in this state transition.
+    pub bridge_exits: Vec<BridgeExit>,
+    /// List of imported bridge exits included in this state transition.
+    pub imported_bridge_exits: Vec<ImportedBridgeExit>,
+    /// Aggchain data which is either one ECDSA or Generic proof.
+    pub aggchain_data: AggchainData,
+    pub custom_chain_data: Vec<u8>,
+    pub l1_info_tree_leaf_count: Option<u32>,
+
+    pub extra_fields: VersionFields,
+}
+
+impl serde::Serialize for Certificate {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        todo!()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Certificate {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        todo!()
+    }
+}
+
+impl Certificate {
+    pub fn hash(&self) -> CertificateId {
+        let commit_bridge_exits =
+            keccak256_combine(self.bridge_exits.iter().map(|exit| exit.hash()));
+        let commit_imported_bridge_exits =
+            keccak256_combine(self.imported_bridge_exits.iter().map(|exit| exit.hash()));
+
+        CertificateId::new(keccak256_combine([
+            self.extra_fields.id_preimage_prefix(),
+            self.network_id.to_be_bytes().as_slice(),
+            self.height.as_u64().to_be_bytes().as_slice(),
+            self.prev_local_exit_root.as_ref(),
+            self.new_local_exit_root.as_ref(),
+            commit_bridge_exits.as_slice(),
+            commit_imported_bridge_exits.as_slice(),
+            self.extra_fields.metadata_slice(),
+        ]))
+    }
+
+    pub const fn metadata(&self) -> Option<&Metadata> {
+        self.extra_fields.metadata()
     }
 
     /// Returns the L1 Info Tree leaf count considered for this [`Certificate`].
     /// Corresponds to the highest L1 Info Tree leaf index considered by the
     /// imported bridge exits.
     pub fn l1_info_tree_leaf_count(&self) -> Option<u32> {
-        todo!("split on version as above")
+        self.l1_info_tree_leaf_count.or_else(|| {
+            self.imported_bridge_exits
+                .iter()
+                .map(|i| i.l1_leaf_index() + 1)
+                .max()
+        })
     }
 
     /// Returns the L1 Info Root considered for this [`Certificate`].
     /// Fails if multiple L1 Info Root are considered among the inclusion proofs
     /// of the imported bridge exits.
     pub fn l1_info_root(&self) -> Result<Option<Digest>, Error> {
-        todo!("split on version as above")
+        let Some(l1_info_root) = self
+            .imported_bridge_exits
+            .first()
+            .map(|imported_bridge_exit| imported_bridge_exit.l1_info_root())
+        else {
+            return Ok(None);
+        };
+
+        if self
+            .imported_bridge_exits
+            .iter()
+            .all(|exit| exit.l1_info_root() == l1_info_root)
+        {
+            Ok(Some(l1_info_root))
+        } else {
+            Err(Error::MultipleL1InfoRoot)
+        }
+    }
+
+    /// Computes the commitment used to verify the extra signature on the
+    /// agglayer only.
+    /// The commitment is expected to be on the certificate id and the optional
+    /// l1 info tree leaf count.
+    fn extra_signature_commitment(&self) -> Digest {
+        let certificate_id = self.hash();
+
+        match self.l1_info_tree_leaf_count {
+            Some(leaf_count) => keccak256_combine([
+                certificate_id.as_digest().as_slice(),
+                leaf_count.to_le_bytes().as_slice(),
+            ]),
+            None => *certificate_id,
+        }
     }
 
     /// Verify the extra certificate signature.
@@ -71,40 +183,95 @@ impl CertificateVx {
         expected_signer: Address,
         signature: Signature,
     ) -> Result<(), SignerError> {
-        match self {
-            Self::V0(cert) => cert.verify_extra_signature(expected_signer, signature),
-            Self::V1(cert) => cert.verify_extra_signature(expected_signer, signature),
-        }
+        let expected_commitment = self.extra_signature_commitment();
+
+        let retrieved_signer = signature
+            .recover_address_from_prehash(&B256::new(expected_commitment.0))
+            .map_err(SignerError::Recovery)?;
+
+        (expected_signer == retrieved_signer)
+            .then_some(())
+            .ok_or(SignerError::InvalidExtraSignature { expected_signer })
     }
 
     /// Verify the signature on the PP commitment.
     pub fn verify_cert_signature(&self, expected_signer: Address) -> Result<(), SignerError> {
-        match self {
-            Self::V0(cert) => cert.verify_cert_signature(expected_signer),
-            Self::V1(cert) => cert.verify_cert_signature(expected_signer),
-        }
+        let pp_commitment_values = SignatureCommitmentValues::from(self);
+
+        let recovered_expected_signer = match &self.aggchain_data {
+            // Verify if one of the commitment version is signed.
+            // NOTE: The legitimacy of the version is verified during the witness generation,
+            // especially in order to forbid version rollback by the chain.
+            AggchainData::ECDSA { signature } => [CommitmentVersion::V3, CommitmentVersion::V2]
+                .iter()
+                .any(|version| {
+                    let commitment = B256::new(pp_commitment_values.commitment(*version).0);
+                    match signature.recover_address_from_prehash(&commitment) {
+                        Ok(recovered) => recovered == expected_signer,
+                        Err(_) => false,
+                    }
+                }),
+            AggchainData::Generic {
+                signature,
+                aggchain_params,
+                ..
+            } => {
+                let signature = signature.as_ref().ok_or(SignerError::Missing)?;
+                let commitment = B256::new(
+                    pp_commitment_values
+                        .aggchain_proof_commitment(aggchain_params)
+                        .0,
+                );
+                let recovered = signature
+                    .recover_address_from_prehash(&commitment)
+                    .map_err(SignerError::Recovery)?;
+
+                recovered == expected_signer
+            }
+        };
+
+        recovered_expected_signer
+            .then_some(())
+            .ok_or(SignerError::InvalidPessimisticProofSignature { expected_signer })
     }
 
     /// Retrieve the signer from the certificate signature.
     pub fn retrieve_signer(&self, version: CommitmentVersion) -> Result<Address, SignerError> {
-        match self {
-            Self::V0(cert) => cert.retrieve_signer(version),
-            Self::V1(cert) => cert.retrieve_signer(version),
-        }
+        let (signature, commitment) = match &self.aggchain_data {
+            AggchainData::ECDSA { signature } => {
+                let commitment = SignatureCommitmentValues::from(self).commitment(version);
+                (signature, commitment)
+            }
+            AggchainData::Generic {
+                signature,
+                aggchain_params,
+                ..
+            } => {
+                let signature = signature.as_ref().ok_or(SignerError::Missing)?;
+                let commitment = SignatureCommitmentValues::from(self)
+                    .aggchain_proof_commitment(aggchain_params);
+                (signature.as_ref(), commitment)
+            }
+        };
+
+        signature
+            .recover_address_from_prehash(&B256::new(commitment.0))
+            .map_err(SignerError::Recovery)
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub enum Version {
-    V0,
-    V1,
-}
-
-impl Version {
-    pub fn as_u32(&self) -> u32 {
-        match self {
-            Self::V0 => 0,
-            Self::V1 => 1,
+impl From<&Certificate> for SignatureCommitmentValues {
+    fn from(certificate: &Certificate) -> Self {
+        Self {
+            new_local_exit_root: certificate.new_local_exit_root,
+            commit_imported_bridge_exits: ImportedBridgeExitCommitmentValues {
+                claims: certificate
+                    .imported_bridge_exits
+                    .iter()
+                    .map(|exit| exit.to_indexed_exit_hash())
+                    .collect(),
+            },
+            height: certificate.height.as_u64(),
         }
     }
 }

--- a/crates/agglayer-types/src/certificate/mod.rs
+++ b/crates/agglayer-types/src/certificate/mod.rs
@@ -1,3 +1,8 @@
+use agglayer_primitives::{Address, Digest, Signature};
+use unified_bridge::CommitmentVersion;
+
+use crate::{Error, SignerError};
+
 mod common;
 mod header;
 mod height;
@@ -46,14 +51,47 @@ impl CertificateVx {
         }
     }
 
-    // TODO re-expose various certificate methods here in fashion similar to
-    // [Self::hash].
-    //
-    // It could also be considered to abstract these methods into a trait.
-    // Some code duplication could be avoided by:
-    // 1. Factoring out common parts of implementation,
-    // 2. Introducing a trait with common "core" methods and an extension trait that
-    //    exposes methods implemented in terms of the core ones.
+    /// Returns the L1 Info Tree leaf count considered for this [`Certificate`].
+    /// Corresponds to the highest L1 Info Tree leaf index considered by the
+    /// imported bridge exits.
+    pub fn l1_info_tree_leaf_count(&self) -> Option<u32> {
+        todo!("split on version as above")
+    }
+
+    /// Returns the L1 Info Root considered for this [`Certificate`].
+    /// Fails if multiple L1 Info Root are considered among the inclusion proofs
+    /// of the imported bridge exits.
+    pub fn l1_info_root(&self) -> Result<Option<Digest>, Error> {
+        todo!("split on version as above")
+    }
+
+    /// Verify the extra certificate signature.
+    pub fn verify_extra_signature(
+        &self,
+        expected_signer: Address,
+        signature: Signature,
+    ) -> Result<(), SignerError> {
+        match self {
+            Self::V0(cert) => cert.verify_extra_signature(expected_signer, signature),
+            Self::V1(cert) => cert.verify_extra_signature(expected_signer, signature),
+        }
+    }
+
+    /// Verify the signature on the PP commitment.
+    pub fn verify_cert_signature(&self, expected_signer: Address) -> Result<(), SignerError> {
+        match self {
+            Self::V0(cert) => cert.verify_cert_signature(expected_signer),
+            Self::V1(cert) => cert.verify_cert_signature(expected_signer),
+        }
+    }
+
+    /// Retrieve the signer from the certificate signature.
+    pub fn retrieve_signer(&self, version: CommitmentVersion) -> Result<Address, SignerError> {
+        match self {
+            Self::V0(cert) => cert.retrieve_signer(version),
+            Self::V1(cert) => cert.retrieve_signer(version),
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]

--- a/crates/agglayer-types/src/certificate/mod.rs
+++ b/crates/agglayer-types/src/certificate/mod.rs
@@ -1,13 +1,4 @@
-use agglayer_interop_types::{aggchain_proof::AggchainData, LocalExitRoot};
-use agglayer_primitives::{Address, Hashable, Signature, B256};
-use pessimistic_proof::{core::commitment::SignatureCommitmentValues, keccak::keccak256_combine};
-use unified_bridge::{
-    BridgeExit, CommitmentVersion, ImportedBridgeExit, ImportedBridgeExitCommitmentValues,
-    NetworkId,
-};
-
-use crate::{Digest, Error, SignerError};
-
+mod common;
 mod header;
 mod height;
 mod id;
@@ -15,7 +6,10 @@ mod index;
 mod metadata;
 #[cfg(feature = "testutils")]
 mod testutils;
+mod v0;
+mod v1;
 
+pub use common::Fields;
 pub use header::{CertificateHeader, CertificateStatus, SettlementTxHash};
 pub use height::Height;
 pub use id::CertificateId;
@@ -23,210 +17,56 @@ pub use index::CertificateIndex;
 pub use metadata::Metadata;
 #[cfg(feature = "testutils")]
 pub use testutils::compute_signature_info;
+pub use v0::CertificateV0;
+pub use v1::CertificateV1;
 
-/// Represents the data submitted by the chains to the AggLayer.
-///
-/// The bridge exits plus the imported bridge exits define
-/// the state transition, resp. the amount that goes out and the amount that
-/// comes in.
-///
-/// The bridge exits refer to the [`BridgeExit`] emitted by
-/// the origin network of the [`Certificate`].
-///
-/// The imported bridge exits refer to the [`BridgeExit`] received and imported
-/// by the origin network of the [`Certificate`].
-///
-/// Note: be mindful to update the [`Self::hash`] method accordingly
-/// upon modifying the fields of this structure.
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct Certificate {
-    /// NetworkID of the origin network.
-    pub network_id: NetworkId,
-    /// Simple increment to count the Certificate per network.
-    pub height: Height,
-    /// Previous local exit root.
-    pub prev_local_exit_root: LocalExitRoot,
-    /// New local exit root.
-    pub new_local_exit_root: LocalExitRoot,
-    /// List of bridge exits included in this state transition.
-    pub bridge_exits: Vec<BridgeExit>,
-    /// List of imported bridge exits included in this state transition.
-    pub imported_bridge_exits: Vec<ImportedBridgeExit>,
-    /// Fixed size field of arbitrary data for the chain needs.
-    pub metadata: Metadata,
-    /// Aggchain data which is either one ECDSA or Generic proof.
-    #[serde(flatten)]
-    pub aggchain_data: AggchainData,
-    #[serde(default)]
-    pub custom_chain_data: Vec<u8>,
-    #[serde(default)]
-    pub l1_info_tree_leaf_count: Option<u32>,
+// Make V0 as the current certificate for now.
+// Should be eventually replaced with CertificateVx.
+pub type Certificate = CertificateV0;
+
+/// Certificate of any supported version
+#[derive(Clone, Debug, derive_more::From)]
+pub enum CertificateVx {
+    V0(CertificateV0),
+    V1(CertificateV1),
 }
 
-impl Certificate {
+impl CertificateVx {
+    pub fn version(&self) -> Version {
+        match self {
+            Self::V0(_) => Version::V0,
+            Self::V1(_) => Version::V1,
+        }
+    }
+
     pub fn hash(&self) -> CertificateId {
-        let commit_bridge_exits =
-            keccak256_combine(self.bridge_exits.iter().map(|exit| exit.hash()));
-        let commit_imported_bridge_exits =
-            keccak256_combine(self.imported_bridge_exits.iter().map(|exit| exit.hash()));
-
-        CertificateId::new(keccak256_combine([
-            self.network_id.to_be_bytes().as_slice(),
-            self.height.as_u64().to_be_bytes().as_slice(),
-            self.prev_local_exit_root.as_ref(),
-            self.new_local_exit_root.as_ref(),
-            commit_bridge_exits.as_slice(),
-            commit_imported_bridge_exits.as_slice(),
-            self.metadata.0.as_slice(),
-        ]))
-    }
-
-    /// Returns the L1 Info Tree leaf count considered for this [`Certificate`].
-    /// Corresponds to the highest L1 Info Tree leaf index considered by the
-    /// imported bridge exits.
-    pub fn l1_info_tree_leaf_count(&self) -> Option<u32> {
-        self.l1_info_tree_leaf_count.or_else(|| {
-            self.imported_bridge_exits
-                .iter()
-                .map(|i| i.l1_leaf_index() + 1)
-                .max()
-        })
-    }
-
-    /// Returns the L1 Info Root considered for this [`Certificate`].
-    /// Fails if multiple L1 Info Root are considered among the inclusion proofs
-    /// of the imported bridge exits.
-    pub fn l1_info_root(&self) -> Result<Option<Digest>, Error> {
-        let Some(l1_info_root) = self
-            .imported_bridge_exits
-            .first()
-            .map(|imported_bridge_exit| imported_bridge_exit.l1_info_root())
-        else {
-            return Ok(None);
-        };
-
-        if self
-            .imported_bridge_exits
-            .iter()
-            .all(|exit| exit.l1_info_root() == l1_info_root)
-        {
-            Ok(Some(l1_info_root))
-        } else {
-            Err(Error::MultipleL1InfoRoot)
+        match self {
+            Self::V0(cert) => cert.hash(),
+            Self::V1(cert) => cert.hash(),
         }
     }
 
-    /// Computes the commitment used to verify the extra signature on the
-    /// agglayer only.
-    /// The commitment is expected to be on the certificate id and the optional
-    /// l1 info tree leaf count.
-    fn extra_signature_commitment(&self) -> Digest {
-        let certificate_id = self.hash();
-
-        match self.l1_info_tree_leaf_count {
-            Some(leaf_count) => keccak256_combine([
-                certificate_id.as_digest().as_slice(),
-                leaf_count.to_le_bytes().as_slice(),
-            ]),
-            None => *certificate_id,
-        }
-    }
-
-    /// Verify the extra certificate signature.
-    pub fn verify_extra_signature(
-        &self,
-        expected_signer: Address,
-        signature: Signature,
-    ) -> Result<(), SignerError> {
-        let expected_commitment = self.extra_signature_commitment();
-
-        let retrieved_signer = signature
-            .recover_address_from_prehash(&B256::new(expected_commitment.0))
-            .map_err(SignerError::Recovery)?;
-
-        (expected_signer == retrieved_signer)
-            .then_some(())
-            .ok_or(SignerError::InvalidExtraSignature { expected_signer })
-    }
-
-    /// Verify the signature on the PP commitment.
-    pub fn verify_cert_signature(&self, expected_signer: Address) -> Result<(), SignerError> {
-        let pp_commitment_values = SignatureCommitmentValues::from(self);
-
-        let recovered_expected_signer = match &self.aggchain_data {
-            // Verify if one of the commitment version is signed.
-            // NOTE: The legitimacy of the version is verified during the witness generation,
-            // especially in order to forbid version rollback by the chain.
-            AggchainData::ECDSA { signature } => [CommitmentVersion::V3, CommitmentVersion::V2]
-                .iter()
-                .any(|version| {
-                    let commitment = B256::new(pp_commitment_values.commitment(*version).0);
-                    match signature.recover_address_from_prehash(&commitment) {
-                        Ok(recovered) => recovered == expected_signer,
-                        Err(_) => false,
-                    }
-                }),
-            AggchainData::Generic {
-                signature,
-                aggchain_params,
-                ..
-            } => {
-                let signature = signature.as_ref().ok_or(SignerError::Missing)?;
-                let commitment = B256::new(
-                    pp_commitment_values
-                        .aggchain_proof_commitment(aggchain_params)
-                        .0,
-                );
-                let recovered = signature
-                    .recover_address_from_prehash(&commitment)
-                    .map_err(SignerError::Recovery)?;
-
-                recovered == expected_signer
-            }
-        };
-
-        recovered_expected_signer
-            .then_some(())
-            .ok_or(SignerError::InvalidPessimisticProofSignature { expected_signer })
-    }
-
-    /// Retrieve the signer from the certificate signature.
-    pub fn retrieve_signer(&self, version: CommitmentVersion) -> Result<Address, SignerError> {
-        let (signature, commitment) = match &self.aggchain_data {
-            AggchainData::ECDSA { signature } => {
-                let commitment = SignatureCommitmentValues::from(self).commitment(version);
-                (signature, commitment)
-            }
-            AggchainData::Generic {
-                signature,
-                aggchain_params,
-                ..
-            } => {
-                let signature = signature.as_ref().ok_or(SignerError::Missing)?;
-                let commitment = SignatureCommitmentValues::from(self)
-                    .aggchain_proof_commitment(aggchain_params);
-                (signature.as_ref(), commitment)
-            }
-        };
-
-        signature
-            .recover_address_from_prehash(&B256::new(commitment.0))
-            .map_err(SignerError::Recovery)
-    }
+    // TODO re-expose various certificate methods here in fashion similar to
+    // [Self::hash].
+    //
+    // It could also be considered to abstract these methods into a trait.
+    // Some code duplication could be avoided by:
+    // 1. Factoring out common parts of implementation,
+    // 2. Introducing a trait with common "core" methods and an extension trait that
+    //    exposes methods implemented in terms of the core ones.
 }
 
-impl From<&Certificate> for SignatureCommitmentValues {
-    fn from(certificate: &Certificate) -> Self {
-        Self {
-            new_local_exit_root: certificate.new_local_exit_root,
-            commit_imported_bridge_exits: ImportedBridgeExitCommitmentValues {
-                claims: certificate
-                    .imported_bridge_exits
-                    .iter()
-                    .map(|exit| exit.to_indexed_exit_hash())
-                    .collect(),
-            },
-            height: certificate.height.as_u64(),
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Version {
+    V0,
+    V1,
+}
+
+impl Version {
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Self::V0 => 0,
+            Self::V1 => 1,
         }
     }
 }

--- a/crates/agglayer-types/src/certificate/testutils.rs
+++ b/crates/agglayer-types/src/certificate/testutils.rs
@@ -6,7 +6,15 @@ use unified_bridge::{
     NetworkId,
 };
 
-use crate::{Certificate, Digest, Height};
+use crate::{certificate::VersionFields, Certificate, Digest, Height, Metadata};
+
+impl Default for VersionFields {
+    fn default() -> Self {
+        Self::V0(crate::certificate::v0::FieldsV0 {
+            metadata: Default::default(),
+        })
+    }
+}
 
 impl Default for Certificate {
     fn default() -> Self {
@@ -26,9 +34,9 @@ impl Default for Certificate {
             bridge_exits: Default::default(),
             imported_bridge_exits: Default::default(),
             aggchain_data: AggchainData::ECDSA { signature },
-            metadata: Default::default(),
             custom_chain_data: vec![],
             l1_info_tree_leaf_count: None,
+            extra_fields: Default::default(),
         }
     }
 }
@@ -96,14 +104,26 @@ impl Certificate {
             bridge_exits: Default::default(),
             imported_bridge_exits: Default::default(),
             aggchain_data: AggchainData::ECDSA { signature },
-            metadata: Default::default(),
             custom_chain_data: vec![],
             l1_info_tree_leaf_count: None,
+            extra_fields: Default::default(),
         }
     }
 
     pub fn with_new_local_exit_root(mut self, new_local_exit_root: LocalExitRoot) -> Self {
         self.new_local_exit_root = new_local_exit_root;
+        self
+    }
+
+    pub fn metadata_or_default(&self) -> &Metadata {
+        self.metadata().unwrap_or(&Metadata::ZERO)
+    }
+
+    pub fn with_metadata(mut self, metadata: Metadata) -> Self {
+        match &mut self.extra_fields {
+            VersionFields::V0(fields) => fields.metadata = metadata,
+            _ => panic!("Setting metadata on an unsupported certificate version"),
+        };
         self
     }
 }

--- a/crates/agglayer-types/src/certificate/v0.rs
+++ b/crates/agglayer-types/src/certificate/v0.rs
@@ -48,7 +48,7 @@ pub struct CertificateV0 {
 
 impl CertificateV0 {
     #[inline]
-    pub fn fields(&self) -> Fields {
+    pub fn fields(&self) -> Fields<'_> {
         Fields {
             version: Version::V0,
             network_id: self.network_id,

--- a/crates/agglayer-types/src/certificate/v0.rs
+++ b/crates/agglayer-types/src/certificate/v0.rs
@@ -1,0 +1,106 @@
+use agglayer_interop_types::{aggchain_proof::AggchainData, LocalExitRoot};
+use agglayer_primitives::{Address, Signature};
+use unified_bridge::{BridgeExit, CommitmentVersion, ImportedBridgeExit, NetworkId};
+
+use crate::{
+    certificate::{common, CertificateId, Fields, Height, Metadata, Version},
+    Digest, Error, SignerError,
+};
+
+/// Represents the data submitted by the chains to the AggLayer.
+///
+/// The bridge exits plus the imported bridge exits define
+/// the state transition, resp. the amount that goes out and the amount that
+/// comes in.
+///
+/// The bridge exits refer to the [`BridgeExit`] emitted by
+/// the origin network of the [`Certificate`].
+///
+/// The imported bridge exits refer to the [`BridgeExit`] received and imported
+/// by the origin network of the [`Certificate`].
+///
+/// Note: be mindful to update the [`Self::hash`] method accordingly
+/// upon modifying the fields of this structure.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct CertificateV0 {
+    /// NetworkID of the origin network.
+    pub network_id: NetworkId,
+    /// Simple increment to count the Certificate per network.
+    pub height: Height,
+    /// Previous local exit root.
+    pub prev_local_exit_root: LocalExitRoot,
+    /// New local exit root.
+    pub new_local_exit_root: LocalExitRoot,
+    /// List of bridge exits included in this state transition.
+    pub bridge_exits: Vec<BridgeExit>,
+    /// List of imported bridge exits included in this state transition.
+    pub imported_bridge_exits: Vec<ImportedBridgeExit>,
+    /// Fixed size field of arbitrary data for the chain needs.
+    pub metadata: Metadata,
+    /// Aggchain data which is either one ECDSA or Generic proof.
+    #[serde(flatten)]
+    pub aggchain_data: AggchainData,
+    #[serde(default)]
+    pub custom_chain_data: Vec<u8>,
+    #[serde(default)]
+    pub l1_info_tree_leaf_count: Option<u32>,
+}
+
+impl CertificateV0 {
+    #[inline]
+    pub fn fields(&self) -> Fields {
+        Fields {
+            version: Version::V0,
+            network_id: self.network_id,
+            height: self.height,
+            prev_local_exit_root: &self.prev_local_exit_root,
+            new_local_exit_root: &self.new_local_exit_root,
+            bridge_exits: &self.bridge_exits,
+            imported_bridge_exits: &self.imported_bridge_exits,
+            aggchain_data: &self.aggchain_data,
+            l1_info_tree_leaf_count: self.l1_info_tree_leaf_count,
+        }
+    }
+
+    pub fn hash(&self) -> CertificateId {
+        self.fields().hash([self.metadata.as_slice()])
+    }
+
+    /// Returns the L1 Info Tree leaf count considered for this [`Certificate`].
+    /// Corresponds to the highest L1 Info Tree leaf index considered by the
+    /// imported bridge exits.
+    pub fn l1_info_tree_leaf_count(&self) -> Option<u32> {
+        self.fields().l1_info_tree_leaf_count()
+    }
+
+    /// Returns the L1 Info Root considered for this [`Certificate`].
+    /// Fails if multiple L1 Info Root are considered among the inclusion proofs
+    /// of the imported bridge exits.
+    pub fn l1_info_root(&self) -> Result<Option<Digest>, Error> {
+        self.fields().l1_info_root()
+    }
+
+    /// Verify the extra certificate signature.
+    pub fn verify_extra_signature(
+        &self,
+        expected_signer: Address,
+        signature: Signature,
+    ) -> Result<(), SignerError> {
+        common::verify_extra_signature(
+            self.hash(),
+            self.l1_info_tree_leaf_count,
+            expected_signer,
+            signature,
+        )
+    }
+
+    /// Verify the signature on the PP commitment.
+    pub fn verify_cert_signature(&self, expected_signer: Address) -> Result<(), SignerError> {
+        self.fields().verify_cert_signature(expected_signer)
+    }
+
+    /// Retrieve the signer from the certificate signature.
+    pub fn retrieve_signer(&self, version: CommitmentVersion) -> Result<Address, SignerError> {
+        self.fields().retrieve_signer(version)
+    }
+}

--- a/crates/agglayer-types/src/certificate/v0.rs
+++ b/crates/agglayer-types/src/certificate/v0.rs
@@ -1,106 +1,12 @@
-use agglayer_interop_types::{aggchain_proof::AggchainData, LocalExitRoot};
-use agglayer_primitives::{Address, Signature};
-use unified_bridge::{BridgeExit, CommitmentVersion, ImportedBridgeExit, NetworkId};
+use crate::certificate::Metadata;
 
-use crate::{
-    certificate::{common, CertificateId, Fields, Height, Metadata, Version},
-    Digest, Error, SignerError,
-};
-
-/// Represents the data submitted by the chains to the AggLayer.
-///
-/// The bridge exits plus the imported bridge exits define
-/// the state transition, resp. the amount that goes out and the amount that
-/// comes in.
-///
-/// The bridge exits refer to the [`BridgeExit`] emitted by
-/// the origin network of the [`Certificate`].
-///
-/// The imported bridge exits refer to the [`BridgeExit`] received and imported
-/// by the origin network of the [`Certificate`].
-///
-/// Note: be mindful to update the [`Self::hash`] method accordingly
-/// upon modifying the fields of this structure.
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct CertificateV0 {
-    /// NetworkID of the origin network.
-    pub network_id: NetworkId,
-    /// Simple increment to count the Certificate per network.
-    pub height: Height,
-    /// Previous local exit root.
-    pub prev_local_exit_root: LocalExitRoot,
-    /// New local exit root.
-    pub new_local_exit_root: LocalExitRoot,
-    /// List of bridge exits included in this state transition.
-    pub bridge_exits: Vec<BridgeExit>,
-    /// List of imported bridge exits included in this state transition.
-    pub imported_bridge_exits: Vec<ImportedBridgeExit>,
-    /// Fixed size field of arbitrary data for the chain needs.
+/// Fields specific to v0 certificate.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct FieldsV0 {
     pub metadata: Metadata,
-    /// Aggchain data which is either one ECDSA or Generic proof.
-    #[serde(flatten)]
-    pub aggchain_data: AggchainData,
-    #[serde(default)]
-    pub custom_chain_data: Vec<u8>,
-    #[serde(default)]
-    pub l1_info_tree_leaf_count: Option<u32>,
 }
 
-impl CertificateV0 {
-    #[inline]
-    pub fn fields(&self) -> Fields<'_> {
-        Fields {
-            version: Version::V0,
-            network_id: self.network_id,
-            height: self.height,
-            prev_local_exit_root: &self.prev_local_exit_root,
-            new_local_exit_root: &self.new_local_exit_root,
-            bridge_exits: &self.bridge_exits,
-            imported_bridge_exits: &self.imported_bridge_exits,
-            aggchain_data: &self.aggchain_data,
-            l1_info_tree_leaf_count: self.l1_info_tree_leaf_count,
-        }
-    }
-
-    pub fn hash(&self) -> CertificateId {
-        self.fields().hash([self.metadata.as_slice()])
-    }
-
-    /// Returns the L1 Info Tree leaf count considered for this [`Certificate`].
-    /// Corresponds to the highest L1 Info Tree leaf index considered by the
-    /// imported bridge exits.
-    pub fn l1_info_tree_leaf_count(&self) -> Option<u32> {
-        self.fields().l1_info_tree_leaf_count()
-    }
-
-    /// Returns the L1 Info Root considered for this [`Certificate`].
-    /// Fails if multiple L1 Info Root are considered among the inclusion proofs
-    /// of the imported bridge exits.
-    pub fn l1_info_root(&self) -> Result<Option<Digest>, Error> {
-        self.fields().l1_info_root()
-    }
-
-    /// Verify the extra certificate signature.
-    pub fn verify_extra_signature(
-        &self,
-        expected_signer: Address,
-        signature: Signature,
-    ) -> Result<(), SignerError> {
-        common::verify_extra_signature(
-            self.hash(),
-            self.l1_info_tree_leaf_count,
-            expected_signer,
-            signature,
-        )
-    }
-
-    /// Verify the signature on the PP commitment.
-    pub fn verify_cert_signature(&self, expected_signer: Address) -> Result<(), SignerError> {
-        self.fields().verify_cert_signature(expected_signer)
-    }
-
-    /// Retrieve the signer from the certificate signature.
-    pub fn retrieve_signer(&self, version: CommitmentVersion) -> Result<Address, SignerError> {
-        self.fields().retrieve_signer(version)
-    }
+impl FieldsV0 {
+    // Empty for backwards compatibility
+    pub const ID_PREIMAGE_PREFIX: &[u8] = &[];
 }

--- a/crates/agglayer-types/src/certificate/v1.rs
+++ b/crates/agglayer-types/src/certificate/v1.rs
@@ -1,0 +1,105 @@
+use agglayer_interop_types::{aggchain_proof::AggchainData, LocalExitRoot};
+use agglayer_primitives::{Address, Signature};
+use unified_bridge::{BridgeExit, CommitmentVersion, ImportedBridgeExit, NetworkId};
+
+use crate::{
+    certificate::{common, CertificateId, Fields, Height, Version},
+    Digest, Error, SignerError,
+};
+
+/// Represents the data submitted by the chains to the AggLayer.
+///
+/// The bridge exits plus the imported bridge exits define
+/// the state transition, resp. the amount that goes out and the amount that
+/// comes in.
+///
+/// The bridge exits refer to the [`BridgeExit`] emitted by
+/// the origin network of the [`Certificate`].
+///
+/// The imported bridge exits refer to the [`BridgeExit`] received and imported
+/// by the origin network of the [`Certificate`].
+///
+/// Note: be mindful to update the [`Self::hash`] method accordingly
+/// upon modifying the fields of this structure.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct CertificateV1 {
+    /// NetworkID of the origin network.
+    pub network_id: NetworkId,
+    /// Simple increment to count the Certificate per network.
+    pub height: Height,
+    /// Previous local exit root.
+    pub prev_local_exit_root: LocalExitRoot,
+    /// New local exit root.
+    pub new_local_exit_root: LocalExitRoot,
+    /// List of bridge exits included in this state transition.
+    pub bridge_exits: Vec<BridgeExit>,
+    /// List of imported bridge exits included in this state transition.
+    pub imported_bridge_exits: Vec<ImportedBridgeExit>,
+    //pub metadata: Metadata,  // removed
+    /// Aggchain data which is either one ECDSA or Generic proof.
+    #[serde(flatten)]
+    pub aggchain_data: AggchainData,
+    #[serde(default)]
+    pub custom_chain_data: Vec<u8>,
+    #[serde(default)]
+    pub l1_info_tree_leaf_count: Option<u32>,
+}
+
+impl CertificateV1 {
+    #[inline]
+    pub fn fields(&self) -> Fields {
+        Fields {
+            version: Version::V0,
+            network_id: self.network_id,
+            height: self.height,
+            prev_local_exit_root: &self.prev_local_exit_root,
+            new_local_exit_root: &self.new_local_exit_root,
+            bridge_exits: &self.bridge_exits,
+            imported_bridge_exits: &self.imported_bridge_exits,
+            aggchain_data: &self.aggchain_data,
+            l1_info_tree_leaf_count: self.l1_info_tree_leaf_count,
+        }
+    }
+
+    pub fn hash(&self) -> CertificateId {
+        self.fields().hash([])
+    }
+
+    /// Returns the L1 Info Tree leaf count considered for this [`Certificate`].
+    /// Corresponds to the highest L1 Info Tree leaf index considered by the
+    /// imported bridge exits.
+    pub fn l1_info_tree_leaf_count(&self) -> Option<u32> {
+        self.fields().l1_info_tree_leaf_count()
+    }
+
+    /// Returns the L1 Info Root considered for this [`Certificate`].
+    /// Fails if multiple L1 Info Root are considered among the inclusion proofs
+    /// of the imported bridge exits.
+    pub fn l1_info_root(&self) -> Result<Option<Digest>, Error> {
+        self.fields().l1_info_root()
+    }
+
+    /// Verify the extra certificate signature.
+    pub fn verify_extra_signature(
+        &self,
+        expected_signer: Address,
+        signature: Signature,
+    ) -> Result<(), SignerError> {
+        common::verify_extra_signature(
+            self.hash(),
+            self.l1_info_tree_leaf_count,
+            expected_signer,
+            signature,
+        )
+    }
+
+    /// Verify the signature on the PP commitment.
+    pub fn verify_cert_signature(&self, expected_signer: Address) -> Result<(), SignerError> {
+        self.fields().verify_cert_signature(expected_signer)
+    }
+
+    /// Retrieve the signer from the certificate signature.
+    pub fn retrieve_signer(&self, version: CommitmentVersion) -> Result<Address, SignerError> {
+        self.fields().retrieve_signer(version)
+    }
+}

--- a/crates/agglayer-types/src/certificate/v1.rs
+++ b/crates/agglayer-types/src/certificate/v1.rs
@@ -1,105 +1,11 @@
-use agglayer_interop_types::{aggchain_proof::AggchainData, LocalExitRoot};
-use agglayer_primitives::{Address, Signature};
-use unified_bridge::{BridgeExit, CommitmentVersion, ImportedBridgeExit, NetworkId};
+use alloy::primitives::hex;
 
-use crate::{
-    certificate::{common, CertificateId, Fields, Height, Version},
-    Digest, Error, SignerError,
-};
+/// Fields specific to v1 certificate.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct FieldsV1 {}
 
-/// Represents the data submitted by the chains to the AggLayer.
-///
-/// The bridge exits plus the imported bridge exits define
-/// the state transition, resp. the amount that goes out and the amount that
-/// comes in.
-///
-/// The bridge exits refer to the [`BridgeExit`] emitted by
-/// the origin network of the [`Certificate`].
-///
-/// The imported bridge exits refer to the [`BridgeExit`] received and imported
-/// by the origin network of the [`Certificate`].
-///
-/// Note: be mindful to update the [`Self::hash`] method accordingly
-/// upon modifying the fields of this structure.
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct CertificateV1 {
-    /// NetworkID of the origin network.
-    pub network_id: NetworkId,
-    /// Simple increment to count the Certificate per network.
-    pub height: Height,
-    /// Previous local exit root.
-    pub prev_local_exit_root: LocalExitRoot,
-    /// New local exit root.
-    pub new_local_exit_root: LocalExitRoot,
-    /// List of bridge exits included in this state transition.
-    pub bridge_exits: Vec<BridgeExit>,
-    /// List of imported bridge exits included in this state transition.
-    pub imported_bridge_exits: Vec<ImportedBridgeExit>,
-    //pub metadata: Metadata,  // removed
-    /// Aggchain data which is either one ECDSA or Generic proof.
-    #[serde(flatten)]
-    pub aggchain_data: AggchainData,
-    #[serde(default)]
-    pub custom_chain_data: Vec<u8>,
-    #[serde(default)]
-    pub l1_info_tree_leaf_count: Option<u32>,
-}
-
-impl CertificateV1 {
-    #[inline]
-    pub fn fields(&self) -> Fields<'_> {
-        Fields {
-            version: Version::V0,
-            network_id: self.network_id,
-            height: self.height,
-            prev_local_exit_root: &self.prev_local_exit_root,
-            new_local_exit_root: &self.new_local_exit_root,
-            bridge_exits: &self.bridge_exits,
-            imported_bridge_exits: &self.imported_bridge_exits,
-            aggchain_data: &self.aggchain_data,
-            l1_info_tree_leaf_count: self.l1_info_tree_leaf_count,
-        }
-    }
-
-    pub fn hash(&self) -> CertificateId {
-        self.fields().hash([])
-    }
-
-    /// Returns the L1 Info Tree leaf count considered for this [`Certificate`].
-    /// Corresponds to the highest L1 Info Tree leaf index considered by the
-    /// imported bridge exits.
-    pub fn l1_info_tree_leaf_count(&self) -> Option<u32> {
-        self.fields().l1_info_tree_leaf_count()
-    }
-
-    /// Returns the L1 Info Root considered for this [`Certificate`].
-    /// Fails if multiple L1 Info Root are considered among the inclusion proofs
-    /// of the imported bridge exits.
-    pub fn l1_info_root(&self) -> Result<Option<Digest>, Error> {
-        self.fields().l1_info_root()
-    }
-
-    /// Verify the extra certificate signature.
-    pub fn verify_extra_signature(
-        &self,
-        expected_signer: Address,
-        signature: Signature,
-    ) -> Result<(), SignerError> {
-        common::verify_extra_signature(
-            self.hash(),
-            self.l1_info_tree_leaf_count,
-            expected_signer,
-            signature,
-        )
-    }
-
-    /// Verify the signature on the PP commitment.
-    pub fn verify_cert_signature(&self, expected_signer: Address) -> Result<(), SignerError> {
-        self.fields().verify_cert_signature(expected_signer)
-    }
-
-    /// Retrieve the signer from the certificate signature.
-    pub fn retrieve_signer(&self, version: CommitmentVersion) -> Result<Address, SignerError> {
-        self.fields().retrieve_signer(version)
-    }
+impl FieldsV1 {
+    // The original position of network ID and height plugged with
+    // all ones, followed by two-byte version,
+    pub const ID_PREIMAGE_PREFIX: &[u8] = &hex!("FFFFFFFF FFFFFFFFFFFFFFFF 0001");
 }

--- a/crates/agglayer-types/src/certificate/v1.rs
+++ b/crates/agglayer-types/src/certificate/v1.rs
@@ -47,7 +47,7 @@ pub struct CertificateV1 {
 
 impl CertificateV1 {
     #[inline]
-    pub fn fields(&self) -> Fields {
+    pub fn fields(&self) -> Fields<'_> {
         Fields {
             version: Version::V0,
             network_id: self.network_id,

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -12,8 +12,8 @@ mod proof_modes;
 #[cfg(feature = "testutils")]
 pub use certificate::compute_signature_info;
 pub use certificate::{
-    Certificate, CertificateHeader, CertificateId, CertificateIndex, CertificateStatus, Height,
-    Metadata, SettlementTxHash,
+    Certificate, CertificateHeader, CertificateId, CertificateIndex, CertificateStatus,
+    CertificateV0, CertificateV1, CertificateVx, Height, Metadata, SettlementTxHash,
 };
 pub use epoch::{EpochConfiguration, EpochNumber};
 pub use error::{CertificateStatusError, Error, SignerError};

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -12,8 +12,8 @@ mod proof_modes;
 #[cfg(feature = "testutils")]
 pub use certificate::compute_signature_info;
 pub use certificate::{
-    Certificate, CertificateHeader, CertificateId, CertificateIndex, CertificateStatus,
-    CertificateV0, CertificateV1, CertificateVx, Height, Metadata, SettlementTxHash,
+    Certificate, CertificateHeader, CertificateId, CertificateIndex, CertificateStatus, FieldsV0,
+    FieldsV1, Height, Metadata, SettlementTxHash, VersionFields,
 };
 pub use epoch::{EpochConfiguration, EpochNumber};
 pub use error::{CertificateStatusError, Error, SignerError};

--- a/crates/pessimistic-proof-test-suite/src/forest.rs
+++ b/crates/pessimistic-proof-test-suite/src/forest.rs
@@ -8,7 +8,6 @@ use agglayer_types::{
 use alloy::signers::{local::PrivateKeySigner, SignerSync};
 use ecdsa_proof_lib::AggchainECDSA;
 use pessimistic_proof::{
-    core::commitment::SignatureCommitmentValues,
     keccak::keccak256_combine,
     local_exit_tree::{data::LocalExitTreeData, LocalExitTree},
     local_state::LocalNetworkState,
@@ -266,7 +265,9 @@ impl Forest {
             compute_aggchain_proof(AggchainECDSA {
                 signer: certificate.retrieve_signer(CommitmentVersion::V2).unwrap(),
                 signature,
-                commit_imported_bridge_exits: SignatureCommitmentValues::from(&certificate)
+                commit_imported_bridge_exits: certificate
+                    .fields()
+                    .signature_commitment_values()
                     .commitment(CommitmentVersion::V2)
                     .0,
                 prev_local_exit_root: certificate.prev_local_exit_root,

--- a/crates/pessimistic-proof-test-suite/src/forest.rs
+++ b/crates/pessimistic-proof-test-suite/src/forest.rs
@@ -8,6 +8,7 @@ use agglayer_types::{
 use alloy::signers::{local::PrivateKeySigner, SignerSync};
 use ecdsa_proof_lib::AggchainECDSA;
 use pessimistic_proof::{
+    core::commitment::SignatureCommitmentValues,
     keccak::keccak256_combine,
     local_exit_tree::{data::LocalExitTreeData, LocalExitTree},
     local_state::LocalNetworkState,
@@ -221,9 +222,9 @@ impl Forest {
             bridge_exits,
             imported_bridge_exits,
             aggchain_data: AggchainData::ECDSA { signature },
-            metadata: Default::default(),
             custom_chain_data: vec![],
             l1_info_tree_leaf_count: None,
+            extra_fields: Default::default(),
         }
     }
 
@@ -265,9 +266,7 @@ impl Forest {
             compute_aggchain_proof(AggchainECDSA {
                 signer: certificate.retrieve_signer(CommitmentVersion::V2).unwrap(),
                 signature,
-                commit_imported_bridge_exits: certificate
-                    .fields()
-                    .signature_commitment_values()
+                commit_imported_bridge_exits: SignatureCommitmentValues::from(&certificate)
                     .commitment(CommitmentVersion::V2)
                     .0,
                 prev_local_exit_root: certificate.prev_local_exit_root,


### PR DESCRIPTION
Versioning mechanism for the `Certificate` structure. Will allow handling of multiple certificate versions with different features. Also makes it possible to evolve the way in which `CertificateId` is calculated.
