### PR TITLE
docs: fix incorrect aggchain_data field documentation

### DIFF
--- a/crates/agglayer-types/src/certificate/mod.rs
+++ b/crates/agglayer-types/src/certificate/mod.rs
@@ -60,8 +60,7 @@ pub struct Certificate {
     pub imported_bridge_exits: Vec<ImportedBridgeExit>,
     /// Fixed size field of arbitrary data for the chain needs.
     pub metadata: Metadata,
-    /// Aggchain data which can be one of: ECDSA, Generic proof, MultisigOnly,
-    /// or MultisigAndAggchainProof.
+    /// Aggchain data for the certificate.
     #[serde(flatten)]
     pub aggchain_data: AggchainData,
     #[serde(default)]


### PR DESCRIPTION
The comment said aggchain_data is "either one ECDSA or Generic proof" but the actual enum has 4 variants: ECDSA, Generic, MultisigOnly, and  MultisigAndAggchainProof. Updated the comment to match reality.