### PR TITLE
fix: make rpc ping_interval configurable

### DIFF
--- a/crates/agglayer-config/src/rpc.rs
+++ b/crates/agglayer-config/src/rpc.rs
@@ -77,7 +77,7 @@ pub struct RpcConfig {
     pub batch_request_limit: Option<u32>,
 
     /// The interval at which to send ping messages
-    #[serde(skip)]
+    #[serde(skip_serializing_if = "crate::is_default")]
     #[serde_as(as = "Option<crate::with::HumanDuration>")]
     pub ping_interval: Option<Duration>,
 


### PR DESCRIPTION
The rpc.ping_interval field in RpcConfig was annotated with #[serde(skip)], which made it impossible to configure from agglayer.toml and kept WebSocket ping/pong permanently disabled, even when the JSON-RPC servers read this value. This change removes the skip attribute and uses HumanDuration with skip_serializing_if, so rpc.ping-interval can now be set via config while remaining None by default when not specified.