### PR TITLE
chore: remove unused imports in cli and main

### DIFF
--- a/crates/agglayer/src/cli.rs
+++ b/crates/agglayer/src/cli.rs
@@ -1,5 +1,5 @@
 //! Agglayer command line interface.
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueHint};
 


### PR DESCRIPTION
Remove unused imports in cli and main