### PR TITLE
docs: clarify LatestProvenCertificatePerNetworkColumn value format

### DIFF
--- a/crates/agglayer-storage/src/columns/latest_proven_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_proven_certificate_per_network/mod.rs
@@ -4,14 +4,14 @@ use serde::{Deserialize, Serialize};
 use super::{ColumnSchema, LATEST_PROVEN_CERTIFICATE_PER_NETWORK_CF};
 
 /// Column family for the latest proven certificate per network.
-/// The key is the network_id and the value is the certificateID and
-/// the height.
+/// The key is the network_id and the value is a `ProvenCertificate`
+/// containing the certificate ID, the network ID and the height.
 ///
 /// ## Column definition
 ///
-/// | key         | value                       |
-/// | --          | --                          |
-/// | `NetworkId` | (`CertificateId`, `Height`) |
+/// | key         | value                                    |
+/// | --          | --                                       |
+/// | `NetworkId` | (`CertificateId`, `NetworkId`, `Height`) |
 pub struct LatestProvenCertificatePerNetworkColumn;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
The previous documentation for `LatestProvenCertificatePerNetworkColumn` claimed that the value was `(CertificateId, Height)`, but the actual persisted type is `ProvenCertificate(CertificateId, NetworkId, Height)`. The orchestrator and tests already rely on this full structure, and the on-disk format is correct. This change only updates the column documentation to match the real value layout so that future readers are not misled when inspecting the schema or implementing migrations.