### PR TITLE
fix(signer): implement set_chain_id for KMS signer

### DIFF
--- a/crates/agglayer-signer/src/lib.rs
+++ b/crates/agglayer-signer/src/lib.rs
@@ -152,11 +152,8 @@ impl Signer for ConfiguredSigner {
             ConfiguredSigner::Local(wallet) => {
                 wallet.set_chain_id(chain_id);
             }
-            ConfiguredSigner::Kms(_signer) => {
-                // KMS signer doesn't support mutable chain ID changes in the
-                // current implementation This is a limitation
-                // of the KmsSigner wrapper
-                panic!("KMS signer doesn't support mutable chain ID changes");
+            ConfiguredSigner::Kms(signer) => {
+                signer.set_chain_id(chain_id);
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes incorrect panic in `ConfiguredSigner::set_chain_id` for KMS signer. The method now properly delegates to `KmsSigner::set_chain_id` instead of panicking.

## Changes

- Replace panic with `signer.set_chain_id(chain_id)` call in `ConfiguredSigner::set_chain_id` for KMS variant
- Remove outdated comment about KMS signer limitation