### PR TITLE
refactor: use vkey hashing utilities from agglayer-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "agglayer-certificate-orchestrator",
  "agglayer-config",
  "agglayer-contracts",
+ "agglayer-primitives 0.11.0",
  "agglayer-prover",
  "agglayer-prover-config",
  "agglayer-prover-types",

--- a/crates/agglayer-aggregator-notifier/Cargo.toml
+++ b/crates/agglayer-aggregator-notifier/Cargo.toml
@@ -9,6 +9,7 @@ agglayer-certificate-orchestrator = { path = "../agglayer-certificate-orchestrat
 agglayer-config = { path = "../agglayer-config" }
 agglayer-contracts = { path = "../agglayer-contracts" }
 agglayer-storage = { path = "../agglayer-storage" }
+agglayer-primitives.workspace = true
 agglayer-types.workspace = true
 pessimistic-proof = { path = "../pessimistic-proof" }
 

--- a/crates/agglayer-aggregator-notifier/src/certifier/l1_context.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/l1_context.rs
@@ -110,12 +110,14 @@ where
             .context("Failed to hash SP1 vkey")
             .map_err(CertificationError::Other)?;
 
-        let proof_vk_hash = agglayer_contracts::aggchain::AggchainVkeyHash::new(vkey_hash_bytes);
+        let vkey_digest = Digest::from(vkey_hash_bytes);
+
+        let proof_vk_hash = agglayer_contracts::aggchain::VKeyHash::from(vkey_digest);
 
         if aggchain_vkey != proof_vk_hash {
             return Err(CertificationError::AggchainProofVkeyMismatch {
-                expected: aggchain_vkey.to_hex(),
-                actual: proof_vk_hash.to_hex(),
+                expected: aggchain_vkey.to_bytes().to_string(),
+                actual: proof_vk_hash.to_bytes().to_string(),
             });
         }
 

--- a/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
@@ -2,7 +2,8 @@ use std::{sync::Arc, thread, time::Duration};
 
 use agglayer_certificate_orchestrator::Certifier;
 use agglayer_config::Config;
-use agglayer_contracts::{aggchain::AggchainVkeyHash, L1RpcError, Settler};
+use agglayer_contracts::{L1RpcError, Settler};
+use agglayer_primitives::vkey_hash::VKeyHash;
 use agglayer_prover::fake::FakeProver;
 use agglayer_storage::tests::{mocks::MockPendingStore, TempDBDir};
 use agglayer_types::{Address, Height, LocalNetworkStateData, NetworkId};
@@ -239,7 +240,7 @@ mockall::mock! {
             &self,
             rollup_address: agglayer_types::Address,
             aggchain_vkey_selector: u16,
-        ) -> Result<AggchainVkeyHash, L1RpcError>;
+        ) -> Result<VKeyHash, L1RpcError>;
 
         async fn get_aggchain_hash(
             &self,

--- a/crates/agglayer-contracts/src/aggchain.rs
+++ b/crates/agglayer-contracts/src/aggchain.rs
@@ -1,21 +1,10 @@
+pub use agglayer_primitives::vkey_hash::VKeyHash;
+
 use agglayer_primitives::{Address, U256};
 use alloy::primitives::Bytes;
 use tracing::error;
 
 use crate::{contracts::AggchainBase, L1RpcClient, L1RpcError};
-
-#[derive(PartialEq, Eq)]
-pub struct AggchainVkeyHash([u8; 32]);
-
-impl AggchainVkeyHash {
-    pub fn new(vkey: [u8; 32]) -> Self {
-        Self(vkey)
-    }
-
-    pub fn to_hex(&self) -> String {
-        hex::encode(self.0)
-    }
-}
 
 #[async_trait::async_trait]
 pub trait AggchainContract {
@@ -23,7 +12,7 @@ pub trait AggchainContract {
         &self,
         rollup_address: Address,
         aggchain_vkey_selector: u16,
-    ) -> Result<AggchainVkeyHash, L1RpcError>;
+    ) -> Result<VKeyHash, L1RpcError>;
 
     async fn get_aggchain_hash(
         &self,
@@ -46,7 +35,7 @@ where
         &self,
         rollup_address: Address,
         aggchain_vkey_selector: u16,
-    ) -> Result<AggchainVkeyHash, L1RpcError> {
+    ) -> Result<VKeyHash, L1RpcError> {
         let aggchain_selector = (((aggchain_vkey_selector as u32) << 16) | 1u32).to_be_bytes();
 
         let client = AggchainBase::new(rollup_address.into(), self.rpc.clone());
@@ -55,7 +44,7 @@ where
             .getAggchainVKey(alloy::primitives::FixedBytes(aggchain_selector))
             .call()
             .await
-            .map(|arg0| AggchainVkeyHash::new(arg0.0))
+            .map(|arg0| VKeyHash::from(arg0))
             .map_err(|error| {
                 error!(?error, "Unable to fetch the aggchain vkey");
 


### PR DESCRIPTION
Replace the ad-hoc implementation of the vkey hashing operations and utilities with the one located in agglayer-primitives.

Fixies agglayer/interop#101