### PR TITLE
Introduce health and readiness endpoints separate from ReadRPC

### DIFF
--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -206,6 +206,11 @@ impl Config {
         std::net::SocketAddr::from((self.rpc.host, self.rpc.admin_port.as_u16()))
     }
 
+    /// Get the health check RPC socket address from the configuration.
+    pub fn health_check_addr(&self) -> std::net::SocketAddr {
+        std::net::SocketAddr::from((self.rpc.host, self.rpc.health_port.as_u16()))
+    }
+
     pub fn path_contextualized(mut self, base_path: &Path) -> Self {
         self.storage = self.storage.path_contextualized(base_path);
 

--- a/crates/agglayer-config/src/rpc.rs
+++ b/crates/agglayer-config/src/rpc.rs
@@ -24,6 +24,12 @@ impl PortDefaults for AdminService {
     const ENV_VAR: Option<&str> = Some("AGGLAYER_ADMIN_PORT");
 }
 
+pub enum HealthService {}
+impl PortDefaults for HealthService {
+    const DEFAULT: u16 = 9092;
+    const ENV_VAR: Option<&str> = Some("AGGLAYER_HEALTH_PORT");
+}
+
 /// The local RPC server configuration.
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -46,6 +52,12 @@ pub struct RpcConfig {
     /// 9091.
     #[serde(default)]
     pub admin_port: Port<AdminService>,
+
+    /// The default port for the local HealthRPC server.
+    /// Overridden by `AGGLAYER_HEALTH_PORT` environment variable, defaults to
+    /// 9092.
+    #[serde(default)]
+    pub health_port: Port<HealthService>,
 
     #[serde(default = "default_host")]
     pub host: Ipv4Addr,
@@ -93,6 +105,7 @@ impl Default for RpcConfig {
             grpc_port: Default::default(),
             readrpc_port: Default::default(),
             admin_port: Default::default(),
+            health_port: Default::default(),
             host: default_host(),
             max_request_body_size: default_body_size(),
             max_response_body_size: default_body_size(),

--- a/crates/agglayer-jsonrpc-api/src/testutils.rs
+++ b/crates/agglayer-jsonrpc-api/src/testutils.rs
@@ -1,4 +1,8 @@
-use std::{future::IntoFuture as _, net::SocketAddr, sync::Arc};
+use std::{
+    future::IntoFuture as _,
+    net::SocketAddr,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 use agglayer_config::Config;
 use agglayer_contracts::L1RpcClient;
@@ -153,6 +157,7 @@ impl TestContext {
             epochs_store,
             config.clone(),
             Arc::new(l1_rpc_client),
+            Arc::new(AtomicBool::new(true)),
         ));
 
         // Create AgglayerImpl
@@ -301,6 +306,7 @@ impl TestContext {
             epochs_store,
             config.clone(),
             Arc::new(l1_rpc_client),
+            Arc::new(AtomicBool::new(true)),
         ));
 
         // Create AgglayerImpl

--- a/crates/agglayer-node/src/node/api/rest.rs
+++ b/crates/agglayer-node/src/node/api/rest.rs
@@ -1,4 +1,9 @@
+use std::sync::atomic::Ordering;
+
+use axum::extract::State;
 use hyper::StatusCode;
+
+use crate::node::ReadinessState;
 
 pub(crate) fn health_router() -> axum::Router {
     axum::Router::new().route("/health", axum::routing::get(health))
@@ -8,5 +13,21 @@ pub(crate) async fn health() -> impl axum::response::IntoResponse {
     (
         StatusCode::OK,
         serde_json::json!({ "health": true }).to_string(),
+    )
+}
+
+pub(crate) fn readiness_router(state: ReadinessState) -> axum::Router {
+    axum::Router::new()
+        .route("/ready", axum::routing::get(readiness))
+        .with_state(state)
+}
+
+pub(crate) async fn readiness(state: State<ReadinessState>) -> impl axum::response::IntoResponse {
+    (
+        StatusCode::OK,
+        serde_json::json!({
+            "rpc": state.rpc.load(Ordering::Relaxed),
+        })
+        .to_string(),
     )
 }


### PR DESCRIPTION
Fixes #825.

This PR aims to separate the health port from the ReadRPC port, and combines it with a new readiness endpoint that allows users to ping it to gain insight as to whether the services hosted by the server (e.g. gRPC) is ready to receive and process requests.