### PR TITLE
fix: guard L1 trace timing behind DEBUG

### DIFF
--- a/crates/agglayer-node/src/l1_tracing.rs
+++ b/crates/agglayer-node/src/l1_tracing.rs
@@ -52,21 +52,25 @@ where
 
         let inner_fut = self.inner.call(request);
         Box::pin(async move {
-            let start = tokio::time::Instant::now();
-            let res = inner_fut.await;
-            let elapsed_ms = start.elapsed().as_millis();
-            match &res {
-                Ok(response) => match response {
-                    Response::Single(response) => {
-                        debug!(seq_no, elapsed_ms, ?response, "L1 response")
-                    }
-                    Response::Batch(response) => {
-                        debug!(seq_no, elapsed_ms, ?response, "L1 batch response")
-                    }
-                },
-                Err(error) => debug!(seq_no, elapsed_ms, ?error, "L1 interaction error"),
+            if tracing::enabled!(tracing::Level::DEBUG) {
+                let start = tokio::time::Instant::now();
+                let res = inner_fut.await;
+                let elapsed_ms = start.elapsed().as_millis();
+                match &res {
+                    Ok(response) => match response {
+                        Response::Single(response) => {
+                            debug!(seq_no, elapsed_ms, ?response, "L1 response")
+                        }
+                        Response::Batch(response) => {
+                            debug!(seq_no, elapsed_ms, ?response, "L1 batch response")
+                        }
+                    },
+                    Err(error) => debug!(seq_no, elapsed_ms, ?error, "L1 interaction error"),
+                }
+                res
+            } else {
+                inner_fut.await
             }
-            res
         })
     }
 }


### PR DESCRIPTION
Guarded timing so it only runs when DEBUG is enabled. This ensures we don’t call Instant::now/elapsed when DEBUG logging is disabled, removing unnecessary per-request overhead while preserving detailed timing logs when debugging.