### PR TITLE
fix: use `DB::default_write_options` consistently

### DIFF
--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use iterators::{ColumnIterator, KeysIterator};
 use rocksdb::{
-    ColumnFamilyDescriptor, DBPinnableSlice, Direction, Options, ReadOptions, WriteBatch,
-    WriteOptions,
+    ColumnFamily, ColumnFamilyDescriptor, DBPinnableSlice, Direction, Options, ReadOptions,
+    WriteBatch, WriteOptions,
 };
 
 use crate::columns::{Codec, ColumnSchema};
@@ -86,16 +86,19 @@ impl DB {
             .ok_or(DBError::ReadOnlyMode)
     }
 
+    fn cf<C: ColumnSchema>(&self) -> Result<&ColumnFamily, DBError> {
+        self.rocksdb
+            .cf_handle(C::COLUMN_FAMILY_NAME)
+            .ok_or(DBError::ColumnFamilyNotFound)
+    }
+
     /// Try to get the value for the given key.
     pub fn get<C: ColumnSchema>(&self, key: &C::Key) -> Result<Option<C::Value>, DBError> {
         let key = key.encode()?;
-        let cf = self
-            .rocksdb
-            .cf_handle(C::COLUMN_FAMILY_NAME)
-            .ok_or(DBError::ColumnFamilyNotFound)?;
+        let cf = self.cf::<C>()?;
 
         self.rocksdb
-            .get_cf(&cf, &key)?
+            .get_cf(cf, &key)?
             .map(|v| C::Value::decode(&v[..]).map_err(Into::into))
             // If the value is not found, return None.
             // If the value is found, decode it and wrap it in Some to propagate decode error.
@@ -106,11 +109,7 @@ impl DB {
         &self,
         keys: impl IntoIterator<Item = C::Key>,
     ) -> Result<Vec<Option<C::Value>>, DBError> {
-        let cf = self
-            .rocksdb
-            .cf_handle(C::COLUMN_FAMILY_NAME)
-            .ok_or(DBError::ColumnFamilyNotFound)?;
-
+        let cf = self.cf::<C>()?;
         let keys: Result<Vec<_>, _> = keys.into_iter().map(|k| k.encode()).collect();
 
         let results: Result<Vec<Option<DBPinnableSlice>>, _> = self
@@ -133,13 +132,10 @@ impl DB {
     pub fn put<C: ColumnSchema>(&self, key: &C::Key, value: &C::Value) -> Result<(), DBError> {
         let key = key.encode()?;
         let value = value.encode()?;
-        let cf = self
-            .rocksdb
-            .cf_handle(C::COLUMN_FAMILY_NAME)
-            .ok_or(DBError::ColumnFamilyNotFound)?;
+        let cf = self.cf::<C>()?;
 
         let write_options = self.write_options()?;
-        self.rocksdb.put_cf_opt(&cf, key, value, write_options)?;
+        self.rocksdb.put_cf_opt(cf, key, value, write_options)?;
 
         Ok(())
     }
@@ -156,10 +152,7 @@ impl DB {
         key_val_pairs: impl IntoIterator<Item = (&'a C::Key, &'a C::Value)>,
         batch: &mut WriteBatch,
     ) -> Result<(), DBError> {
-        let cf = self
-            .rocksdb
-            .cf_handle(C::COLUMN_FAMILY_NAME)
-            .ok_or(DBError::ColumnFamilyNotFound)?;
+        let cf = self.cf::<C>()?;
 
         key_val_pairs
             .into_iter()
@@ -187,10 +180,7 @@ impl DB {
 
     /// Try to get every key in the column family.
     pub fn keys<C: ColumnSchema>(&self) -> Result<KeysIterator<'_, C>, DBError> {
-        let cf = self
-            .rocksdb
-            .cf_handle(C::COLUMN_FAMILY_NAME)
-            .ok_or(DBError::ColumnFamilyNotFound)?;
+        let cf = self.cf::<C>()?;
 
         let mut iterator = self.rocksdb.raw_iterator_cf(&cf);
         iterator.seek_to_first();
@@ -203,10 +193,7 @@ impl DB {
         opts: ReadOptions,
         direction: Direction,
     ) -> Result<ColumnIterator<'_, C>, DBError> {
-        let cf = self
-            .rocksdb
-            .cf_handle(C::COLUMN_FAMILY_NAME)
-            .ok_or(DBError::ColumnFamilyNotFound)?;
+        let cf = self.cf::<C>()?;
 
         let mut iterator = self.rocksdb.raw_iterator_cf_opt(&cf, opts);
 
@@ -219,10 +206,7 @@ impl DB {
     }
 
     pub(crate) fn delete<C: ColumnSchema>(&self, key: &C::Key) -> Result<(), DBError> {
-        let cf = self
-            .rocksdb
-            .cf_handle(C::COLUMN_FAMILY_NAME)
-            .ok_or(DBError::ColumnFamilyNotFound)?;
+        let cf = self.cf::<C>()?;
         let key = key.encode()?;
 
         let write_options = self.write_options()?;


### PR DESCRIPTION
* The options were not previously passed to the batch write method.
* Also a small refactor to get the column family easier.
* Fixes agglayer/security#104.