### PR TITLE
refactor(cli): deduplicate config printing logic

### DIFF
--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -9,6 +9,11 @@ use sp1_sdk::HashableKey as _;
 
 mod cli;
 
+fn print_toml_pretty(value: &agglayer_config::Config, context: &'static str) -> eyre::Result<()> {
+    println!("{}", toml::to_string_pretty(value).context(context)?);
+    Ok(())
+}
+
 fn main() -> eyre::Result<()> {
     dotenvy::dotenv().ok();
 
@@ -16,19 +21,14 @@ fn main() -> eyre::Result<()> {
 
     match cli.cmd {
         cli::Commands::Run { cfg } => agglayer_node::main(cfg, &version(), None)?,
-        cli::Commands::Config { base_dir } => println!(
-            "{}",
-            toml::to_string_pretty(&agglayer_config::Config::new(&base_dir))
-                .context("Failed to serialize Config to TOML")?
-        ),
+        cli::Commands::Config { base_dir } => print_toml_pretty(
+            &agglayer_config::Config::new(&base_dir),
+            "Failed to serialize Config to TOML",
+        )?,
         cli::Commands::ValidateConfig { path } => {
             match agglayer_config::Config::try_load(path.as_path()) {
                 Ok(config) => {
-                    println!(
-                        "{}",
-                        toml::to_string_pretty(&config)
-                            .context("Failed to serialize ValidateConfig to TOML")?
-                    );
+                    print_toml_pretty(&config, "Failed to serialize ValidateConfig to TOML")?;
                 }
                 Err(error) => eprintln!("{error}"),
             }


### PR DESCRIPTION
Avoid code drift between `config` and `validate-config` commands by centralizing how `agglayer_config::Config` is rendered to TOML and printed.
