### PR TITLE
refactor: remove Error derive from GenerationType

### DIFF
--- a/crates/agglayer-types/src/proof_modes.rs
+++ b/crates/agglayer-types/src/proof_modes.rs
@@ -15,7 +15,7 @@ impl ExecutionMode {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, thiserror::Error, PartialEq, Eq)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum GenerationType {
     Native,
     Prover,


### PR DESCRIPTION
GenerationType is a simple mode enum (Native / Prover) used as a field inside real error types and for serialization/formatting, but never as an error in Result or via ?. Deriving thiserror::Error on it did not provide any functional benefit, did not add Display (it already implements it manually), and was inconsistent with the rest of the codebase where only actual error types derive Error. This change removes the unnecessary Error derive