### PR TITLE
test: fix storage structure snapshot

### DIFF
--- a/crates/agglayer-storage/src/types/certificate/tests/snapshots/agglayer_storage__types__certificate__tests__structure__structure_snapshot.snap
+++ b/crates/agglayer-storage/src/types/certificate/tests/snapshots/agglayer_storage__types__certificate__tests__structure__structure_snapshot.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/agglayer-storage/src/types/certificate/tests/structure.rs
 expression: "&registry"
+snapshot_kind: text
 ---
 {
   "AggchainDataError": {
@@ -13,7 +14,7 @@ expression: "&registry"
       "1": {
         "InvalidMultisig": {
           "NEWTYPE": {
-            "TYPENAME": "MultisigError"
+            "TYPENAME": "agglayer_types::aggchain_data::MultisigEror"
           }
         }
       },
@@ -176,17 +177,24 @@ expression: "&registry"
         "HasInvalidSignature": "UNIT"
       },
       "2": {
-        "UnknownRecoveredSigner": {
+        "HasDuplicateSigner": {
           "STRUCT": [
             {
-              "recovered": {
+              "signer": {
                 "TYPENAME": "agglayer_primitives::Address"
               }
+            }
+          ]
+        }
+      },
+      "3": {
+        "OutOfBoundSignerIndex": {
+          "STRUCT": [
+            {
+              "idx": "U64"
             },
             {
-              "prehash": {
-                "TYPENAME": "agglayer_primitives::Digest"
-              }
+              "total": "U64"
             }
           ]
         }
@@ -670,6 +678,52 @@ expression: "&registry"
           "NEWTYPE": {
             "TYPENAME": "AggchainDataError"
           }
+        }
+      }
+    }
+  },
+  "agglayer_types::aggchain_data::MultisigEror": {
+    "ENUM": {
+      "0": {
+        "UnderThreshold": {
+          "STRUCT": [
+            {
+              "got": "U64"
+            },
+            {
+              "expected": "U64"
+            }
+          ]
+        }
+      },
+      "1": {
+        "InvalidSignature": "UNIT"
+      },
+      "2": {
+        "UnknownRecoveredSigner": {
+          "STRUCT": [
+            {
+              "recovered": {
+                "TYPENAME": "agglayer_primitives::Address"
+              }
+            },
+            {
+              "prehash": {
+                "TYPENAME": "agglayer_primitives::Digest"
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "HasDuplicateSigner": {
+          "STRUCT": [
+            {
+              "signer": {
+                "TYPENAME": "agglayer_primitives::Address"
+              }
+            }
+          ]
         }
       }
     }

--- a/crates/agglayer-types/src/aggchain_data/multisig.rs
+++ b/crates/agglayer-types/src/aggchain_data/multisig.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use crate::aggchain_data::PayloadWithCtx;
 
 #[derive(Clone, Debug, Error, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename = "agglayer_types::aggchain_data::MultisigEror")]
 pub enum MultisigError {
     #[error("Multisig is under the required threshold. got: {got}, expected: {expected}")]
     UnderThreshold { got: usize, expected: usize },


### PR DESCRIPTION
Due to a limitation, the `serde_reflection` crate is not able to deal with multiple types with the same name, even if defined in separate modules. To avoid the name clash, apply `#[serde(rename = _)]` to one of those types.

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
