### PR TITLE
refactor: remove redundant invariant checks in RateLimiterCore

### DIFF
--- a/crates/agglayer-rate-limiting/src/local/limiter/core.rs
+++ b/crates/agglayer-rate-limiting/src/local/limiter/core.rs
@@ -37,8 +37,6 @@ impl<S: RawState> RateLimiterCore<S> {
     /// Reserve a rate limiting slot.
     pub fn reserve(&mut self, time: S::Instant) -> Result<SlotTracker, S::LimitedInfo> {
         let occupancy = self.query(time);
-        log_assert!(occupancy <= self.state.max_events());
-
         if occupancy < self.state.max_events() {
             self.reserved += 1;
             Ok(SlotTracker::new())
@@ -57,7 +55,6 @@ impl<S: RawState> RateLimiterCore<S> {
 
     /// Record a rate limiting event.
     pub fn record(&mut self, time: S::Instant, slot: SlotTracker) {
-        log_assert!(self.state.raw().query() < self.state.max_events());
         self.state.record(time);
         self.release(slot);
     }


### PR DESCRIPTION
Removed two redundant log_assert checks in RateLimiterCore::reserve and RateLimiterCore::record. The max_events invariants are already enforced by RateLimiterCore::query and State::record, so these extra checks did not add safety but did duplicate work on the hot path.