### PR TITLE
feat: introduce an admin_forceSetCertificateStatus endpoint

### DIFF
--- a/crates/agglayer-jsonrpc-api/src/admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/admin.rs
@@ -10,6 +10,7 @@ use agglayer_types::{
     Height, NetworkId,
 };
 use jsonrpsee::{core::async_trait, proc_macros::rpc, server::ServerBuilder};
+use tokio::sync::mpsc;
 use tower_http::{compression::CompressionLayer, cors::CorsLayer};
 use tracing::{error, info, instrument, warn};
 
@@ -36,6 +37,7 @@ pub(crate) trait AdminAgglayer {
         &self,
         certificate_id: CertificateId,
         status: CertificateStatus,
+        process_now: bool,
     ) -> RpcResult<()>;
 
     #[method(name = "setLatestPendingCertificate")]
@@ -58,6 +60,7 @@ pub(crate) trait AdminAgglayer {
 
 /// The Admin RPC agglayer service implementation.
 pub struct AdminAgglayerImpl<PendingStore, StateStore, DebugStore> {
+    certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
     pending_store: Arc<PendingStore>,
     state: Arc<StateStore>,
     debug_store: Arc<DebugStore>,
@@ -67,12 +70,14 @@ pub struct AdminAgglayerImpl<PendingStore, StateStore, DebugStore> {
 impl<PendingStore, StateStore, DebugStore> AdminAgglayerImpl<PendingStore, StateStore, DebugStore> {
     /// Create an instance of the admin RPC agglayer service.
     pub fn new(
+        certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
         pending_store: Arc<PendingStore>,
         state: Arc<StateStore>,
         debug_store: Arc<DebugStore>,
         config: Arc<Config>,
     ) -> Self {
         Self {
+            certificate_sender,
             pending_store,
             state,
             debug_store,
@@ -231,6 +236,7 @@ where
         &self,
         certificate_id: CertificateId,
         status: CertificateStatus,
+        process_now: bool,
     ) -> RpcResult<()> {
         warn!(
             ?certificate_id,
@@ -243,6 +249,26 @@ where
                 error!(?error, "Failed to update certificate status");
                 Error::internal("Unable to update certificate status")
             })?;
+        if process_now {
+            let header = self
+                .state
+                .get_certificate_header(&certificate_id)
+                .map_err(|error| {
+                    error!(?error, "Failed to get certificate header");
+                    Error::internal("Unable to get certificate header")
+                })?
+                .ok_or_else(|| {
+                    error!("Certificate header not found");
+                    Error::ResourceNotFound(format!("CertificateHeader({certificate_id})"))
+                })?;
+            self.certificate_sender
+                .send((header.network_id, header.height, certificate_id))
+                .await
+                .map_err(|error| {
+                    error!(?error, "Failed to send certificate to orchestrator");
+                    Error::internal("Unable to send certificate to orchestrator")
+                })?;
+        }
         Ok(())
     }
 

--- a/crates/agglayer-jsonrpc-api/src/testutils.rs
+++ b/crates/agglayer-jsonrpc-api/src/testutils.rs
@@ -146,7 +146,7 @@ impl TestContext {
 
         // Create agglayer_rpc::AgglayerService with the provider
         let rpc_service = Arc::new(agglayer_rpc::AgglayerService::new(
-            certificate_sender,
+            certificate_sender.clone(),
             pending_store.clone(),
             state_store.clone(),
             debug_store.clone(),
@@ -161,6 +161,7 @@ impl TestContext {
         // Create the routers
         let router = agglayer_impl.start().await.unwrap();
         let admin_router = AdminAgglayerImpl::new(
+            certificate_sender,
             pending_store.clone(),
             state_store.clone(),
             debug_store.clone(),

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -254,7 +254,7 @@ impl Node {
         // Set up the core service object.
         let service = Arc::new(AgglayerService::new(core));
         let rpc_service = Arc::new(agglayer_rpc::AgglayerService::new(
-            data_sender,
+            data_sender.clone(),
             pending_store.clone(),
             state_store.clone(),
             debug_store.clone(),
@@ -264,6 +264,7 @@ impl Node {
         ));
 
         let admin_router = AdminAgglayerImpl::new(
+            data_sender,
             pending_store.clone(),
             state_store.clone(),
             debug_store.clone(),


### PR DESCRIPTION
Fixes https://github.com/agglayer/agglayer/issues/1048

Does not add the guarantee that there's no CertificateTask live for this cert yet, akin to admin_forcePushCertificate. We should probably fix both at the same time later downstream, for now this is assumed to be guaranteed by the admin user calling the API.