### PR TITLE
fix: check proof existence before insertion to prevent overwrite

### DIFF
--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -287,8 +287,15 @@ where
         } else {
             info!("Successfully generated and verified the p-proof!");
 
-            // TODO: Check if the key already exists
-            pending_store.insert_generated_proof(&certificate_id, &proof)?;
+            // Check if proof already exists to avoid overwriting without notice
+            if let Some(_existing_proof) = pending_store.get_proof(certificate_id)? {
+                warn!(
+                    %certificate_id,
+                    "Proof already exists for certificate, skipping insertion to avoid overwrite"
+                );
+            } else {
+                pending_store.insert_generated_proof(&certificate_id, &proof)?;
+            }
 
             // Prune the SMTs of the state
             state

--- a/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
@@ -58,6 +58,12 @@ async fn happy_path() {
         .return_once(|_, _| Ok(Some(certificate)));
 
     pending_store
+        .expect_get_proof()
+        .once()
+        .with(eq(certificate_id))
+        .return_once(|_| Ok(None));
+
+    pending_store
         .expect_insert_generated_proof()
         .once()
         .with(eq(certificate_id), always())


### PR DESCRIPTION
Check if proof already exists before inserting to avoid overwriting.

Fixes the TODO. If proof exists, we log a warning and skip insertion
instead of silently overwriting it.