### PR TITLE
chore: remove unused import

### DIFF
--- a/crates/agglayer-rate-limiting/src/local/state/wall_clock.rs
+++ b/crates/agglayer-rate-limiting/src/local/state/wall_clock.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZeroU32, time::Duration};
 
-use serde_with::{serde_as, DurationSeconds};
+use serde_with::DurationSeconds;
 use tokio::time::Instant;
 
 /// An error indicating the request has been rate limited.


### PR DESCRIPTION
A recent nightly compiler started flagging this up. The fix is required to unblock the CI because the clippy job uses the nightly compiler.