### PR TITLE
fix: make log_assert_eq panic only in debug

### DIFF
--- a/crates/agglayer-utils/src/assertions.rs
+++ b/crates/agglayer-utils/src/assertions.rs
@@ -37,7 +37,7 @@ macro_rules! log_assert_eq {
     ($lhs:expr, $rhs:expr $(,)?) => {
         match (&$lhs, &$rhs) {
             (lhs, rhs) => {
-                ::std::assert_eq!(lhs, rhs);
+                ::std::debug_assert_eq!(lhs, rhs);
                 if !(*lhs == *rhs) {
                     $crate::assertions::error!(
                         "INVARIANT VIOLATED in {}:{}: left: {lhs:?}, right: {rhs:?}",
@@ -51,7 +51,7 @@ macro_rules! log_assert_eq {
     ($lhs:expr, $rhs:expr, $($fmt:expr),+ $(,)?) => {
         match (&$lhs, &$rhs) {
             (lhs, rhs) => {
-                ::std::assert_eq!(lhs, rhs, $($fmt,)+);
+                ::std::debug_assert_eq!(lhs, rhs, $($fmt,)+);
                 if !(*lhs == *rhs) {
                     $crate::assertions::error!(
                         "INVARIANT VIOLATED in {}:{}: left: {lhs:?}, right: {rhs:?}, {}",


### PR DESCRIPTION
Reason for changes: `log_assert_eq!` used `assert_eq!`, which caused a panic in both debug and release when the invariant was violated, and the block with error! was never actually executed. This was inconsistent with the doc comment and tests, which expected a panic only when debug assertions were enabled and logging in release.
What was done: replaced `assert_eq!` with `debug_assert_eq!` in both branches of `log_assert_eq!` so that the macro only panics in debug builds and logs via error! when the invariant is violated in release, bringing its behavior in line with log_assert! and the documentation.