### PR TITLE
fix: return TxNotFound before querying L1 block height

### DIFF
--- a/crates/agglayer-jsonrpc-api/src/service/mod.rs
+++ b/crates/agglayer-jsonrpc-api/src/service/mod.rs
@@ -132,15 +132,18 @@ where
     pub async fn get_tx_status(&self, hash: B256) -> Result<TxStatus, TxStatusError> {
         debug!("Received request to get transaction status for l1 tx hash {hash}");
 
-        let receipt = self.kernel.check_tx_status(hash).await.map_err(|error| {
-            error!(
-                ?error,
-                "Failed to get transaction status for l1 tx hash {hash}"
-            );
-            TxStatusError::StatusCheck(error)
-        })?;
-
-        let receipt = receipt.ok_or_else(|| TxStatusError::TxNotFound { hash })?;
+        let receipt = self
+            .kernel
+            .check_tx_status(hash)
+            .await
+            .map_err(|error| {
+                error!(
+                    ?error,
+                    "Failed to get transaction status for l1 tx hash {hash}"
+                );
+                TxStatusError::StatusCheck(error)
+            })?
+            .ok_or_else(|| TxStatusError::TxNotFound { hash })?;
 
         let current_block = self
             .kernel


### PR DESCRIPTION
Adjusted the error handling order in `AgglayerService::get_tx_status`. Now first inspect the receipt result from 
check_tx_status and immediately return TxStatusError::TxNotFound when no receipt is found, without performing an additional 
current_l1_block_height RPC call. This removes an unnecessary L1 request for non-existent transactions and ensures that the “transaction not found” condition is never masked by a later failure to fetch the current L1 block height.