### PR TITLE
feat: move all dynamic error types to eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
  "agglayer-prover",
  "agglayer-prover-config",
  "agglayer-storage",
- "anyhow",
  "assert_cmd",
  "clap",
+ "color-eyre",
  "dirs",
  "dotenvy",
  "eyre",
@@ -78,7 +78,6 @@ dependencies = [
  "agglayer-storage",
  "agglayer-types",
  "alloy",
- "anyhow",
  "arc-swap",
  "async-trait",
  "eyre",
@@ -107,17 +106,7 @@ dependencies = [
 [[package]]
 name = "agglayer-bincode"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b600f94a636bff0170bd11b2b93f4a7fd305be95bfbaa558e1a9a1f0e6a87bdd"
-dependencies = [
- "bincode",
- "serde",
-]
-
-[[package]]
-name = "agglayer-bincode"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426#74570d8a556ec36336fc06416bc8f8bdf2d88426"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
  "bincode",
  "serde",
@@ -135,7 +124,6 @@ dependencies = [
  "agglayer-test-suite",
  "agglayer-types",
  "alloy",
- "anyhow",
  "arc-swap",
  "async-trait",
  "buildstructor",
@@ -182,7 +170,7 @@ dependencies = [
 name = "agglayer-config"
 version = "0.1.0"
 dependencies = [
- "agglayer-primitives 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-primitives",
  "agglayer-prover-config",
  "agglayer-types",
  "alloy-primitives",
@@ -207,10 +195,10 @@ dependencies = [
 name = "agglayer-contracts"
 version = "0.1.0"
 dependencies = [
- "agglayer-primitives 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-primitives",
  "alloy",
- "anyhow",
  "async-trait",
+ "eyre",
  "fail",
  "hex",
  "num-derive",
@@ -225,24 +213,23 @@ dependencies = [
 [[package]]
 name = "agglayer-elf-build"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426#74570d8a556ec36336fc06416bc8f8bdf2d88426"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
- "anyhow",
  "cargo_metadata",
  "clap",
+ "eyre",
  "sp1-build",
 ]
 
 [[package]]
 name = "agglayer-evm-client"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3136c5a74d075bcba7837b71be64c6486a96ff7e47e92f6d67a631077a55ae1f"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
- "agglayer-primitives 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "agglayer-primitives",
  "alloy",
- "anyhow",
  "async-trait",
+ "eyre",
  "thiserror 2.0.16",
 ]
 
@@ -253,8 +240,8 @@ dependencies = [
  "agglayer-config",
  "alloy",
  "alloy-primitives",
- "anyhow",
  "async-trait",
+ "eyre",
  "gcloud-sdk",
  "serde",
  "thiserror 2.0.16",
@@ -269,13 +256,13 @@ dependencies = [
  "agglayer-grpc-client",
  "agglayer-grpc-server",
  "agglayer-grpc-types",
- "agglayer-interop 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-interop",
  "agglayer-rpc",
  "agglayer-storage",
  "agglayer-types",
  "alloy",
- "anyhow",
  "axum 0.8.4",
+ "eyre",
  "http",
  "prost 0.13.5",
  "rstest",
@@ -310,10 +297,10 @@ dependencies = [
 name = "agglayer-grpc-types"
 version = "0.1.0"
 dependencies = [
- "agglayer-interop 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-interop",
  "agglayer-types",
- "anyhow",
  "bolero",
+ "eyre",
  "hex",
  "insta",
  "pbjson 0.8.0",
@@ -326,43 +313,18 @@ dependencies = [
 [[package]]
 name = "agglayer-interop"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39edcae2dc53474844ff4b83385a0b8648c984319bb50d50b0700a9895503803"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
- "agglayer-interop-grpc-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "agglayer-interop-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "agglayer-interop"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426#74570d8a556ec36336fc06416bc8f8bdf2d88426"
-dependencies = [
- "agglayer-interop-grpc-types 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-interop-types 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-interop-grpc-types",
+ "agglayer-interop-types",
 ]
 
 [[package]]
 name = "agglayer-interop-grpc-types"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99ea508c69dd2a77d58d4832d392d2128990cd3c6ec0addabab101c8b6f7f80"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
- "agglayer-interop-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode",
- "pbjson 0.7.0",
- "prost 0.13.5",
- "serde",
- "thiserror 2.0.16",
- "tonic-types 0.13.1",
-]
-
-[[package]]
-name = "agglayer-interop-grpc-types"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426#74570d8a556ec36336fc06416bc8f8bdf2d88426"
-dependencies = [
- "agglayer-interop-types 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-interop-types",
  "bincode",
  "pbjson 0.7.0",
  "prost 0.13.5",
@@ -374,31 +336,11 @@ dependencies = [
 [[package]]
 name = "agglayer-interop-types"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3765e1cea355ce34e3e0dd824a5e57198bf3498ffe242be7758bf3a889b3f49"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
- "agglayer-bincode 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "agglayer-primitives 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "agglayer-tries 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode",
- "educe",
- "hex",
- "serde",
- "sp1-core-machine",
- "sp1-prover",
- "sp1-sdk",
- "thiserror 2.0.16",
- "unified-bridge 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "agglayer-interop-types"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426#74570d8a556ec36336fc06416bc8f8bdf2d88426"
-dependencies = [
- "agglayer-bincode 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-primitives 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-tries 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-bincode",
+ "agglayer-primitives",
+ "agglayer-tries",
  "arbitrary",
  "bincode",
  "educe",
@@ -408,7 +350,7 @@ dependencies = [
  "sp1-prover",
  "sp1-sdk",
  "thiserror 2.0.16",
- "unified-bridge 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "unified-bridge",
 ]
 
 [[package]]
@@ -423,9 +365,9 @@ dependencies = [
  "agglayer-telemetry 0.1.0",
  "agglayer-types",
  "alloy",
- "anyhow",
  "axum 0.8.4",
  "buildstructor",
+ "eyre",
  "fail",
  "futures",
  "hex",
@@ -478,7 +420,6 @@ dependencies = [
  "agglayer-telemetry 0.1.0",
  "agglayer-types",
  "alloy",
- "anyhow",
  "arc-swap",
  "axum 0.8.4",
  "buildstructor",
@@ -517,22 +458,7 @@ dependencies = [
 [[package]]
 name = "agglayer-primitives"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e08a5ddabc0710ff57206a6222135e45b380d3f15f62ea5267c0a91bd42d9f"
-dependencies = [
- "alloy-primitives",
- "byteorder",
- "derive_more 2.0.1",
- "hex",
- "k256",
- "serde",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "agglayer-primitives"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426#74570d8a556ec36336fc06416bc8f8bdf2d88426"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -548,7 +474,7 @@ dependencies = [
 [[package]]
 name = "agglayer-prover"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v1.2.1#f429f7d23822c2ef07854edac2a570824eafcb4d"
+source = "git+https://github.com/agglayer/provers.git?branch=ekleog%2Feyre-a-bit#03b4ec639288b5568c1250218b610fae3518de94"
 dependencies = [
  "agglayer-prover-config",
  "agglayer-prover-types",
@@ -573,7 +499,7 @@ dependencies = [
 [[package]]
 name = "agglayer-prover-config"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v1.2.1#f429f7d23822c2ef07854edac2a570824eafcb4d"
+source = "git+https://github.com/agglayer/provers.git?branch=ekleog%2Feyre-a-bit#03b4ec639288b5568c1250218b610fae3518de94"
 dependencies = [
  "prover-config",
  "prover-logger",
@@ -586,9 +512,9 @@ dependencies = [
 [[package]]
 name = "agglayer-prover-types"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v1.2.1#f429f7d23822c2ef07854edac2a570824eafcb4d"
+source = "git+https://github.com/agglayer/provers.git?branch=ekleog%2Feyre-a-bit#03b4ec639288b5568c1250218b610fae3518de94"
 dependencies = [
- "agglayer-interop 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "agglayer-interop",
  "pbjson 0.7.0",
  "prost 0.13.5",
  "prover-executor",
@@ -651,11 +577,12 @@ version = "0.1.0"
 dependencies = [
  "agglayer-config",
  "agglayer-storage",
- "agglayer-tries 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-tries",
  "agglayer-types",
  "alloy-primitives",
  "chrono",
  "criterion",
+ "eyre",
  "hex",
  "insta",
  "mockall",
@@ -724,22 +651,9 @@ dependencies = [
 [[package]]
 name = "agglayer-tries"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2db770a5571e86a72e216d2711f519ba6887f63cfc57cb6c38c0ff0363b314d"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
- "agglayer-primitives 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex",
- "serde",
- "serde_with",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "agglayer-tries"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426#74570d8a556ec36336fc06416bc8f8bdf2d88426"
-dependencies = [
- "agglayer-primitives 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-primitives",
  "hex",
  "serde",
  "serde_with",
@@ -750,10 +664,10 @@ dependencies = [
 name = "agglayer-types"
 version = "0.1.0"
 dependencies = [
- "agglayer-bincode 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-interop-types 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-primitives 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-tries 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-bincode",
+ "agglayer-interop-types",
+ "agglayer-primitives",
+ "agglayer-tries",
  "agglayer-types",
  "alloy",
  "arbitrary",
@@ -770,7 +684,7 @@ dependencies = [
  "sp1-sdk",
  "strum_macros 0.27.2",
  "thiserror 2.0.16",
- "unified-bridge 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "unified-bridge",
 ]
 
 [[package]]
@@ -2738,6 +2652,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,12 +3348,12 @@ dependencies = [
 name = "ecdsa-proof-lib"
 version = "0.1.0"
 dependencies = [
- "agglayer-primitives 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-tries 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-primitives",
+ "agglayer-tries",
  "k256",
  "serde",
  "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-4.0.0)",
- "unified-bridge 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "unified-bridge",
 ]
 
 [[package]]
@@ -4599,9 +4540,9 @@ dependencies = [
  "agglayer-telemetry 0.1.0",
  "agglayer-types",
  "alloy",
- "anyhow",
  "arc-swap",
  "buildstructor",
+ "eyre",
  "fail",
  "futures",
  "hex",
@@ -5730,6 +5671,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "owo-colors"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6160,9 +6107,11 @@ name = "pessimistic-proof"
 version = "0.1.0"
 dependencies = [
  "agglayer-elf-build",
- "agglayer-primitives 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-tries 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-primitives",
+ "agglayer-tries",
  "arbitrary",
+ "color-eyre",
+ "eyre",
  "hex",
  "hex-literal 0.4.1",
  "pessimistic-proof-core",
@@ -6176,16 +6125,16 @@ dependencies = [
  "sp1-sdk",
  "thiserror 2.0.16",
  "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unified-bridge 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "unified-bridge",
 ]
 
 [[package]]
 name = "pessimistic-proof-core"
 version = "0.1.0"
 dependencies = [
- "agglayer-bincode 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-primitives 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-tries 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-bincode",
+ "agglayer-primitives",
+ "agglayer-tries",
  "alloy",
  "alloy-primitives",
  "arbitrary",
@@ -6201,7 +6150,7 @@ dependencies = [
  "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-4.0.0)",
  "toml",
  "tracing",
- "unified-bridge 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "unified-bridge",
 ]
 
 [[package]]
@@ -6209,13 +6158,13 @@ name = "pessimistic-proof-test-suite"
 version = "0.1.0"
 dependencies = [
  "agglayer-prover",
- "agglayer-tries 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-tries",
  "agglayer-types",
  "alloy",
- "anyhow",
  "base64 0.22.1",
  "clap",
  "ecdsa-proof-lib",
+ "eyre",
  "hex",
  "hex-literal 0.4.1",
  "insta",
@@ -6231,7 +6180,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tracing",
- "unified-bridge 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "unified-bridge",
  "uuid 1.18.0",
 ]
 
@@ -6741,14 +6690,14 @@ dependencies = [
 [[package]]
 name = "prover-alloy"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v1.2.1#f429f7d23822c2ef07854edac2a570824eafcb4d"
+source = "git+https://github.com/agglayer/provers.git?branch=ekleog%2Feyre-a-bit#03b4ec639288b5568c1250218b610fae3518de94"
 dependencies = [
  "agglayer-evm-client",
  "alloy",
- "anyhow",
  "async-trait",
  "derive_more 2.0.1",
  "educe",
+ "eyre",
  "ff 0.13.1",
  "serde",
  "url",
@@ -6757,7 +6706,7 @@ dependencies = [
 [[package]]
 name = "prover-config"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v1.2.1#f429f7d23822c2ef07854edac2a570824eafcb4d"
+source = "git+https://github.com/agglayer/provers.git?branch=ekleog%2Feyre-a-bit#03b4ec639288b5568c1250218b610fae3518de94"
 dependencies = [
  "prover-utils",
  "serde",
@@ -6768,7 +6717,7 @@ dependencies = [
 [[package]]
 name = "prover-engine"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v1.2.1#f429f7d23822c2ef07854edac2a570824eafcb4d"
+source = "git+https://github.com/agglayer/provers.git?branch=ekleog%2Feyre-a-bit#03b4ec639288b5568c1250218b610fae3518de94"
 dependencies = [
  "agglayer-telemetry 0.2.1",
  "anyhow",
@@ -6788,7 +6737,7 @@ dependencies = [
 [[package]]
 name = "prover-executor"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v1.2.1#f429f7d23822c2ef07854edac2a570824eafcb4d"
+source = "git+https://github.com/agglayer/provers.git?branch=ekleog%2Feyre-a-bit#03b4ec639288b5568c1250218b610fae3518de94"
 dependencies = [
  "anyhow",
  "buildstructor",
@@ -6815,7 +6764,7 @@ dependencies = [
 [[package]]
 name = "prover-logger"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v1.2.1#f429f7d23822c2ef07854edac2a570824eafcb4d"
+source = "git+https://github.com/agglayer/provers.git?branch=ekleog%2Feyre-a-bit#03b4ec639288b5568c1250218b610fae3518de94"
 dependencies = [
  "serde",
  "tracing",
@@ -6826,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "prover-utils"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v1.2.1#f429f7d23822c2ef07854edac2a570824eafcb4d"
+source = "git+https://github.com/agglayer/provers.git?branch=ekleog%2Feyre-a-bit#03b4ec639288b5568c1250218b610fae3518de94"
 dependencies = [
  "humantime-serde",
  "serde",
@@ -9293,6 +9242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-forest"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9505,25 +9464,10 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified-bridge"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed7ffb6ee35350e44f40e4385ddda852802d43984a8ebfc238a8f0594c5ab24"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
- "agglayer-primitives 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "agglayer-tries 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-literal 1.0.0",
- "serde",
- "serde_with",
- "sha2",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "unified-bridge"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426#74570d8a556ec36336fc06416bc8f8bdf2d88426"
-dependencies = [
- "agglayer-primitives 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
- "agglayer-tries 0.9.0 (git+https://github.com/agglayer/interop.git?rev=74570d8a556ec36336fc06416bc8f8bdf2d88426)",
+ "agglayer-primitives",
+ "agglayer-tries",
  "arbitrary",
  "hex-literal 1.0.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,21 +44,21 @@ pessimistic-proof-core = { path = "crates/pessimistic-proof-core" }
 pessimistic-proof-test-suite = { path = "crates/pessimistic-proof-test-suite" }
 
 # Interop
-agglayer-bincode = { git = "https://github.com/agglayer/interop.git", rev = "74570d8a556ec36336fc06416bc8f8bdf2d88426" }
-agglayer-interop = { git = "https://github.com/agglayer/interop.git", rev = "74570d8a556ec36336fc06416bc8f8bdf2d88426" }
-agglayer-interop-types = { git = "https://github.com/agglayer/interop.git", rev = "74570d8a556ec36336fc06416bc8f8bdf2d88426" }
-agglayer-elf-build = { git = "https://github.com/agglayer/interop.git", rev = "74570d8a556ec36336fc06416bc8f8bdf2d88426" }
-agglayer-primitives = { git = "https://github.com/agglayer/interop.git", rev = "74570d8a556ec36336fc06416bc8f8bdf2d88426" }
-agglayer-tries = { git = "https://github.com/agglayer/interop.git", rev = "74570d8a556ec36336fc06416bc8f8bdf2d88426" }
-unified-bridge = { git = "https://github.com/agglayer/interop.git", rev = "74570d8a556ec36336fc06416bc8f8bdf2d88426" }
+agglayer-bincode = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-interop = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-interop-types = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-elf-build = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-primitives = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-tries = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+unified-bridge = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
 
 # Provers
-agglayer-prover = { git = "https://github.com/agglayer/provers.git", tag = "v1.2.1" }
-agglayer-prover-config = { git = "https://github.com/agglayer/provers.git", tag = "v1.2.1" }
-agglayer-prover-types = { git = "https://github.com/agglayer/provers.git", tag = "v1.2.1" }
-prover-alloy = { git = "https://github.com/agglayer/provers.git", tag = "v1.2.1" }
-prover-config = { git = "https://github.com/agglayer/provers.git", tag = "v1.2.1" }
-prover-executor = { git = "https://github.com/agglayer/provers.git", tag = "v1.2.1" }
+agglayer-prover = { git = "https://github.com/agglayer/provers.git", branch = "ekleog/eyre-a-bit" }
+agglayer-prover-config = { git = "https://github.com/agglayer/provers.git", branch = "ekleog/eyre-a-bit" }
+agglayer-prover-types = { git = "https://github.com/agglayer/provers.git", branch = "ekleog/eyre-a-bit" }
+prover-alloy = { git = "https://github.com/agglayer/provers.git", branch = "ekleog/eyre-a-bit" }
+prover-config = { git = "https://github.com/agglayer/provers.git", branch = "ekleog/eyre-a-bit" }
+prover-executor = { git = "https://github.com/agglayer/provers.git", branch = "ekleog/eyre-a-bit" }
 
 # SP1 dependencies
 # Note: Whenever these are updated, also consider updating the SP1 toolchain docker image version.
@@ -82,6 +82,7 @@ base64 = "0.22.0"
 bolero = { version = "0.13.0", features = ["arbitrary"] }
 buildstructor = "0.5.4"
 clap = { version = "4.5", features = ["derive", "env"] }
+color-eyre = { version = "0.6.5" }
 criterion = "0.5.1"
 derive_more = "2.0"
 dirs = "5.0"
@@ -126,6 +127,7 @@ tonic = { version = "0.12.3", default-features = false }
 tonic-reflection = "0.12.3"
 tonic-types = "0.12.3"
 tower = "0.4.13"
+tower-http = { version = "0.6.2", features = ["full"] }
 tracing = "0.1.41"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/crates/agglayer-aggregator-notifier/Cargo.toml
+++ b/crates/agglayer-aggregator-notifier/Cargo.toml
@@ -17,7 +17,6 @@ prover-config.workspace = true
 prover-executor.workspace = true
 agglayer-prover-config.workspace = true
 
-anyhow.workspace = true
 async-trait.workspace = true
 arc-swap.workspace = true
 alloy.workspace = true

--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -12,7 +12,7 @@ use agglayer_types::{
     aggchain_proof::AggchainData, bincode, Certificate, Digest, Height, LocalNetworkStateData,
     NetworkId, Proof,
 };
-use eyre::Context as _;
+use eyre::{eyre, Context as _};
 use pessimistic_proof::{
     core::{commitment::StateCommitment, generate_pessimistic_proof},
     local_state::LocalNetworkState,
@@ -195,7 +195,7 @@ where
             })
             .await
             .map_err(CertificationError::Other)?
-            .map_err(CertificationError::Sp1ExecuteFailed)?;
+            .map_err(|e| CertificationError::Sp1ExecuteFailed(eyre!(e)))?;
 
             let pv_sp1_execute: PessimisticProofOutput = PessimisticProofOutput::bincode_codec()
                 .deserialize(pv.as_slice())

--- a/crates/agglayer-certificate-orchestrator/Cargo.toml
+++ b/crates/agglayer-certificate-orchestrator/Cargo.toml
@@ -20,7 +20,6 @@ testutils = [
 
 [dependencies]
 alloy.workspace = true
-anyhow.workspace = true
 arc-swap.workspace = true
 async-trait.workspace = true
 buildstructor.workspace = true

--- a/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
@@ -87,7 +87,7 @@ where
                     error!(?error, "Internal error in certificate processing");
                 }
                 _ => {
-                    let error = anyhow::Error::from(error.clone());
+                    let error = eyre::Error::from(error.clone());
                     debug!(?error, "Error in certificate processing");
                 }
             }
@@ -155,7 +155,7 @@ where
                 Ok(())
             }
             CertificateStatus::InError { error } => {
-                warn!(error = ?anyhow::Error::from(error.clone()), "Certificate is already in error");
+                warn!(error = ?eyre::Error::from(error.clone()), "Certificate is already in error");
                 Err(*error.clone())
             }
         }

--- a/crates/agglayer-certificate-orchestrator/src/error.rs
+++ b/crates/agglayer-certificate-orchestrator/src/error.rs
@@ -44,7 +44,7 @@ pub enum CertificationError {
     /// SP1 native execute call which includes the aggchain proof stark
     /// verification failed.
     #[error("Sp1-native execution failed.")]
-    Sp1ExecuteFailed(#[source] anyhow::Error),
+    Sp1ExecuteFailed(#[source] eyre::Error),
 
     /// The PP public values differ between the ones computed during the
     /// rust native execution, and the ones computed by the sp1 zkvm execution.
@@ -161,7 +161,7 @@ impl From<CertificationError> for CertificateStatusError {
                 CertificateStatusError::TypeConversionError(source)
             }
             error => {
-                let error = anyhow::Error::from(error);
+                let error = eyre::Error::from(error);
                 CertificateStatusError::InternalError(format!("{error:?}"))
             }
         }

--- a/crates/agglayer-certificate-orchestrator/src/lib.rs
+++ b/crates/agglayer-certificate-orchestrator/src/lib.rs
@@ -209,7 +209,7 @@ where
         epochs_store: Arc<EpochsStore>,
         current_epoch: Arc<ArcSwap<PerEpochStore>>,
         state_store: Arc<StateStore>,
-    ) -> anyhow::Result<JoinHandle<()>> {
+    ) -> eyre::Result<JoinHandle<()>> {
         let mut orchestrator = Self::try_new(
             clock,
             data_receiver,

--- a/crates/agglayer-contracts/Cargo.toml
+++ b/crates/agglayer-contracts/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 alloy.workspace = true
-anyhow.workspace = true
 async-trait.workspace = true
+eyre.workspace = true
 fail.workspace = true
 hex.workspace = true
 num-traits = "0.2"

--- a/crates/agglayer-contracts/src/lib.rs
+++ b/crates/agglayer-contracts/src/lib.rs
@@ -81,7 +81,7 @@ pub enum L1RpcError {
     #[error("Unable to get transaction")]
     UnableToGetTransaction {
         #[source]
-        source: Box<anyhow::Error>,
+        source: eyre::Error,
     },
     #[error("Unable to parse aggchain vkey")]
     UnableToParseAggchainVkey,

--- a/crates/agglayer-gcp-kms/Cargo.toml
+++ b/crates/agglayer-gcp-kms/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 [dependencies]
 alloy = {workspace = true, features = ["signers", "signer-local", "signer-gcp"]}
 alloy-primitives.workspace = true
-anyhow.workspace = true
 async-trait.workspace = true
+eyre.workspace = true
 gcloud-sdk.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true

--- a/crates/agglayer-gcp-kms/src/error.rs
+++ b/crates/agglayer-gcp-kms/src/error.rs
@@ -15,5 +15,5 @@ pub enum Error {
 
     /// An error occurred while interacting with the KMS provider.
     #[error("KMS error: {0}")]
-    KmsError(anyhow::Error),
+    KmsError(eyre::Error),
 }

--- a/crates/agglayer-gcp-kms/src/lib.rs
+++ b/crates/agglayer-gcp-kms/src/lib.rs
@@ -94,7 +94,7 @@ impl KMS {
                 .await
                 .map_err(|e| {
                     Error::KmsError(
-                        anyhow::Error::new(e).context("Unable to create GoogleApiClient"),
+                        eyre::Error::new(e).wrap_err("Unable to create GoogleApiClient"),
                     )
                 })?;
 
@@ -102,7 +102,7 @@ impl KMS {
         let gcp_signer = GcpSigner::new(client, specifier, Some(self.chain_id))
             .await
             .map_err(|e| {
-                Error::KmsError(anyhow::Error::new(e).context("Unable to create GcpSigner"))
+                Error::KmsError(eyre::Error::new(e).wrap_err("Unable to create GcpSigner"))
             })?;
 
         Ok(KmsSigner::new(gcp_signer))

--- a/crates/agglayer-gcp-kms/src/signer.rs
+++ b/crates/agglayer-gcp-kms/src/signer.rs
@@ -33,7 +33,7 @@ impl KmsSigner {
         self.signer
             .sign_message(message.as_ref())
             .await
-            .map_err(|e| Error::KmsError(anyhow::Error::new(e).context("Unable to sign message")))
+            .map_err(|e| Error::KmsError(eyre::Error::new(e).wrap_err("Unable to sign message")))
     }
 
     /// Signs a transaction using the internal signer, this method can fail if
@@ -45,7 +45,7 @@ impl KmsSigner {
             .sign_transaction(&mut tx_clone)
             .await
             .map_err(|e| {
-                Error::KmsError(anyhow::Error::new(e).context("Unable to sign transaction"))
+                Error::KmsError(eyre::Error::new(e).wrap_err("Unable to sign transaction"))
             })
     }
 

--- a/crates/agglayer-grpc-api/Cargo.toml
+++ b/crates/agglayer-grpc-api/Cargo.toml
@@ -15,8 +15,8 @@ agglayer-storage.workspace = true
 agglayer-types.workspace = true
 
 axum = { workspace = true, features = ["tokio", "http1", "http2"] }
-anyhow = { workspace = true }
 alloy.workspace = true
+eyre.workspace = true
 http.workspace = true
 prost.workspace = true
 serde.workspace = true

--- a/crates/agglayer-grpc-api/src/lib.rs
+++ b/crates/agglayer-grpc-api/src/lib.rs
@@ -45,7 +45,7 @@ impl ServerBuilder {
             + Send
             + 'static,
         S::Future: Send + 'static,
-        S::Error: Into<anyhow::Error> + Send,
+        S::Error: Into<eyre::Error> + Send,
     {
         self.router = self.router.route_service(
             &format!("/{}/{{*rest}}", S::NAME),

--- a/crates/agglayer-grpc-types/Cargo.toml
+++ b/crates/agglayer-grpc-types/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = { workspace = true, optional = true }
 agglayer-types = { workspace = true, features = ["testutils"] }
 agglayer-interop = { workspace = true, features = ["testutils"] }
 
-anyhow.workspace = true
 bolero.workspace = true
+eyre.workspace = true
 insta.workspace = true
 rstest.workspace = true

--- a/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_data__debug.snap
+++ b/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_data__debug.snap
@@ -1,5 +1,8 @@
 ---
 source: crates/agglayer-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 invalid value
+
+Location:
+    crates/agglayer-grpc-types/src/compat/v1/tests.rs:21:25

--- a/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_data_in_field__debug.snap
+++ b/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_data_in_field__debug.snap
@@ -1,5 +1,8 @@
 ---
 source: crates/agglayer-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 value: invalid value
+
+Location:
+    crates/agglayer-grpc-types/src/compat/v1/tests.rs:21:25

--- a/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_data_in_nested__debug.snap
+++ b/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_data_in_nested__debug.snap
@@ -1,5 +1,8 @@
 ---
 source: crates/agglayer-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 data.value: invalid value
+
+Location:
+    crates/agglayer-grpc-types/src/compat/v1/tests.rs:21:25

--- a/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_sig__debug.snap
+++ b/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_sig__debug.snap
@@ -1,8 +1,11 @@
 ---
 source: crates/agglayer-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 failed to parse signature
 
 Caused by:
     invalid parity: 5
+
+Location:
+    crates/agglayer-grpc-types/src/compat/v1/tests.rs:21:25

--- a/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_sig_in_nested__debug.snap
+++ b/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__bad_sig_in_nested__debug.snap
@@ -1,8 +1,11 @@
 ---
 source: crates/agglayer-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 data.signature: failed to parse signature
 
 Caused by:
     invalid parity: 5
+
+Location:
+    crates/agglayer-grpc-types/src/compat/v1/tests.rs:21:25

--- a/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__failed_deser__debug.snap
+++ b/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__failed_deser__debug.snap
@@ -1,8 +1,11 @@
 ---
 source: crates/agglayer-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 failed to deserialize proof
 
 Caused by:
     failed
+
+Location:
+    crates/agglayer-grpc-types/src/compat/v1/tests.rs:21:25

--- a/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__failed_ser__debug.snap
+++ b/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__failed_ser__debug.snap
@@ -1,8 +1,11 @@
 ---
 source: crates/agglayer-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 failed to serialize proof
 
 Caused by:
     failed
+
+Location:
+    crates/agglayer-grpc-types/src/compat/v1/tests.rs:21:25

--- a/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__no_proof__debug.snap
+++ b/crates/agglayer-grpc-types/src/compat/v1/snapshots/agglayer_grpc_types__compat__v1__tests__no_proof__debug.snap
@@ -1,5 +1,8 @@
 ---
 source: crates/agglayer-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 proof: required field is missing
+
+Location:
+    crates/agglayer-grpc-types/src/compat/v1/tests.rs:21:25

--- a/crates/agglayer-grpc-types/src/compat/v1/tests.rs
+++ b/crates/agglayer-grpc-types/src/compat/v1/tests.rs
@@ -18,7 +18,7 @@ fn error_messages(#[case] name: &str, #[case] error: Error) {
     insta::assert_debug_snapshot!(format!("{name}/kind"), error.kind());
     insta::assert_snapshot!(
         format!("{name}/debug"),
-        format!("{:?}", anyhow::Error::from(error))
+        format!("{:?}", eyre::Error::from(error))
     );
 }
 

--- a/crates/agglayer-jsonrpc-api/Cargo.toml
+++ b/crates/agglayer-jsonrpc-api/Cargo.toml
@@ -5,43 +5,39 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-agglayer-telemetry = { workspace = true }
 agglayer-config.workspace = true
+agglayer-contracts.workspace = true
 agglayer-rate-limiting.workspace = true
+agglayer-rpc.workspace = true
+agglayer-storage.workspace = true
+agglayer-telemetry.workspace = true
 agglayer-types.workspace = true
 
-alloy = { workspace = true }
-futures = { workspace = true }
-jsonrpsee = { workspace = true, features = ["full"] }
+alloy.workspace = true
+axum = { workspace = true, features = ["tokio", "http1", "http2"] }
+buildstructor.workspace = true
+eyre.workspace = true
+futures.workspace = true
 hex.workspace = true
-
+http.workspace = true
+hyper.workspace = true
+jsonrpsee = { workspace = true, features = ["full"] }
+pin-project.workspace = true
+reqwest.workspace = true
+rstest = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_with.workspace = true
-tokio.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
-
-anyhow.workspace = true
-axum = { version = "0.8.1", features = ["tokio", "http1", "http2"] }
-buildstructor.workspace = true
-hyper.workspace = true
-http.workspace = true
-pin-project.workspace = true
-reqwest = "0.12.23"
+tokio.workspace = true
 tokio-util.workspace = true
 tokio-stream.workspace = true
 toml.workspace = true
 tonic.workspace = true
-tower-http = { version = "0.6.2", features = ["full"] }
 tower.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
-
-agglayer-contracts.workspace = true
-agglayer-rpc.workspace = true
-agglayer-storage.workspace = true
-
-rstest = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["full", "node-bindings"] }

--- a/crates/agglayer-jsonrpc-api/src/admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/admin.rs
@@ -80,7 +80,7 @@ where
     StateStore: StateReader + StateWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
 {
-    pub async fn start(self) -> anyhow::Result<axum::Router> {
+    pub async fn start(self) -> eyre::Result<axum::Router> {
         // Create the RPC service
         let config = self.config.clone();
 

--- a/crates/agglayer-jsonrpc-api/src/lib.rs
+++ b/crates/agglayer-jsonrpc-api/src/lib.rs
@@ -120,7 +120,7 @@ where
     StateStore: StateReader + StateWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
 {
-    pub async fn start(self) -> anyhow::Result<axum::Router> {
+    pub async fn start(self) -> eyre::Result<axum::Router> {
         let config = self.rpc_service.config();
 
         // Create the RPC server.

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 alloy.workspace = true
-anyhow.workspace = true
 axum = { workspace = true, features = ["tokio", "http1", "http2"] }
 arc-swap.workspace = true
 buildstructor.workspace = true

--- a/crates/agglayer-node/src/epoch_synchronizer.rs
+++ b/crates/agglayer-node/src/epoch_synchronizer.rs
@@ -9,7 +9,6 @@ use agglayer_storage::{
     },
 };
 use agglayer_types::EpochNumber;
-use anyhow::Result;
 use tokio::sync::broadcast::error::TryRecvError;
 use tracing::{debug, error, info};
 
@@ -21,7 +20,7 @@ impl EpochSynchronizer {
         mut opened_epoch: EpochsStore::PerEpochStore,
         mut current_epoch_number: EpochNumber,
         mut epoch_stream: tokio::sync::broadcast::Receiver<agglayer_clock::Event>,
-    ) -> Result<EpochsStore::PerEpochStore>
+    ) -> eyre::Result<EpochsStore::PerEpochStore>
     where
         EpochsStore: EpochStoreWriter,
         EpochsStore::PerEpochStore: PerEpochReader + PerEpochWriter,
@@ -55,7 +54,7 @@ impl EpochSynchronizer {
                     current_epoch_number = n;
                 }
                 Err(TryRecvError::Closed) => {
-                    anyhow::bail!("Epoch stream closed during epoch synchronization");
+                    eyre::bail!("Epoch stream closed during epoch synchronization");
                 }
                 Err(TryRecvError::Lagged(n)) => {
                     debug!(
@@ -77,7 +76,7 @@ impl EpochSynchronizer {
         state_store: Arc<StateStore>,
         epochs_store: Arc<EpochsStore>,
         clock_ref: ClockRef,
-    ) -> Result<EpochsStore::PerEpochStore>
+    ) -> eyre::Result<EpochsStore::PerEpochStore>
     where
         StateStore: StateReader + MetadataReader + MetadataWriter,
         EpochsStore: EpochStoreWriter,
@@ -101,7 +100,7 @@ impl EpochSynchronizer {
             Some(lse_number) => {
                 debug!("synchronizer: Latest settled epoch: {}", lse_number);
                 if current_epoch_number < lse_number {
-                    anyhow::bail!(
+                    eyre::bail!(
                         "Unable to synchronize: Current epoch is less than the latest settled \
                          epoch"
                     );

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{future::IntoFuture, path::PathBuf, sync::Arc};
 
 use agglayer_config::Config;
-use eyre::{bail, eyre};
+use eyre::bail;
 use node::Node;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
@@ -63,7 +63,7 @@ pub fn main(
         }
         Err(e) => {
             eprintln!("Failed to initialize logger: {e:?}");
-            return Err(eyre!(e.into_boxed_dyn_error()));
+            return Err(e);
         }
     }
 

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -1,8 +1,7 @@
 use agglayer_config::log::LogFormat;
-use anyhow::Result;
 use tracing_subscriber::{prelude::*, util::SubscriberInitExt, EnvFilter};
 
-pub(crate) fn tracing(config: &agglayer_config::Log) -> Result<()> {
+pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<()> {
     // TODO: Support multiple outputs.
     let writer = config.outputs.first().cloned().unwrap_or_default();
 

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -24,7 +24,7 @@ use alloy::{
     providers::{ProviderBuilder, WsConnect},
     signers::Signer,
 };
-use eyre::{eyre, Context as _};
+use eyre::Context as _;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -54,9 +54,8 @@ impl Node {
     /// # use agglayer_config::Config;
     /// # use agglayer_node::Node;
     /// # use tokio_util::sync::CancellationToken;
-    /// # use anyhow::Result;
     /// #
-    /// async fn start_node() -> Result<()> {
+    /// async fn start_node() -> eyre::Result<()> {
     ///    let config: Arc<Config> = Arc::new(Config::default());
     ///
     ///    Node::builder()
@@ -177,7 +176,6 @@ impl Node {
         let current_epoch_store =
             EpochSynchronizer::start(state_store.clone(), epochs_store.clone(), clock_ref.clone())
                 .await
-                .map_err(|e| eyre!(e.into_boxed_dyn_error()))
                 .context("Failed starting epoch synchronizer")?;
 
         info!(
@@ -249,7 +247,6 @@ impl Node {
             .certifier_task_builder(certifier_client)
             .start()
             .await
-            .map_err(|e| eyre!(e.into_boxed_dyn_error()))
             .context("Failed starting certificate orchestrator")?;
 
         info!("Certificate orchestrator started.");
@@ -273,14 +270,12 @@ impl Node {
         )
         .start()
         .await
-        .map_err(|e| eyre!(e.into_boxed_dyn_error()))
         .context("Failed starting admin router")?;
 
         // Bind the core to the RPC server.
         let json_rpc_router = AgglayerImpl::new(service, rpc_service.clone())
             .start()
             .await
-            .map_err(|e| eyre!(e.into_boxed_dyn_error()))
             .context("Failed starting JSON-RPC router")?;
 
         let public_grpc_router =

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+eyre.workspace = true
 hex.workspace = true
 parking_lot.workspace = true
 rand = { version = "0.9.0", optional = true }

--- a/crates/agglayer-storage/src/columns/proof_per_certificate/tests.rs
+++ b/crates/agglayer-storage/src/columns/proof_per_certificate/tests.rs
@@ -47,7 +47,7 @@ struct SP1ProofWithPublicValuesV3 {
 }
 
 impl SP1ProofWithPublicValuesV3 {
-    fn load(path: impl AsRef<std::path::Path>) -> Result<Self, Box<dyn std::error::Error>> {
+    fn load(path: impl AsRef<std::path::Path>) -> eyre::Result<Self> {
         agglayer_types::bincode::sp1v4()
             .deserialize_from(std::fs::File::open(path).expect("failed to open file"))
             .map_err(Into::into)

--- a/crates/agglayer/Cargo.toml
+++ b/crates/agglayer/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env", "string"] }
 dirs.workspace = true
 dotenvy.workspace = true
@@ -16,11 +15,11 @@ tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 
-agglayer-config = { path = "../agglayer-config" }
-agglayer-node = { path = "../agglayer-node" }
-agglayer-prover-config = { workspace = true }
+agglayer-config.workspace = true
+agglayer-node.workspace = true
+agglayer-prover-config.workspace = true
 agglayer-prover.workspace = true
-agglayer-storage = { path = "../agglayer-storage" }
+agglayer-storage.workspace = true
 pessimistic-proof.workspace = true
 
 [dev-dependencies]
@@ -28,4 +27,6 @@ assert_cmd = "2.0.14"
 insta.workspace = true
 
 [build-dependencies]
+color-eyre.workspace = true
+eyre.workspace = true
 vergen-git2 = { version = "1.0.0", features = ["build"] }

--- a/crates/agglayer/build.rs
+++ b/crates/agglayer/build.rs
@@ -1,13 +1,17 @@
+use eyre::eyre;
 use vergen_git2::{Emitter, Git2Builder};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
     Emitter::new()
         .add_instructions(
             &Git2Builder::default()
                 .describe(true, true, None)
                 .commit_timestamp(true)
                 .build()?,
-        )?
-        .emit()?;
+        )
+        .map_err(|e| eyre!(e))?
+        .emit()
+        .map_err(|e| eyre!(e))?;
     Ok(())
 }

--- a/crates/agglayer/tests/config.rs
+++ b/crates/agglayer/tests/config.rs
@@ -1,7 +1,7 @@
 use assert_cmd::Command;
 
 #[test]
-fn config_display() -> Result<(), Box<dyn std::error::Error>> {
+fn config_display() -> eyre::Result<()> {
     let mut cmd = Command::cargo_bin("agglayer")?;
     cmd.args(["config", "--base-dir", "/tmp/agglayer-test"]);
 
@@ -15,7 +15,7 @@ fn config_display() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn prover_config_display() -> Result<(), Box<dyn std::error::Error>> {
+fn prover_config_display() -> eyre::Result<()> {
     let mut cmd = Command::cargo_bin("agglayer")?;
     cmd.args(["prover-config"]);
 

--- a/crates/pessimistic-proof-test-suite/Cargo.toml
+++ b/crates/pessimistic-proof-test-suite/Cargo.toml
@@ -21,13 +21,13 @@ ecdsa-proof-lib = { path = "./aggchain-proof-ecdsa-example/lib/" }
 alloy.workspace = true
 base64.workspace = true
 clap.workspace = true
+eyre.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 sp1-sdk = { workspace = true }
 sp1-core-machine.workspace = true
 lazy_static.workspace = true
-anyhow.workspace = true
 rand.workspace = true
 hex-literal = "0.4"
 hex.workspace = true

--- a/crates/pessimistic-proof/Cargo.toml
+++ b/crates/pessimistic-proof/Cargo.toml
@@ -32,6 +32,9 @@ rand = "0.9.0"
 rs_merkle = { version = "1.4", default-features = false }
 
 [build-dependencies]
+color-eyre.workspace = true
+eyre.workspace = true
+
 agglayer-elf-build.workspace = true
 
 [lints]

--- a/crates/pessimistic-proof/build.rs
+++ b/crates/pessimistic-proof/build.rs
@@ -1,3 +1,5 @@
-pub fn main() -> agglayer_elf_build::Result<()> {
-    agglayer_elf_build::build_program("crates/pessimistic-proof-program").map(drop)
+pub fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
+    agglayer_elf_build::build_program("crates/pessimistic-proof-program")?;
+    Ok(())
 }

--- a/tests/integrations/Cargo.toml
+++ b/tests/integrations/Cargo.toml
@@ -9,9 +9,9 @@ workspace = true
 
 [dependencies]
 alloy.workspace = true
-anyhow.workspace = true
 arc-swap.workspace = true
 buildstructor.workspace = true
+eyre.workspace = true
 fail = { workspace = true, features = ["failpoints"] }
 futures.workspace = true
 hex.workspace = true


### PR DESCRIPTION
Fixes https://github.com/agglayer/security/issues/80

BREAKING-CHANGE: Error types have been migrated to eyre in the API. No expected user-facing change unless the binary enables color-eyre.