### PR TITLE
fix: correct typo in aggchain_data_payload variable name

### DIFF
--- a/crates/agglayer-aggregator-notifier/src/certifier/l1_context.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/l1_context.rs
@@ -46,7 +46,7 @@ where
 
         let l1_info_root = self.fetch_l1_info_root(certificate).await?;
 
-        let aggchain_data_paylaod = CertificateAggchainData::try_from(
+        let aggchain_data_payload = CertificateAggchainData::try_from(
             certificate.aggchain_data.clone(),
         )
         .map_err(|source| CertificationError::Types {
@@ -62,7 +62,7 @@ where
 
         // Fetch context based on the aggchain data type that we received from the
         // chain.
-        let aggchain_data_ctx: CertificateAggchainDataCtx = match aggchain_data_paylaod {
+        let aggchain_data_ctx: CertificateAggchainDataCtx = match aggchain_data_payload {
             CertificateAggchainData::LegacyEcdsa { .. } => {
                 let signer = self
                     .l1_rpc


### PR DESCRIPTION
## **PR Description**

Identified and fixed a misspelling in the `fetch_l1_context` function.

**Changes:**

* Renamed `aggchain_data_paylaod` to `aggchain_data_payload`.

This is a non-functional change to improve code readability and maintainability.