### PR TITLE
fix: remove duplicate record_connection_established call

### DIFF
--- a/crates/agglayer-clock/src/block.rs
+++ b/crates/agglayer-clock/src/block.rs
@@ -190,7 +190,6 @@ where
         })?;
 
         info!("Successfully subscribed to L1 block stream");
-        agglayer_telemetry::clock::record_connection_established();
 
         // Wait for genesis block if needed
         while self.latest_seen_block < self.genesis_block {


### PR DESCRIPTION
record_connection_established() was called twice on BlockClock creation: once inside WsConnectWithTimeout::connect() and again in new_with_ws(). Removed the redundant call in new_with_ws().