### PR TITLE
chore: remove `serde` requirement from storage codec

### DIFF
--- a/crates/agglayer-storage/src/columns/certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/certificate_per_network/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{CertificateId, Height};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, CERTIFICATE_PER_NETWORK_CF};
+use super::{ColumnSchema, CERTIFICATE_PER_NETWORK_CF};
 
 #[cfg(test)]
 mod tests;
@@ -21,7 +21,7 @@ pub struct Key {
     pub(crate) height: Height,
 }
 
-impl Codec for Key {}
+impl_codec_using_bincode_for!(Key);
 
 impl ColumnSchema for CertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/certificate_per_network/mod.rs
@@ -21,7 +21,7 @@ pub struct Key {
     pub(crate) height: Height,
 }
 
-impl_codec_using_bincode_for!(Key);
+crate::columns::impl_codec_using_bincode_for!(Key);
 
 impl ColumnSchema for CertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/latest_pending_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_pending_certificate_per_network/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{CertificateId, Height, NetworkId};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, LATEST_PENDING_CERTIFICATE_PER_NETWORK_CF};
+use super::{ColumnSchema, LATEST_PENDING_CERTIFICATE_PER_NETWORK_CF};
 
 /// Column family for the latest pending certificate per network.
 /// The key is the network_id and the value is the certificateID and
@@ -19,7 +19,7 @@ pub struct PendingCertificate(pub CertificateId, pub Height);
 
 pub type Key = NetworkId;
 
-impl Codec for PendingCertificate {}
+impl_codec_using_bincode_for!(PendingCertificate);
 
 impl ColumnSchema for LatestPendingCertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/latest_pending_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_pending_certificate_per_network/mod.rs
@@ -19,7 +19,7 @@ pub struct PendingCertificate(pub CertificateId, pub Height);
 
 pub type Key = NetworkId;
 
-impl_codec_using_bincode_for!(PendingCertificate);
+crate::columns::impl_codec_using_bincode_for!(PendingCertificate);
 
 impl ColumnSchema for LatestPendingCertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/latest_proven_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_proven_certificate_per_network/mod.rs
@@ -19,7 +19,7 @@ pub struct ProvenCertificate(pub CertificateId, pub NetworkId, pub Height);
 
 pub type Key = NetworkId;
 
-impl_codec_using_bincode_for!(ProvenCertificate);
+crate::columns::impl_codec_using_bincode_for!(ProvenCertificate);
 
 impl ColumnSchema for LatestProvenCertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/latest_proven_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_proven_certificate_per_network/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{CertificateId, Height, NetworkId};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, LATEST_PROVEN_CERTIFICATE_PER_NETWORK_CF};
+use super::{ColumnSchema, LATEST_PROVEN_CERTIFICATE_PER_NETWORK_CF};
 
 /// Column family for the latest proven certificate per network.
 /// The key is the network_id and the value is the certificateID and
@@ -19,7 +19,7 @@ pub struct ProvenCertificate(pub CertificateId, pub NetworkId, pub Height);
 
 pub type Key = NetworkId;
 
-impl Codec for ProvenCertificate {}
+impl_codec_using_bincode_for!(ProvenCertificate);
 
 impl ColumnSchema for LatestProvenCertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/latest_settled_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_settled_certificate_per_network/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{CertificateId, CertificateIndex, EpochNumber, Height, NetworkId};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, LATEST_SETTLED_CERTIFICATE_PER_NETWORK_CF};
+use super::{ColumnSchema, LATEST_SETTLED_CERTIFICATE_PER_NETWORK_CF};
 
 #[cfg(test)]
 mod tests;
@@ -27,7 +27,7 @@ pub struct SettledCertificate(
 
 pub type Key = NetworkId;
 
-impl Codec for SettledCertificate {}
+impl_codec_using_bincode_for!(SettledCertificate);
 
 impl ColumnSchema for LatestSettledCertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/latest_settled_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_settled_certificate_per_network/mod.rs
@@ -27,7 +27,7 @@ pub struct SettledCertificate(
 
 pub type Key = NetworkId;
 
-impl_codec_using_bincode_for!(SettledCertificate);
+crate::columns::impl_codec_using_bincode_for!(SettledCertificate);
 
 impl ColumnSchema for LatestSettledCertificatePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/local_exit_tree_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/local_exit_tree_per_network/mod.rs
@@ -33,7 +33,7 @@ pub enum Value {
     Frontier([u8; 32]),
 }
 
-impl_codec_using_bincode_for!(Key, Value);
+crate::columns::impl_codec_using_bincode_for!(Key, Value);
 
 impl ColumnSchema for LocalExitTreePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/local_exit_tree_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/local_exit_tree_per_network/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, LOCAL_EXIT_TREE_PER_NETWORK_CF};
+use super::{ColumnSchema, LOCAL_EXIT_TREE_PER_NETWORK_CF};
 
 /// Column family for the local exit tree per network.
 ///
@@ -33,8 +33,7 @@ pub enum Value {
     Frontier([u8; 32]),
 }
 
-impl Codec for Key {}
-impl Codec for Value {}
+impl_codec_using_bincode_for!(Key, Value);
 
 impl ColumnSchema for LocalExitTreePerNetworkColumn {
     type Key = Key;

--- a/crates/agglayer-storage/src/columns/mod.rs
+++ b/crates/agglayer-storage/src/columns/mod.rs
@@ -15,7 +15,7 @@ pub enum CodecError {
     BadCertificateVersion { version: u8 },
 }
 
-pub fn bincode_codec() -> bincode::Codec<impl bincode::Options>  {
+pub fn bincode_codec() -> bincode::Codec<impl bincode::Options> {
     bincode::default()
 }
 
@@ -54,6 +54,24 @@ pub trait Codec: Sized {
 
     fn decode(buf: &[u8]) -> Result<Self, CodecError>;
 }
+
+macro_rules! impl_codec_using_bincode_for {
+    ($($type:ty),* $(,)?) => {
+        $(
+            impl $crate::columns::Codec for $type {
+                fn encode(&self) -> Result<Vec<u8>, $crate::columns::CodecError> {
+                    Ok($crate::columns::bincode_codec().serialize(self)?)
+                }
+
+                fn decode(buf: &[u8]) -> Result<Self, $crate::columns::CodecError> {
+                    Ok($crate::columns::bincode_codec().deserialize(buf)?)
+                }
+            }
+        )*
+    };
+}
+
+pub(crate) use impl_codec_using_bincode_for;
 
 pub trait ColumnSchema {
     type Key: Codec;

--- a/crates/agglayer-storage/src/columns/mod.rs
+++ b/crates/agglayer-storage/src/columns/mod.rs
@@ -1,5 +1,4 @@
 use agglayer_types::bincode;
-use serde::{de::DeserializeOwned, Serialize};
 
 #[derive(Debug, thiserror::Error)]
 pub enum CodecError {
@@ -50,14 +49,10 @@ pub const PROOF_PER_CERTIFICATE_CF: &str = "proof_per_certificate_cf";
 // debug CFs
 pub const DEBUG_CERTIFICATES_CF: &str = "debug_certificates";
 
-pub trait Codec: Sized + Serialize + DeserializeOwned {
-    fn encode(&self) -> Result<Vec<u8>, CodecError> {
-        Ok(bincode_codec().serialize(self)?)
-    }
+pub trait Codec: Sized {
+    fn encode(&self) -> Result<Vec<u8>, CodecError>;
 
-    fn decode(buf: &[u8]) -> Result<Self, CodecError> {
-        Ok(bincode_codec().deserialize(buf)?)
-    }
+    fn decode(buf: &[u8]) -> Result<Self, CodecError>;
 }
 
 pub trait ColumnSchema {

--- a/crates/agglayer-storage/src/columns/pending_queue/mod.rs
+++ b/crates/agglayer-storage/src/columns/pending_queue/mod.rs
@@ -15,7 +15,7 @@ pub(crate) struct PendingQueueColumn;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PendingQueueKey(pub(crate) NetworkId, pub(crate) Height);
 
-impl_codec_using_bincode_for!(PendingQueueKey);
+crate::columns::impl_codec_using_bincode_for!(PendingQueueKey);
 
 impl ColumnSchema for PendingQueueColumn {
     type Key = PendingQueueKey;

--- a/crates/agglayer-storage/src/columns/pending_queue/mod.rs
+++ b/crates/agglayer-storage/src/columns/pending_queue/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{Certificate, Height, NetworkId};
 use serde::{Deserialize, Serialize};
 
-use super::{Codec, ColumnSchema, PENDING_QUEUE_CF};
+use super::{ColumnSchema, PENDING_QUEUE_CF};
 
 /// Column family containing the pending certificates queue.
 ///
@@ -15,7 +15,7 @@ pub(crate) struct PendingQueueColumn;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PendingQueueKey(pub(crate) NetworkId, pub(crate) Height);
 
-impl Codec for PendingQueueKey {}
+impl_codec_using_bincode_for!(PendingQueueKey);
 
 impl ColumnSchema for PendingQueueColumn {
     type Key = PendingQueueKey;

--- a/crates/agglayer-storage/src/lib.rs
+++ b/crates/agglayer-storage/src/lib.rs
@@ -1,3 +1,19 @@
+macro_rules! impl_codec_using_bincode_for {
+    ($($type:ty),* $(,)?) => {
+        $(
+            impl $crate::columns::Codec for $type {
+                fn encode(&self) -> Result<Vec<u8>, $crate::columns::CodecError> {
+                    Ok($crate::columns::bincode_codec().serialize(self)?)
+                }
+
+                fn decode(buf: &[u8]) -> Result<Self, $crate::columns::CodecError> {
+                    Ok($crate::columns::bincode_codec().deserialize(buf)?)
+                }
+            }
+        )*
+    };
+}
+
 // Physical storage
 #[rustfmt::skip]
 pub mod storage;
@@ -5,6 +21,7 @@ pub mod storage;
 #[rustfmt::skip]
 pub mod stores;
 
+#[macro_use]
 #[rustfmt::skip]
 pub mod columns;
 #[rustfmt::skip]

--- a/crates/agglayer-storage/src/lib.rs
+++ b/crates/agglayer-storage/src/lib.rs
@@ -1,19 +1,3 @@
-macro_rules! impl_codec_using_bincode_for {
-    ($($type:ty),* $(,)?) => {
-        $(
-            impl $crate::columns::Codec for $type {
-                fn encode(&self) -> Result<Vec<u8>, $crate::columns::CodecError> {
-                    Ok($crate::columns::bincode_codec().serialize(self)?)
-                }
-
-                fn decode(buf: &[u8]) -> Result<Self, $crate::columns::CodecError> {
-                    Ok($crate::columns::bincode_codec().deserialize(buf)?)
-                }
-            }
-        )*
-    };
-}
-
 // Physical storage
 #[rustfmt::skip]
 pub mod storage;

--- a/crates/agglayer-storage/src/types/certificate/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/mod.rs
@@ -21,7 +21,9 @@ use std::borrow::Cow;
 
 use agglayer_tries::roots::LocalExitRoot;
 use agglayer_types::{
-    aggchain_proof::{AggchainData, AggchainProof, Proof, MultisigPayload}, primitives::Digest, Certificate, Height, Metadata, NetworkId, Signature
+    aggchain_proof::{AggchainData, AggchainProof, MultisigPayload, Proof},
+    primitives::Digest,
+    Certificate, Height, Metadata, NetworkId, Signature,
 };
 use pessimistic_proof::unified_bridge::{
     AggchainProofPublicValues, BridgeExit, ImportedBridgeExit,
@@ -310,7 +312,9 @@ impl From<AggchainDataV1<'_>> for AggchainData {
                 signature,
                 public_values: Some(public_values.into_owned()),
             },
-            AggchainDataV1::MultisigOnly { multisig } => Self::MultisigOnly(MultisigPayload(multisig.into_owned())),
+            AggchainDataV1::MultisigOnly { multisig } => {
+                Self::MultisigOnly(MultisigPayload(multisig.into_owned()))
+            }
             AggchainDataV1::MultisigAndAggchainProof {
                 multisig,
                 proof,
@@ -338,9 +342,8 @@ fn decode<T: for<'de> Deserialize<'de> + Into<Certificate>>(
 }
 
 impl crate::columns::Codec for Certificate {
-    fn encode(&self) -> Result<Vec<u8>, CodecError> {
-        // TODO get rid of the clones <https://github.com/agglayer/agglayer/issues/618>
-        Ok(bincode_codec().serialize(&CurrentCertificate::from(self))?)
+    fn encode_into<W: std::io::Write>(&self, writer: W) -> Result<(), CodecError> {
+        Ok(bincode_codec().serialize_into(writer, &CurrentCertificate::from(self))?)
     }
 
     fn decode(bytes: &[u8]) -> Result<Self, CodecError> {

--- a/crates/agglayer-storage/src/types/mod.rs
+++ b/crates/agglayer-storage/src/types/mod.rs
@@ -3,15 +3,7 @@ use agglayer_types::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::columns::Codec;
-
 mod certificate;
-
-macro_rules! default_codec_impl {
-    ($($ident: ident),+) => {
-        $(impl crate::columns::Codec for $ident {})+
-    };
-}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MetadataKey {
@@ -55,10 +47,7 @@ pub enum SmtValue {
     Leaf(Digest),
 }
 
-impl Codec for SmtKey {}
-impl Codec for SmtValue {}
-
-default_codec_impl!(
+impl_codec_using_bincode_for!(
     u64,
     u32,
     CertificateId,
@@ -71,5 +60,7 @@ default_codec_impl!(
     NetworkId,
     PerEpochMetadataKey,
     PerEpochMetadataValue,
-    Proof
+    Proof,
+    SmtKey,
+    SmtValue,
 );

--- a/crates/agglayer-storage/src/types/mod.rs
+++ b/crates/agglayer-storage/src/types/mod.rs
@@ -47,7 +47,7 @@ pub enum SmtValue {
     Leaf(Digest),
 }
 
-impl_codec_using_bincode_for!(
+crate::columns::impl_codec_using_bincode_for!(
     u64,
     u32,
     CertificateId,


### PR DESCRIPTION
With the gradual move towards protobuf in storage, the requirement for all storage types to implement the `serde` traits is unnecessary and a bit limiting. This removes the `serde` supertraits from `agglayer_storage::columns::Codec`. Consequently, we do not have convenient default implementation for the methods so a macro is introduced for it.