### PR TITLE
chore: Audit SIGP:AGLPP-03.2 Copy-Paste Doc

### DIFF
--- a/crates/pessimistic-proof-core/src/local_balance_tree.rs
+++ b/crates/pessimistic-proof-core/src/local_balance_tree.rs
@@ -10,12 +10,12 @@ use crate::ProofError;
 /// id and 160 for token address).
 pub const LOCAL_BALANCE_TREE_DEPTH: usize = 192;
 
-/// A commitment to the set of per-network nullifier trees maintained by the
+/// A commitment to the set of per-network local balance trees maintained by the
 /// local network
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LocalBalanceTree {
-    /// The Merkle Root of the nullifier tree
+    /// The Merkle Root of the local balance tree
     #[serde_as(as = "_")]
     pub root: Digest,
 }

--- a/crates/pessimistic-proof/src/local_balance_tree.rs
+++ b/crates/pessimistic-proof/src/local_balance_tree.rs
@@ -4,12 +4,12 @@ pub use pessimistic_proof_core::local_balance_tree::{LocalBalancePath, LOCAL_BAL
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-/// A commitment to the set of per-network nullifier trees maintained by the
+/// A commitment to the set of per-network local balance trees maintained by the
 /// local network
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LocalBalanceTree {
-    /// The Merkle Root of the nullifier tree
+    /// The Merkle Root of the local balance tree
     #[serde_as(as = "_")]
     pub root: Digest,
 }


### PR DESCRIPTION
Update all references to "nullifier tree" in local_balance_tree documentation to correctly reference "local balance tree" or "balance tree".

Closes https://github.com/agglayer/security/issues/183
