### PR TITLE
fix(storage): document CertificateIndex in latest settled column

### DIFF
--- a/crates/agglayer-storage/src/columns/latest_settled_certificate_per_network/mod.rs
+++ b/crates/agglayer-storage/src/columns/latest_settled_certificate_per_network/mod.rs
@@ -8,7 +8,7 @@ mod tests;
 
 /// Column family for the latest settled certificate per network.
 /// The key is the network_id and the value is the certificateID,
-/// the height and the epoch_number.
+/// the height, the epoch_number and the certificate_index.
 ///
 /// ## Column definition
 ///


### PR DESCRIPTION
The latest_settled_certificate_per_network column stored a SettledCertificate that already included CertificateIndex, but the high-level comment only mentioned CertificateId, Height and EpochNumber. This patch updates the documentation comment to reflect the actual value layout and keep it consistent with the existing table and the type definition.