### PR TITLE
fix: fix backup list silently succeeding when backups are disabled

### DIFF
--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -60,6 +60,9 @@ fn main() -> eyre::Result<()> {
                     Ok(result) => println!("{}", serde_json::to_string(&result).unwrap()),
                     Err(error) => eprintln!("{error}"),
                 }
+            } else {
+                println!("Backups are not enabled in the configuration file.");
+                exit(1);
             }
         }
 


### PR DESCRIPTION
backup list returned exit code 0 with no output when backups were disabled in config, while backup restore correctly reported the error and exited with code 1.