### PR TITLE
fix: avoid unused signature allocation in legacy aggchain hash

### DIFF
--- a/crates/pessimistic-proof-core/src/aggchain_data/aggchain_hash.rs
+++ b/crates/pessimistic-proof-core/src/aggchain_data/aggchain_hash.rs
@@ -73,11 +73,11 @@ impl AggchainHashValues {
 impl From<&AggchainData> for AggchainHashValues {
     fn from(value: &AggchainData) -> Self {
         match value {
-            AggchainData::LegacyEcdsa { signer, signature } => AggchainHashValues::ConsensusType1 {
+            AggchainData::LegacyEcdsa { signer, .. } => AggchainHashValues::ConsensusType1 {
                 aggchain_vkey: None,
                 aggchain_params: None,
                 multisig_hash: MultiSignature {
-                    signatures: vec![Some(*signature)],
+                    signatures: vec![],
                     expected_signers: vec![*signer],
                     threshold: 1,
                 }


### PR DESCRIPTION
Legacy ECDSA aggchain hash construction was allocating and copying a signature even though multisig_hash ignores signatures entirely and depends only on signers + threshold.
Removed the unused signature vector allocation when building the legacy multisig hash while keeping the hash inputs unchanged.