### PR TITLE
test(storage): centralize tx result success test fixture

### DIFF
--- a/crates/agglayer-storage/src/columns/settlement_attempt_results/tests.rs
+++ b/crates/agglayer-storage/src/columns/settlement_attempt_results/tests.rs
@@ -3,10 +3,7 @@ use ulid::Ulid;
 use crate::{
     schema::Codec as _,
     types::{
-        generated::agglayer::storage::v0::{
-            settlement_attempt_result, BlockHash, BlockNumber, ContractCallMetadata,
-            ContractCallOutcome, ContractCallResult, SettlementAttemptResult, TxHash,
-        },
+        generated::agglayer::storage::v0::SettlementAttemptResult,
         settlement::{
             attempt,
             attempt_result::{Key, Value},
@@ -20,7 +17,7 @@ fn settlement_attempt_result_roundtrip_codec() {
         settlement_job_id: Ulid::from(7u128),
         attempt_sequence_number: 3,
     };
-    let value = mk_attempt_result_success();
+    let value = SettlementAttemptResult::contract_call_success_for_test(23);
 
     let encoded_key = key.encode().expect("Unable to encode key");
     let decoded_key = Key::decode(&encoded_key).expect("Unable to decode key");
@@ -33,24 +30,4 @@ fn settlement_attempt_result_roundtrip_codec() {
     let encoded_value = value.encode().expect("Unable to encode value");
     let decoded_value = Value::decode(&encoded_value).expect("Unable to decode value");
     assert_eq!(decoded_value, value);
-}
-
-fn mk_attempt_result_success() -> SettlementAttemptResult {
-    SettlementAttemptResult {
-        result: Some(settlement_attempt_result::Result::ContractCallResult(
-            ContractCallResult {
-                outcome: ContractCallOutcome::Success as i32,
-                metadata: Some(ContractCallMetadata {
-                    metadata: vec![0xab, 0xcd].into(),
-                }),
-                block_hash: Some(BlockHash {
-                    hash: vec![0x44; 32].into(),
-                }),
-                block_number: Some(BlockNumber { number: 123 }),
-                tx_hash: Some(TxHash {
-                    hash: vec![0x55; 32].into(),
-                }),
-            },
-        )),
-    }
 }

--- a/crates/agglayer-storage/src/columns/settlement_job_results/tests.rs
+++ b/crates/agglayer-storage/src/columns/settlement_job_results/tests.rs
@@ -3,10 +3,7 @@ use ulid::Ulid;
 use crate::{
     schema::Codec as _,
     types::{
-        generated::agglayer::storage::v0::{
-            BlockHash, BlockNumber, ContractCallMetadata, ContractCallOutcome, ContractCallResult,
-            SettlementJobResult, TxHash,
-        },
+        generated::agglayer::storage::v0::SettlementJobResult,
         settlement::job_result::{Key, Value},
     },
 };
@@ -14,7 +11,7 @@ use crate::{
 #[test]
 fn settlement_job_result_roundtrip_codec() {
     let key = Ulid::from(7u128);
-    let value = mk_job_result_success();
+    let value = SettlementJobResult::contract_call_success_for_test(23);
 
     let encoded_key = key.encode().expect("Unable to encode key");
     let decoded_key = Key::decode(&encoded_key).expect("Unable to decode key");
@@ -23,22 +20,4 @@ fn settlement_job_result_roundtrip_codec() {
     let encoded_value = value.encode().expect("Unable to encode value");
     let decoded_value = Value::decode(&encoded_value).expect("Unable to decode value");
     assert_eq!(decoded_value, value);
-}
-
-fn mk_job_result_success() -> SettlementJobResult {
-    SettlementJobResult {
-        contract_call_result: Some(ContractCallResult {
-            outcome: ContractCallOutcome::Success as i32,
-            metadata: Some(ContractCallMetadata {
-                metadata: vec![0xab, 0xcd].into(),
-            }),
-            block_hash: Some(BlockHash {
-                hash: vec![0x44; 32].into(),
-            }),
-            block_number: Some(BlockNumber { number: 123 }),
-            tx_hash: Some(TxHash {
-                hash: vec![0x55; 32].into(),
-            }),
-        }),
-    }
 }

--- a/crates/agglayer-storage/src/stores/state/tests/settlement.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/settlement.rs
@@ -4,8 +4,7 @@ use std::{
 };
 
 use agglayer_types::{
-    Address, ContractCallOutcome, ContractCallResult, Digest, Nonce, SettlementAttempt,
-    SettlementAttemptResult, SettlementJob, SettlementJobResult, SettlementTxHash, B256, U256,
+    Address, Digest, Nonce, SettlementAttempt, SettlementJob, SettlementTxHash, U256,
 };
 use ulid::Ulid;
 
@@ -20,10 +19,13 @@ use crate::{
     error::Error,
     stores::{state::StateStore, SettlementReader as _, SettlementWriter as _},
     tests::TempDBDir,
-    types::settlement::{
-        attempt::Key as SettlementAttemptKey,
-        attempt_per_wallet::{
-            Key as SettlementAttemptPerWalletKey, Value as SettlementAttemptPerWalletValue,
+    types::{
+        generated::agglayer::storage::v0,
+        settlement::{
+            attempt::Key as SettlementAttemptKey,
+            attempt_per_wallet::{
+                Key as SettlementAttemptPerWalletKey, Value as SettlementAttemptPerWalletValue,
+            },
         },
     },
 };
@@ -56,26 +58,6 @@ fn mk_settlement_attempt(seed: u64) -> SettlementAttempt {
         hash: SettlementTxHash::new(Digest::from([(seed as u8).wrapping_add(4); 32])),
         submission_time: SystemTime::UNIX_EPOCH + Duration::from_secs(seed),
     }
-}
-
-fn mk_attempt_result_success(seed: u8) -> SettlementAttemptResult {
-    SettlementAttemptResult::ContractCall(ContractCallResult {
-        outcome: ContractCallOutcome::Success,
-        metadata: vec![seed, seed.wrapping_add(1)].into(),
-        block_hash: B256::from([seed; 32]),
-        block_number: seed as u64 + 100,
-        tx_hash: SettlementTxHash::new(Digest::from([seed.wrapping_add(2); 32])),
-    })
-}
-
-fn mk_job_result_success(seed: u8) -> SettlementJobResult {
-    SettlementJobResult::ContractCall(ContractCallResult {
-        outcome: ContractCallOutcome::Success,
-        metadata: vec![seed, seed.wrapping_add(1)].into(),
-        block_hash: B256::from([seed; 32]),
-        block_number: seed as u64 + 100,
-        tx_hash: SettlementTxHash::new(Digest::from([seed.wrapping_add(2); 32])),
-    })
 }
 
 fn setup_store() -> (TempDBDir, Arc<crate::storage::DB>, StateStore) {
@@ -165,7 +147,13 @@ fn insert_settlement_attempt_result_succeeds_once() {
         .insert_settlement_attempt(&job_id, 1, &mk_settlement_attempt(1))
         .expect("attempt insert must succeed");
     assert!(store
-        .insert_settlement_attempt_result(&job_id, 1, &mk_attempt_result_success(1))
+        .insert_settlement_attempt_result(
+            &job_id,
+            1,
+            &v0::SettlementAttemptResult::contract_call_success_for_test(1)
+                .try_into()
+                .expect("test tx result helper should be decodable"),
+        )
         .is_ok());
 }
 
@@ -173,8 +161,12 @@ fn insert_settlement_attempt_result_succeeds_once() {
 fn insert_settlement_attempt_result_duplicate_fails() {
     let (_tmp, db, store) = setup_store();
     let job_id = mk_ulid(6);
-    let first = mk_attempt_result_success(1);
-    let second = mk_attempt_result_success(2);
+    let first = v0::SettlementAttemptResult::contract_call_success_for_test(1)
+        .try_into()
+        .expect("test tx result helper should be decodable");
+    let second = v0::SettlementAttemptResult::contract_call_success_for_test(2)
+        .try_into()
+        .expect("test tx result helper should be decodable");
     store
         .insert_settlement_job(&job_id, &mk_settlement_job(6))
         .expect("job insert must succeed");
@@ -204,7 +196,13 @@ fn insert_settlement_attempt_result_without_attempt_fails() {
         .insert_settlement_job(&job_id, &mk_settlement_job(42))
         .expect("job insert must succeed");
 
-    let res = store.insert_settlement_attempt_result(&job_id, 1, &mk_attempt_result_success(1));
+    let res = store.insert_settlement_attempt_result(
+        &job_id,
+        1,
+        &v0::SettlementAttemptResult::contract_call_success_for_test(1)
+            .try_into()
+            .expect("test tx result helper should be decodable"),
+    );
     assert!(matches!(res, Err(Error::UnprocessedAction(_))));
 }
 
@@ -279,7 +277,12 @@ fn get_settlement_job_result_returns_none_when_missing() {
 #[test]
 fn insert_settlement_job_result_without_job_fails() {
     let (_tmp, _db, store) = setup_store();
-    let res = store.insert_settlement_job_result(&mk_ulid(13), &mk_job_result_success(13));
+    let res = store.insert_settlement_job_result(
+        &mk_ulid(13),
+        &v0::SettlementJobResult::contract_call_success_for_test(13)
+            .try_into()
+            .expect("test tx result helper should be decodable"),
+    );
     assert!(matches!(res, Err(Error::UnprocessedAction(_))));
 }
 
@@ -287,7 +290,9 @@ fn insert_settlement_job_result_without_job_fails() {
 fn get_settlement_job_result_returns_value_after_insert() {
     let (_tmp, _db, store) = setup_store();
     let job_id = mk_ulid(14);
-    let result = mk_job_result_success(14);
+    let result = v0::SettlementJobResult::contract_call_success_for_test(14)
+        .try_into()
+        .expect("test tx result helper should be decodable");
 
     store
         .insert_settlement_job(&job_id, &mk_settlement_job(14))
@@ -308,8 +313,12 @@ fn get_settlement_job_result_returns_value_after_insert() {
 fn insert_settlement_job_result_duplicate_fails() {
     let (_tmp, db, store) = setup_store();
     let job_id = mk_ulid(15);
-    let first = mk_job_result_success(15);
-    let second = mk_job_result_success(16);
+    let first = v0::SettlementJobResult::contract_call_success_for_test(15)
+        .try_into()
+        .expect("test tx result helper should be decodable");
+    let second = v0::SettlementJobResult::contract_call_success_for_test(16)
+        .try_into()
+        .expect("test tx result helper should be decodable");
 
     store
         .insert_settlement_job(&job_id, &mk_settlement_job(15))
@@ -334,8 +343,12 @@ fn job_attempt_result_can_be_read_back_together() {
     let job_id = mk_ulid(21);
     let job = mk_settlement_job(21);
     let attempt = mk_settlement_attempt(5);
-    let attempt_result = mk_attempt_result_success(21);
-    let job_result = mk_job_result_success(22);
+    let attempt_result = v0::SettlementAttemptResult::contract_call_success_for_test(21)
+        .try_into()
+        .expect("test tx result helper should be decodable");
+    let job_result = v0::SettlementJobResult::contract_call_success_for_test(22)
+        .try_into()
+        .expect("test tx result helper should be decodable");
 
     store
         .insert_settlement_job(&job_id, &job)
@@ -407,8 +420,12 @@ fn result_absent_does_not_imply_attempt_absent() {
 fn duplicate_insert_preserves_original_value() {
     let (_tmp, db, store) = setup_store();
     let job_id = mk_ulid(23);
-    let first = mk_attempt_result_success(1);
-    let second = mk_attempt_result_success(2);
+    let first = v0::SettlementAttemptResult::contract_call_success_for_test(1)
+        .try_into()
+        .expect("test tx result helper should be decodable");
+    let second = v0::SettlementAttemptResult::contract_call_success_for_test(2)
+        .try_into()
+        .expect("test tx result helper should be decodable");
     store
         .insert_settlement_job(&job_id, &mk_settlement_job(23))
         .expect("job insert must succeed");

--- a/crates/agglayer-storage/src/types/mod.rs
+++ b/crates/agglayer-storage/src/types/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod disabled_network;
 pub mod generated; // TODO: remove "pub" once implementation of storage is completed
 pub(crate) mod network_info;
 pub(crate) mod settlement;
+#[cfg(any(test, feature = "testutils"))]
+mod testutils;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MetadataKey {

--- a/crates/agglayer-storage/src/types/settlement/compat/tx_result.rs
+++ b/crates/agglayer-storage/src/types/settlement/compat/tx_result.rs
@@ -136,7 +136,8 @@ mod tests {
             contract_call_result: None,
         };
 
-        assert!(SettlementJobResult::try_from(proto).is_err());
+        let result: Result<SettlementJobResult, _> = proto.try_into();
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/agglayer-storage/src/types/testutils.rs
+++ b/crates/agglayer-storage/src/types/testutils.rs
@@ -1,0 +1,40 @@
+use super::generated::agglayer::storage::v0::{
+    settlement_attempt_result, BlockHash, BlockNumber, ContractCallMetadata, ContractCallOutcome,
+    ContractCallResult, SettlementAttemptResult, SettlementJobResult, TxHash,
+};
+
+fn contract_call_success_for_test(seed: u8) -> ContractCallResult {
+    ContractCallResult {
+        outcome: ContractCallOutcome::Success as i32,
+        metadata: Some(ContractCallMetadata {
+            metadata: vec![seed, seed.wrapping_add(1)].into(),
+        }),
+        block_hash: Some(BlockHash {
+            hash: vec![seed; 32].into(),
+        }),
+        block_number: Some(BlockNumber {
+            number: seed as u64 + 100,
+        }),
+        tx_hash: Some(TxHash {
+            hash: vec![seed.wrapping_add(2); 32].into(),
+        }),
+    }
+}
+
+impl SettlementAttemptResult {
+    pub fn contract_call_success_for_test(seed: u8) -> Self {
+        Self {
+            result: Some(settlement_attempt_result::Result::ContractCallResult(
+                contract_call_success_for_test(seed),
+            )),
+        }
+    }
+}
+
+impl SettlementJobResult {
+    pub fn contract_call_success_for_test(seed: u8) -> Self {
+        Self {
+            contract_call_result: Some(contract_call_success_for_test(seed)),
+        }
+    }
+}


### PR DESCRIPTION
This follow-up removes duplicated settlement TxResult success builders
from storage tests and consolidates them in one shared generated test
utility.

It adds TxResult::contract_call_success_for_test behind test and
testutils gating and updates settlement column/state tests to consume
it consistently. State tests now use try_into() to keep fallible
conversion semantics explicit.

Refs #1438