### PR TITLE
chore(cli): remove duplicate error context in Vkey command

### DIFF
--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -38,9 +38,7 @@ fn main() -> eyre::Result<()> {
                 .enable_all()
                 .build()?
                 .block_on(async move {
-                    let vkey_hex = compute_program_vkey(ELF)
-                        .await
-                        .context("Failed to compute program vkey");
+                    let vkey_hex = compute_program_vkey(ELF).await;
                     match vkey_hex {
                         Ok(vkey_hex) => println!("{vkey_hex}"),
                         Err(error) => eprintln!("{error:?}"),


### PR DESCRIPTION
The Vkey CLI path added an outer .context("Failed to compute program vkey") on top of compute_program_vkey, which already annotates the error with the same message. This produced duplicated context layers without adding value. Removing the outer context keeps error reporting consistent with other call sites and avoids redundant noise while preserving the inner, actionable context.