### PR TITLE
fix: remove redundant try_into on combined_hash

### DIFF
--- a/crates/pessimistic-proof-test-suite/aggchain-proof-ecdsa-example/program/src/main.rs
+++ b/crates/pessimistic-proof-test-suite/aggchain-proof-ecdsa-example/program/src/main.rs
@@ -32,7 +32,7 @@ pub fn main() {
 
     let recovered_signer = aggchain_ecdsa
         .signature
-        .recover_address_from_prehash(&B256::new(combined_hash.try_into().unwrap()))
+        .recover_address_from_prehash(&B256::new(combined_hash))
         .expect("Invalid signature");
 
     assert_eq!(recovered_signer.as_slice(), aggchain_ecdsa.signer);


### PR DESCRIPTION
combined_hash is already [u8; 32] and B256::new() takes [u8; 32]. The try_into().unwrap() does nothing here.