### PR TITLE
fix(node): add Debug derive to L1TraceLayer

### DIFF
--- a/crates/agglayer-node/src/l1_tracing.rs
+++ b/crates/agglayer-node/src/l1_tracing.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 type Request = alloy::rpc::json_rpc::RequestPacket;
 type Response = alloy::rpc::json_rpc::ResponsePacket;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct L1TraceLayer;
 
 impl<S> tower::Layer<S> for L1TraceLayer {


### PR DESCRIPTION
What was wrong: `L1TraceLayer` was missing Debug derive while similar Layer types (`CancelLoggerLayer`,` LoggingTimeoutLayer`) in the codebase have it.
Summary: Added `Debug` to the derive macro for `L1TraceLayer` to maintain consistency with project conventions.