### PR TITLE
fix: switching to prehash for signer

### DIFF
--- a/crates/agglayer-jsonrpc-api/src/signed_tx.rs
+++ b/crates/agglayer-jsonrpc-api/src/signed_tx.rs
@@ -130,7 +130,7 @@ impl SignedTx {
     /// Attempt to recover the address of the signer.
     pub(crate) fn signer(&self) -> Result<Address, alloy::primitives::SignatureError> {
         self.signature
-            .recover_address_from_msg(self.hash())
+            .recover_address_from_prehash(&self.hash())
             .map(Into::into)
     }
 


### PR DESCRIPTION
This PR is fixing the address recovery of the `signex_tx`, we were using a digest (B256/U256) as a message which end up being serialized again using  [EIP-191](https://docs.rs/alloy/latest/alloy/primitives/fn.eip191_hash_message.html)