### PR TITLE
fix: always verify the last merkle link

### DIFF
--- a/crates/pessimistic-proof-core/src/aggchain_data/mod.rs
+++ b/crates/pessimistic-proof-core/src/aggchain_data/mod.rs
@@ -16,8 +16,7 @@ pub use crate::aggchain_data::{
 };
 use crate::{
     local_state::commitment::{
-        PessimisticRootCommitmentValues, PessimisticRootCommitmentVersion,
-        SignatureCommitmentValues, SignatureCommitmentVersion,
+        PessimisticRootCommitmentVersion, SignatureCommitmentValues, SignatureCommitmentVersion,
     },
     proof::ConstrainedValues,
     ProofError,
@@ -124,8 +123,7 @@ impl AggchainData {
         };
 
         // Verify initial state commitment and PP root matches
-        let base_pp_root_version = PessimisticRootCommitmentValues::from(&constrained_values)
-            .infer_settled_pp_root_version(constrained_values.prev_pessimistic_root)?;
+        let base_pp_root_version = constrained_values.prev_pessimistic_root_version;
 
         match (base_pp_root_version, target_pp_root_version) {
             // From V2 to V2: OK


### PR DESCRIPTION
Based on (my basic analysis of the report and mostly) @hadjiszs's awesome explanation of where the check is currently, without which I definitely wouldn't have been able to write this as quickly :purple_heart: 

Hopefully this will be a correct fix! I wrote it very quickly trying to be in time for the release planned for tomorrow