### PR TITLE
docs: add clarification, debugging, and verification guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,21 @@
 - Keep recommendations short, opinionated, and tied to tradeoffs.
 - If multiple paths exist, present one default path and one fallback.
 
+## Clarification Before Action
+
+- If ambiguity can affect correctness, security, scope, or destination path, ask before acting.
+- If ambiguity is low-risk, state one explicit assumption and proceed with the smallest reversible change.
+
+## Evidence-Based Debugging and Communication
+
+- Avoid overconfidence. Do not present uncertain conclusions as facts.
+- State uncertainty explicitly when evidence is incomplete.
+- Present multiple viable options when tradeoffs exist; let the user choose.
+- Treat root-cause analysis as hypothesis-first until verified.
+- Use evidence-based language: prefer "might", "could", or "one possibility is" before validation.
+- Do not claim causality without proof from logs, traces, tests, debugger output, or reproducible steps.
+- Follow evidence-first debugging: collect data (including targeted logs when needed) before proposing or applying a fix.
+
 ## Dedicated domain behavior (Agglayer)
 - Explicitly frame advice in Agglayer terms: cross-chain settlement, proofs, bridge safety, and operational reliability.
 - Prefer changes that improve safety invariants, observability, and rollback clarity over local optimizations.
@@ -13,6 +28,15 @@
 ## Collaboration norms
 - Confirm assumptions in one sentence when requirements are ambiguous, then proceed with the safest minimal change.
 - Surface risks early (consensus/security/regression/perf) and suggest one concrete verification step.
+- Precedence: when rules conflict, favor the Clarification Before Action section.
+
+## Definition of Done
+- Documentation-only changes are not exempt: run verification before declaring completion.
+- Default verification: run `cargo check --workspace --tests --all-features`.
+- For code behavior changes, run `cargo make ci-all`.
+- Report exact command(s) and whether each passed or failed.
+- If checks fail, attempt focused fixes for failures plausibly caused by your changes, then rerun checks.
+- Do not loop: stop after 2 fix-and-rerun cycles or if failures appear unrelated to your changes, then hand control back with a brief summary.
 
 ## Commit convention
 - Use Conventional Commits exactly: `<type>(<optional-scope>): <description>`.


### PR DESCRIPTION
Establishes clearer protocols for handling ambiguity, debugging with uncertainty, and defining completion criteria including mandatory verification steps for all changes.