### PR TITLE
build(deps): update `slab` in the pessimisitc proof

### DIFF
--- a/crates/pessimistic-proof-program/Cargo.lock
+++ b/crates/pessimistic-proof-program/Cargo.lock
@@ -4233,9 +4233,9 @@ checksum = "9fed904c7fb2856d868b92464fc8fa597fce366edea1a9cbfaa8cb5fe080bd6d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
Fixes https://rustsec.org/advisories/RUSTSEC-2025-0047