### PR TITLE
fix(storage): use idiomatic Entry pattern for end checkpoint update

### DIFF
--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -427,8 +427,9 @@ where
 
         debug!("Certificate assigned to epoch");
         if let Some(height) = end_checkpoint_entry_assignment {
-            let entry = end_checkpoint_entry.or_default();
-            *entry = height;
+            end_checkpoint_entry
+                .and_modify(|h| *h = height)
+                .or_insert(height);
 
             debug!(
                 "Updating end checkpoint for network {} to height {}",


### PR DESCRIPTION
The previous code used or_default() followed by assignment, which inserted Height::ZERO and then immediately overwrote it with the same value in the Vacant case. This was redundant and non-idiomatic.
 
Replace with and_modify().or_insert() pattern that handles both Vacant and Occupied cases correctly without unnecessary operations.