### PR TITLE
feat: remove extra certificate signer

### DIFF
--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -125,14 +125,6 @@ pub struct Config {
 
     #[serde(default, skip_serializing_if = "crate::is_default")]
     pub grpc: GrpcConfig,
-
-    /// Extra Certificate signer per network.
-    /// Signatures is expected to be performed on the same commitment as
-    /// the certificate signature, which is the V2 commitment for now.
-    #[serde(default)]
-    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub extra_certificate_signer: HashMap<u32, Address>,
 }
 
 impl Config {
@@ -185,7 +177,6 @@ impl Config {
             debug_mode: false,
             mock_verifier: false,
             grpc: Default::default(),
-            extra_certificate_signer: Default::default(),
         }
     }
 

--- a/crates/agglayer-config/tests/fixtures/valide_config/extra_certificate_signers.toml
+++ b/crates/agglayer-config/tests/fixtures/valide_config/extra_certificate_signers.toml
@@ -1,2 +1,0 @@
-[extra-certificate-signer]
-1337 = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__extra_certificate_signers.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__extra_certificate_signers.snap
@@ -64,6 +64,3 @@ input-backpressure-buffer-size = 1000
 
 [storage]
 db-path = "./storage"
-
-[extra-certificate-signer]
-1337 = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"

--- a/crates/agglayer-config/tests/validate_deserialize.rs
+++ b/crates/agglayer-config/tests/validate_deserialize.rs
@@ -89,31 +89,3 @@ fn prover_grpc_max_decoding_message_size() {
 
     assert_eq!(config.grpc.max_decoding_message_size, 100 * 1024 * 1024);
 }
-
-#[test]
-fn extra_certificate_signers() {
-    let input = "./tests/fixtures/valide_config/extra_certificate_signers.toml";
-
-    let config: Config = toml::from_str(&std::fs::read_to_string(input).unwrap()).unwrap();
-
-    assert_toml_snapshot!(config, {
-        ".storage.*" => insta::dynamic_redaction(|value, path| {
-            if path.to_string() != "storage.db-path" {
-                if let insta::internals::Content::String(path) = value {
-                    return insta::internals::Content::String(path.replace(Path::new("./").canonicalize().unwrap().to_str().unwrap(), "/tmp/agglayer"));
-                }
-            }
-
-            value
-        }),
-    });
-
-    assert_eq!(
-        *config
-            .extra_certificate_signer
-            .get(&1337)
-            .unwrap()
-            .into_alloy(),
-        alloy_primitives::address!("abcdefabcdefabcdefabcdefabcdefabcdefabcd").0
-    );
-}

--- a/crates/agglayer-grpc-api/src/certificate_submission_service/mod.rs
+++ b/crates/agglayer-grpc-api/src/certificate_submission_service/mod.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use agglayer_contracts::{L1TransactionFetcher, RollupContract};
 use agglayer_grpc_server::node::v1::certificate_submission_service_server::CertificateSubmissionService;
@@ -10,14 +10,9 @@ use agglayer_storage::stores::{
     DebugReader, DebugWriter, PendingCertificateReader, PendingCertificateWriter, StateReader,
     StateWriter,
 };
-use agglayer_types::Signature;
 use error::CertificateSubmissionErrorWrapper;
-use tonic::Status;
 use tonic_types::{ErrorDetails, StatusExt};
 use tracing::instrument;
-
-const GRPC_METADATA_NAME_EXTRA_CERTIFICATE_SIGNATURE: &str =
-    "x-agglayer-extra-certificate-signature";
 
 const SUBMIT_CERTIFICATE_METHOD_PATH: &str =
     "agglayer-node.grpc-api.v1.certificate-submission-service.submit_certificate";
@@ -42,10 +37,6 @@ where
         &self,
         request: tonic::Request<SubmitCertificateRequest>,
     ) -> Result<tonic::Response<SubmitCertificateResponse>, tonic::Status> {
-        // Retrieve extra signature from query metadata if any
-        let extra_signature: Option<Signature> =
-            get_extra_signature(request.metadata()).map_err(|e| *e)?;
-
         let certificate: agglayer_types::Certificate = match request.into_inner().certificate {
             Some(certificate) => certificate.try_into().map_err(
                 |error: agglayer_grpc_types::compat::v1::Error| {
@@ -65,7 +56,7 @@ where
 
         let certificate_id = self
             .service
-            .send_certificate(certificate, extra_signature)
+            .send_certificate(certificate)
             .await
             .map_err(|error| {
                 CertificateSubmissionErrorWrapper::new(error, SUBMIT_CERTIFICATE_METHOD_PATH)
@@ -74,61 +65,5 @@ where
         Ok(tonic::Response::new(SubmitCertificateResponse {
             certificate_id: Some(certificate_id.into()),
         }))
-    }
-}
-
-pub(crate) fn get_extra_signature(
-    metadata: &tonic::metadata::MetadataMap,
-) -> Result<Option<Signature>, Box<Status>> {
-    if let Some(value) = metadata.get(GRPC_METADATA_NAME_EXTRA_CERTIFICATE_SIGNATURE) {
-        let sig_str = value.to_str().map_err(|e| {
-            tonic::Status::invalid_argument(format!("invalid signature encoding: {e}"))
-        })?;
-
-        let sig = Signature::from_str(sig_str).map_err(|e| {
-            tonic::Status::invalid_argument(format!("invalid hex in signature: {e}"))
-        })?;
-
-        Ok(Some(sig))
-    } else {
-        Ok(None)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use agglayer_types::{
-        aggchain_proof::AggchainData, primitives::alloy_primitives::hex, Certificate, Height,
-        NetworkId,
-    };
-    use rstest::rstest;
-
-    use super::{get_extra_signature, GRPC_METADATA_NAME_EXTRA_CERTIFICATE_SIGNATURE};
-
-    #[rstest]
-    #[case("0x")]
-    #[case("")]
-    fn parse_query_metadata(#[case] prefix: String) {
-        let mut metadata = tonic::metadata::MetadataMap::new();
-
-        let expected_signature = {
-            let cert = Certificate::new_for_test(NetworkId::new(10), Height::new(1));
-            let AggchainData::ECDSA { signature } = cert.aggchain_data else {
-                panic!("dummy test certificate changed")
-            };
-
-            signature
-        };
-
-        metadata.insert(
-            GRPC_METADATA_NAME_EXTRA_CERTIFICATE_SIGNATURE,
-            format!("{prefix}{}", hex::encode(expected_signature.as_bytes()))
-                .parse()
-                .unwrap(),
-        );
-
-        assert!(
-            matches!(get_extra_signature(&metadata), Ok(Some(signature)) if signature == expected_signature)
-        );
     }
 }

--- a/crates/agglayer-jsonrpc-api/src/lib.rs
+++ b/crates/agglayer-jsonrpc-api/src/lib.rs
@@ -204,13 +204,7 @@ where
     }
 
     async fn send_certificate(&self, certificate: Certificate) -> RpcResult<CertificateId> {
-        // NOTE: Extra certificate signature is not supported on the json rpc api
-        let extra_signature = None;
-
-        Ok(self
-            .rpc_service
-            .send_certificate(certificate, extra_signature)
-            .await?)
+        Ok(self.rpc_service.send_certificate(certificate).await?)
     }
 
     async fn get_certificate_header(

--- a/crates/agglayer-rpc/src/error.rs
+++ b/crates/agglayer-rpc/src/error.rs
@@ -72,17 +72,6 @@ pub enum SignatureVerificationError {
     #[error("signature not provided")]
     SignatureMissing,
 
-    /// Extra Certificate signature is missing for the given network.
-    #[error("missing extra signature from {expected_signer} for the network {network_id}")]
-    MissingExtraSignature {
-        network_id: NetworkId,
-        expected_signer: Address,
-    },
-
-    /// The extra signature is invalid.
-    #[error("invalid extra signature: {0}")]
-    InvalidExtraSignature(#[source] SignerError),
-
     /// The pessimistic proof signature is invalid.
     #[error("invalid pessimistic proof signature: {0}")]
     InvalidPessimisticProofSignature(#[source] SignerError),
@@ -93,9 +82,6 @@ impl SignatureVerificationError {
         match e {
             agglayer_types::SignerError::Missing => Self::SignatureMissing,
             e @ agglayer_types::SignerError::Recovery(_) => Self::CouldNotRecoverCertSigner(e),
-            e @ agglayer_types::SignerError::InvalidExtraSignature { .. } => {
-                Self::InvalidExtraSignature(e)
-            }
             e @ agglayer_types::SignerError::InvalidPessimisticProofSignature { .. } => {
                 Self::InvalidPessimisticProofSignature(e)
             }

--- a/crates/agglayer-rpc/src/lib.rs
+++ b/crates/agglayer-rpc/src/lib.rs
@@ -11,8 +11,8 @@ use agglayer_storage::{
     },
 };
 use agglayer_types::{
-    Address, Certificate, CertificateHeader, CertificateId, CertificateStatus, EpochConfiguration,
-    Height, NetworkId, Signature,
+    Certificate, CertificateHeader, CertificateId, CertificateStatus, EpochConfiguration, Height,
+    NetworkId,
 };
 use error::SignatureVerificationError;
 use tokio::sync::mpsc;
@@ -328,42 +328,10 @@ where
             .map_err(SignatureVerificationError::from_signer_error)
     }
 
-    /// Verify the extra [`Certificate`] signature.
-    #[instrument(skip_all, level = "debug")]
-    pub(crate) fn verify_extra_cert_signature(
-        &self,
-        certificate: &Certificate,
-        extra_signer: Option<&Address>,
-        extra_signature: Option<Signature>,
-    ) -> Result<(), SignatureVerificationError> {
-        match (extra_signer, extra_signature) {
-            // Extra signature expected and provided
-            (Some(&expected_extra_signer), Some(extra_signature)) => certificate
-                .verify_extra_signature(expected_extra_signer, extra_signature)
-                .map_err(SignatureVerificationError::from_signer_error)?,
-            // Extra signature is expected but missing
-            (Some(&expected_signer), None) => {
-                return Err(SignatureVerificationError::MissingExtraSignature {
-                    network_id: certificate.network_id,
-                    expected_signer,
-                });
-            }
-            // Extra signature provided but not required
-            (None, Some(_)) => {
-                warn!("Unexpected extra signature provided");
-            }
-            // No extra signature provided nor required
-            (None, None) => {}
-        };
-
-        Ok(())
-    }
-
     #[instrument(skip(self, certificate), fields(hash, rollup_id = certificate.network_id.to_u32()), level = "info")]
     pub async fn send_certificate(
         &self,
         certificate: Certificate,
-        extra_signature: Option<Signature>,
     ) -> Result<CertificateId, CertificateSubmissionError> {
         let hash = certificate.hash();
         let hash_string = hash.to_string();
@@ -374,22 +342,6 @@ where
             "Received certificate {hash} for rollup {} at height {}", certificate.network_id.to_u32(), certificate.height
         );
         self.validate_pre_existing_certificate(&certificate).await?;
-
-        // Verify the extra certificate signature
-        self.verify_extra_cert_signature(
-            &certificate,
-            self.config()
-                .extra_certificate_signer
-                .get(&certificate.network_id.to_u32()),
-            extra_signature,
-        )
-        .map_err(|error| {
-            error!(
-                ?error,
-                "Failed to verify the extra signature for the certificate"
-            );
-            CertificateSubmissionError::SignatureError(error)
-        })?;
 
         // Verify the certificate signature
         self.verify_cert_signature(&certificate)

--- a/crates/agglayer-types/src/certificate/mod.rs
+++ b/crates/agglayer-types/src/certificate/mod.rs
@@ -1,5 +1,5 @@
 use agglayer_interop_types::{aggchain_proof::AggchainData, LocalExitRoot};
-use agglayer_primitives::{Address, Hashable, Signature, B256};
+use agglayer_primitives::{Address, Hashable, B256};
 use pessimistic_proof::{core::commitment::SignatureCommitmentValues, keccak::keccak256_combine};
 use unified_bridge::{
     BridgeExit, CommitmentVersion, ImportedBridgeExit, ImportedBridgeExitCommitmentValues,
@@ -114,39 +114,6 @@ impl Certificate {
         } else {
             Err(Error::MultipleL1InfoRoot)
         }
-    }
-
-    /// Computes the commitment used to verify the extra signature on the
-    /// agglayer only.
-    /// The commitment is expected to be on the certificate id and the optional
-    /// l1 info tree leaf count.
-    fn extra_signature_commitment(&self) -> Digest {
-        let certificate_id = self.hash();
-
-        match self.l1_info_tree_leaf_count {
-            Some(leaf_count) => keccak256_combine([
-                certificate_id.as_digest().as_slice(),
-                leaf_count.to_le_bytes().as_slice(),
-            ]),
-            None => *certificate_id,
-        }
-    }
-
-    /// Verify the extra certificate signature.
-    pub fn verify_extra_signature(
-        &self,
-        expected_signer: Address,
-        signature: Signature,
-    ) -> Result<(), SignerError> {
-        let expected_commitment = self.extra_signature_commitment();
-
-        let retrieved_signer = signature
-            .recover_address_from_prehash(&B256::new(expected_commitment.0))
-            .map_err(SignerError::Recovery)?;
-
-        (expected_signer == retrieved_signer)
-            .then_some(())
-            .ok_or(SignerError::InvalidExtraSignature { expected_signer })
     }
 
     /// Verify the signature on the PP commitment.

--- a/crates/agglayer-types/src/error.rs
+++ b/crates/agglayer-types/src/error.rs
@@ -143,12 +143,6 @@ pub enum SignerError {
     Recovery(#[source] SignatureError),
 
     #[error(
-        "Invalid extra signature either due to wrong signer or commitment. expected signer: \
-         {expected_signer}"
-    )]
-    InvalidExtraSignature { expected_signer: Address },
-
-    #[error(
         "Invalid PP signature either due to wrong signer or commitment. expected signer: \
          {expected_signer}"
     )]


### PR DESCRIPTION
Fixes #923 

CONFIG-CHANGE: Removal of the `[extra-certificate-signer]` config field.

BREAKING-CHANGE: Cannot set an `extra-certificate-signer` anymore,
  feature replaced by the upcoming multisig.
