### PR TITLE
feat: use settlement job ID instead of tx hash until certificate is s…

### DIFF
--- a/crates/agglayer-certificate-orchestrator/src/settlement_client.rs
+++ b/crates/agglayer-certificate-orchestrator/src/settlement_client.rs
@@ -1,4 +1,6 @@
-use agglayer_types::{CertificateId, CertificateIndex, EpochNumber, NetworkId, SettlementTxHash};
+use agglayer_types::{
+    CertificateId, CertificateIndex, EpochNumber, NetworkId, SettlementJobId, SettlementTxHash,
+};
 
 use crate::Error;
 
@@ -34,15 +36,15 @@ pub trait SettlementClient: Unpin + Send + Sync + 'static {
         &self,
         certificate_id: CertificateId,
         nonce: Option<NonceInfo>,
-    ) -> Result<SettlementTxHash, Error>;
+    ) -> Result<SettlementJobId, Error>;
 
-    /// Watch for the transaction to be mined and update the certificate
-    /// accordingly.
+    /// Watch for the settlement job to complete and return the settlement transaction hash
+    /// along with epoch and index.
     async fn wait_for_settlement(
         &self,
-        settlement_tx_hash: SettlementTxHash,
+        settlement_job_id: SettlementJobId,
         certificate_id: CertificateId,
-    ) -> Result<(EpochNumber, CertificateIndex), Error>;
+    ) -> Result<(SettlementTxHash, EpochNumber, CertificateIndex), Error>;
 
     /// Returns a reference to the provider for direct L1 queries.
     fn get_provider(&self) -> &Self::Provider;

--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -28,6 +28,7 @@ use agglayer_storage::{
 };
 use agglayer_types::{
     Certificate, CertificateHeader, CertificateId, CertificateIndex, CertificateStatus, Digest,
+    SettlementJobId,
     EpochNumber, ExecutionMode, Height, LocalNetworkStateData, NetworkId, Proof, SettlementTxHash,
 };
 use arc_swap::ArcSwap;
@@ -355,6 +356,7 @@ impl StateWriter for DummyPendingStore {
                 new_local_exit_root: certificate.new_local_exit_root,
                 status,
                 metadata: certificate.metadata,
+                settlement_job_id: None,
                 settlement_tx_hash: None,
             },
         );
@@ -927,18 +929,23 @@ impl SettlementClient for Check {
         &self,
         _certificate_id: CertificateId,
         _nonce_info: Option<NonceInfo>,
-    ) -> Result<SettlementTxHash, Error> {
-        Ok(SettlementTxHash::for_tests())
+    ) -> Result<SettlementJobId, Error> {
+        use ulid::Ulid;
+        Ok(SettlementJobId::new(Ulid::new()))
     }
 
-    /// Watch for the transaction to be mined and update the certificate
-    /// accordingly
+    /// Watch for the settlement job to complete and return the settlement transaction hash
+    /// along with epoch and index.
     async fn wait_for_settlement(
         &self,
-        _settlement_tx_hash: SettlementTxHash,
+        _settlement_job_id: SettlementJobId,
         _certificate_id: CertificateId,
-    ) -> Result<(EpochNumber, CertificateIndex), Error> {
-        Ok((EpochNumber::ZERO, CertificateIndex::ZERO))
+    ) -> Result<(SettlementTxHash, EpochNumber, CertificateIndex), Error> {
+        Ok((
+            SettlementTxHash::for_tests(),
+            EpochNumber::ZERO,
+            CertificateIndex::ZERO,
+        ))
     }
 
     fn get_provider(&self) -> &Self::Provider {

--- a/crates/agglayer-rpc/src/tests/network_info.rs
+++ b/crates/agglayer-rpc/src/tests/network_info.rs
@@ -56,6 +56,7 @@ fn transient_network_info() {
         new_local_exit_root: pending_certificate.new_local_exit_root,
         metadata: Metadata::DEFAULT,
         status: agglayer_types::CertificateStatus::Pending,
+        settlement_job_id: None,
         settlement_tx_hash: None,
     };
 
@@ -186,6 +187,7 @@ fn pending_certificate_defined() {
         new_local_exit_root: pending_certificate.new_local_exit_root,
         metadata: Metadata::DEFAULT,
         status: agglayer_types::CertificateStatus::Pending,
+        settlement_job_id: None,
         settlement_tx_hash: None,
     };
 

--- a/crates/agglayer-storage/src/columns/certificate_header/tests.rs
+++ b/crates/agglayer-storage/src/columns/certificate_header/tests.rs
@@ -26,6 +26,7 @@ fn can_parse_value() {
         new_local_exit_root: [5; 32].into(),
         status: agglayer_types::CertificateStatus::Pending,
         metadata: Metadata::new([6; 32].into()),
+        settlement_job_id: None,
         settlement_tx_hash: None,
     };
 

--- a/crates/agglayer-storage/src/columns/certificate_per_network/tests.rs
+++ b/crates/agglayer-storage/src/columns/certificate_per_network/tests.rs
@@ -31,6 +31,7 @@ fn can_parse_value() {
         new_local_exit_root: [5; 32].into(),
         status: agglayer_types::CertificateStatus::Pending,
         metadata: Metadata::new([6; 32].into()),
+        settlement_job_id: None,
         settlement_tx_hash: None,
     };
 

--- a/crates/agglayer-storage/src/stores/interfaces/writer.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/writer.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use agglayer_types::{
     primitives::Digest, Certificate, CertificateId, CertificateIndex, CertificateStatus,
-    EpochNumber, ExecutionMode, Height, LocalNetworkStateData, NetworkId, Proof, SettlementTxHash,
+    EpochNumber, ExecutionMode, Height, LocalNetworkStateData, NetworkId, Proof, SettlementJobId,
+    SettlementTxHash,
 };
 
 use crate::{error::Error, stores::PerEpochReader};
@@ -57,6 +58,17 @@ pub trait StateWriter: Send + Sync {
 
     fn enable_network(&self, network_id: &NetworkId) -> Result<(), Error>;
 
+    /// Update settlement job ID. Used when settlement is submitted but not yet settled.
+    fn update_settlement_job_id(
+        &self,
+        certificate_id: &CertificateId,
+        job_id: SettlementJobId,
+        force: UpdateEvenIfAlreadyPresent,
+        set_status: UpdateStatusToCandidate,
+    ) -> Result<(), Error>;
+
+    /// Update settlement transaction hash. Used when certificate is marked as Settled.
+    /// This should clear the settlement_job_id and set the settlement_tx_hash.
     fn update_settlement_tx_hash(
         &self,
         certificate_id: &CertificateId,

--- a/crates/agglayer-storage/src/tests/mocks/state_store.rs
+++ b/crates/agglayer-storage/src/tests/mocks/state_store.rs
@@ -1,6 +1,6 @@
 use agglayer_types::{
     primitives::Digest, Certificate, CertificateHeader, CertificateId, CertificateStatus,
-    EpochNumber, Height, LocalNetworkStateData, NetworkId, SettlementTxHash,
+    EpochNumber, Height, LocalNetworkStateData, NetworkId, SettlementJobId, SettlementTxHash,
 };
 use mockall::mock;
 
@@ -34,6 +34,14 @@ mock! {
     }
 
     impl StateWriter for StateStore {
+        fn update_settlement_job_id(
+            &self,
+            certificate_id: &CertificateId,
+            job_id: SettlementJobId,
+            force: UpdateEvenIfAlreadyPresent,
+            set_status: UpdateStatusToCandidate,
+        ) -> Result<(), Error>;
+
         fn update_settlement_tx_hash(
             &self,
             certificate_id: &CertificateId,

--- a/crates/agglayer-types/Cargo.toml
+++ b/crates/agglayer-types/Cargo.toml
@@ -35,6 +35,7 @@ sp1-prover.workspace = true
 thiserror.workspace = true
 rand.workspace = true
 strum_macros.workspace = true
+ulid.workspace = true
 
 [dev-dependencies]
 agglayer-types = { path = ".", features = ["testutils"] }

--- a/crates/agglayer-types/benches/criterion.rs
+++ b/crates/agglayer-types/benches/criterion.rs
@@ -15,6 +15,7 @@ fn bench_parse_certificate_header(c: &mut Criterion) {
             new_local_exit_root: LocalExitRoot::default(),
             metadata: Metadata::default(),
             status: CertificateStatus::Pending,
+            settlement_job_id: None,
             settlement_tx_hash: None,
         })
         .unwrap();

--- a/crates/agglayer-types/src/certificate/header/mod.rs
+++ b/crates/agglayer-types/src/certificate/header/mod.rs
@@ -2,9 +2,11 @@ use crate::{
     CertificateId, CertificateIndex, EpochNumber, Height, LocalExitRoot, Metadata, NetworkId,
 };
 
+mod settlement_job_id;
 mod settlement_tx_hash;
 mod status;
 
+pub use settlement_job_id::SettlementJobId;
 pub use settlement_tx_hash::SettlementTxHash;
 pub use status::CertificateStatus;
 
@@ -19,5 +21,9 @@ pub struct CertificateHeader {
     pub new_local_exit_root: LocalExitRoot,
     pub metadata: Metadata,
     pub status: CertificateStatus,
+    /// Settlement job ID used to track settlement until marked as Settled.
+    /// Once settled, this is cleared and settlement_tx_hash is set.
+    pub settlement_job_id: Option<SettlementJobId>,
+    /// Settlement transaction hash. Only set when certificate is marked as Settled.
     pub settlement_tx_hash: Option<SettlementTxHash>,
 }

--- a/crates/agglayer-types/src/certificate/header/settlement_job_id.rs
+++ b/crates/agglayer-types/src/certificate/header/settlement_job_id.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use ulid::Ulid;
+
+/// Settlement job ID used to track settlement jobs until they are marked as Settled.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct SettlementJobId(Ulid);
+
+impl SettlementJobId {
+    /// Create a new settlement job ID from a ULID.
+    pub fn new(ulid: Ulid) -> Self {
+        Self(ulid)
+    }
+
+    /// Get the underlying ULID.
+    pub fn ulid(&self) -> Ulid {
+        self.0
+    }
+
+    /// Create a zero settlement job ID for testing.
+    #[cfg(any(test, feature = "testutils"))]
+    pub fn for_tests() -> Self {
+        Self(Ulid::from_bytes([0u8; 16]))
+    }
+}
+
+impl From<Ulid> for SettlementJobId {
+    fn from(ulid: Ulid) -> Self {
+        Self(ulid)
+    }
+}
+
+impl From<SettlementJobId> for Ulid {
+    fn from(job_id: SettlementJobId) -> Self {
+        job_id.0
+    }
+}
+
+impl std::fmt::Display for SettlementJobId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::str::FromStr for SettlementJobId {
+    type Err = ulid::DecodeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Ulid::from_string(s)?))
+    }
+}
+
+impl Serialize for SettlementJobId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Serialize ULID as bytes (16 bytes)
+        serializer.serialize_bytes(&self.0.to_bytes())
+    }
+}
+
+impl<'de> Deserialize<'de> for SettlementJobId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+        let bytes: Vec<u8> = Vec::deserialize(deserializer)?;
+        if bytes.len() != 16 {
+            return Err(D::Error::custom(format!(
+                "Expected 16 bytes for ULID, got {}",
+                bytes.len()
+            )));
+        }
+        let mut ulid_bytes = [0u8; 16];
+        ulid_bytes.copy_from_slice(&bytes);
+        Ok(Self(Ulid::from_bytes(ulid_bytes)))
+    }
+}
+

--- a/crates/agglayer-types/src/certificate/mod.rs
+++ b/crates/agglayer-types/src/certificate/mod.rs
@@ -21,7 +21,7 @@ mod metadata;
 #[cfg(feature = "testutils")]
 mod testutils;
 
-pub use header::{CertificateHeader, CertificateStatus, SettlementTxHash};
+pub use header::{CertificateHeader, CertificateStatus, SettlementJobId, SettlementTxHash};
 pub use height::Height;
 pub use id::CertificateId;
 pub use index::CertificateIndex;

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -18,7 +18,7 @@ pub mod testutils {
 }
 pub use certificate::{
     Certificate, CertificateHeader, CertificateId, CertificateIndex, CertificateStatus, Height,
-    Metadata, SettlementTxHash,
+    Metadata, SettlementJobId, SettlementTxHash,
 };
 pub use epoch::{EpochConfiguration, EpochNumber};
 pub use error::{CertificateStatusError, Error, SignerError};


### PR DESCRIPTION
Track settlement using job ID until certificate is marked as Settled, then store transaction hash.

- Add `SettlementJobId` type and field to `CertificateHeader`
- Update `SettlementClient` to return/accept job IDs
- Update certificate and network tasks to use job IDs until settled
- Clear job ID and set tx hash when status becomes Settled

Closes #1237