### PR TITLE
refactor(storage): replace protobuf codec impls with macro

### DIFF
--- a/crates/agglayer-storage/src/schema/codec.rs
+++ b/crates/agglayer-storage/src/schema/codec.rs
@@ -68,3 +68,58 @@ macro_rules! impl_codec_using_bincode_for {
 }
 
 pub(crate) use impl_codec_using_bincode_for;
+
+macro_rules! impl_codec_using_protobuf_for {
+    ($($type:ty),* $(,)?) => {
+        $(
+            impl $crate::schema::Codec for $type {
+                fn encode_into<W: ::std::io::Write>(
+                    &self,
+                    mut writer: W,
+                ) -> Result<(), $crate::schema::CodecError> {
+                    let mut buf = ::prost::bytes::BytesMut::with_capacity(
+                        <Self as ::prost::Message>::encoded_len(self),
+                    );
+
+                    <Self as ::prost::Message>::encode(self, &mut buf)?;
+
+                    writer.write_all(&buf)?;
+
+                    Ok(())
+                }
+
+                fn decode(buf: &[u8]) -> Result<Self, $crate::schema::CodecError> {
+                    <Self as ::prost::Message>::decode(buf).map_err(Into::into)
+                }
+            }
+        )*
+    };
+    ($($type:ty => $proto:ty),* $(,)?) => {
+        $(
+            impl $crate::schema::Codec for $type {
+                fn encode_into<W: ::std::io::Write>(
+                    &self,
+                    mut writer: W,
+                ) -> Result<(), $crate::schema::CodecError> {
+                    let proto: $proto = self.into();
+                    let mut buf = ::prost::bytes::BytesMut::with_capacity(
+                        <$proto as ::prost::Message>::encoded_len(&proto),
+                    );
+
+                    <$proto as ::prost::Message>::encode(&proto, &mut buf)?;
+
+                    writer.write_all(&buf)?;
+
+                    Ok(())
+                }
+
+                fn decode(buf: &[u8]) -> Result<Self, $crate::schema::CodecError> {
+                    let proto = <$proto as ::prost::Message>::decode(buf)?;
+                    Ok(proto.into())
+                }
+            }
+        )*
+    };
+}
+
+pub(crate) use impl_codec_using_protobuf_for;

--- a/crates/agglayer-storage/src/schema/mod.rs
+++ b/crates/agglayer-storage/src/schema/mod.rs
@@ -2,6 +2,6 @@ mod codec;
 mod column;
 pub mod options;
 
-pub(crate) use codec::impl_codec_using_bincode_for;
 pub use codec::{bincode_codec, Codec, CodecError};
+pub(crate) use codec::{impl_codec_using_bincode_for, impl_codec_using_protobuf_for};
 pub use column::{ColumnDescriptor, ColumnSchema};

--- a/crates/agglayer-storage/src/storage/migration/record.rs
+++ b/crates/agglayer-storage/src/storage/migration/record.rs
@@ -1,8 +1,4 @@
-use std::io;
-
-use prost::{bytes::BytesMut, Message as _};
-
-use crate::{schema::Codec, types::generated::agglayer::storage::v0};
+use crate::types::generated::agglayer::storage::v0;
 
 /// Metadata recorded about each migration step performed.
 ///
@@ -24,23 +20,4 @@ impl From<v0::MigrationRecord> for MigrationRecord {
     }
 }
 
-impl Codec for MigrationRecord {
-    fn encode_into<W: io::Write>(&self, mut writer: W) -> Result<(), crate::schema::CodecError> {
-        let proto: v0::MigrationRecord = self.into();
-        let len = proto.encoded_len();
-
-        let mut buf = BytesMut::new();
-        buf.reserve(len);
-
-        <v0::MigrationRecord as prost::Message>::encode(&proto, &mut buf)?;
-
-        writer.write_all(&buf)?;
-
-        Ok(())
-    }
-
-    fn decode(buf: &[u8]) -> Result<Self, crate::schema::CodecError> {
-        let proto = <v0::MigrationRecord as prost::Message>::decode(buf)?;
-        Ok(proto.into())
-    }
-}
+crate::schema::impl_codec_using_protobuf_for!(MigrationRecord => v0::MigrationRecord);

--- a/crates/agglayer-storage/src/types/disabled_network/mod.rs
+++ b/crates/agglayer-storage/src/types/disabled_network/mod.rs
@@ -1,26 +1,3 @@
-use std::io;
-
-use prost::{bytes::BytesMut, Message as _};
-
-use crate::schema::Codec;
-
 pub type Value = super::generated::agglayer::storage::v0::DisabledNetwork;
 
-impl Codec for Value {
-    fn encode_into<W: io::Write>(&self, mut writer: W) -> Result<(), crate::schema::CodecError> {
-        let len = self.encoded_len();
-
-        let mut buf = BytesMut::new();
-        buf.reserve(len);
-
-        <Value as prost::Message>::encode(self, &mut buf)?;
-
-        writer.write_all(&buf)?;
-
-        Ok(())
-    }
-
-    fn decode(buf: &[u8]) -> Result<Self, crate::schema::CodecError> {
-        <Value as prost::Message>::decode(buf).map_err(Into::into)
-    }
-}
+crate::schema::impl_codec_using_protobuf_for!(Value);

--- a/crates/agglayer-storage/src/types/network_info/mod.rs
+++ b/crates/agglayer-storage/src/types/network_info/mod.rs
@@ -1,12 +1,9 @@
-use std::io;
-
-use prost::{bytes::BytesMut, Message};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
 pub use super::generated::agglayer::storage::v0;
 use crate::{
-    schema::{Codec, CodecError},
+    schema::CodecError,
     types::network_info::v0::{
         network_info_value::{self, ValueDiscriminants},
         NetworkType,
@@ -30,24 +27,7 @@ impl Key {
 
 pub type Value = super::generated::agglayer::storage::v0::NetworkInfoValue;
 
-impl Codec for Value {
-    fn encode_into<W: io::Write>(&self, mut writer: W) -> Result<(), CodecError> {
-        let len = self.encoded_len();
-
-        let mut buf = BytesMut::new();
-        buf.reserve(len);
-
-        <Value as prost::Message>::encode(self, &mut buf)?;
-
-        writer.write_all(&buf)?;
-
-        Ok(())
-    }
-
-    fn decode(buf: &[u8]) -> Result<Self, CodecError> {
-        <Value as prost::Message>::decode(buf).map_err(Into::into)
-    }
-}
+crate::schema::impl_codec_using_protobuf_for!(Value);
 
 impl TryFrom<v0::NetworkType> for agglayer_types::NetworkType {
     type Error = CodecError;

--- a/crates/agglayer-storage/src/types/settlement/attempt.rs
+++ b/crates/agglayer-storage/src/types/settlement/attempt.rs
@@ -1,9 +1,4 @@
-use std::io;
-
-use prost::{bytes::BytesMut, Message as _};
 use serde::{Deserialize, Serialize};
-
-use crate::schema::Codec;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Key {
@@ -13,21 +8,4 @@ pub struct Key {
 
 pub type Value = crate::types::generated::agglayer::storage::v0::SettlementAttempt;
 
-impl Codec for Value {
-    fn encode_into<W: io::Write>(&self, mut writer: W) -> Result<(), crate::schema::CodecError> {
-        let len = self.encoded_len();
-
-        let mut buf = BytesMut::new();
-        buf.reserve(len);
-
-        <Value as prost::Message>::encode(self, &mut buf)?;
-
-        writer.write_all(&buf)?;
-
-        Ok(())
-    }
-
-    fn decode(buf: &[u8]) -> Result<Self, crate::schema::CodecError> {
-        <Value as prost::Message>::decode(buf).map_err(Into::into)
-    }
-}
+crate::schema::impl_codec_using_protobuf_for!(Value);

--- a/crates/agglayer-storage/src/types/settlement/attempt_result.rs
+++ b/crates/agglayer-storage/src/types/settlement/attempt_result.rs
@@ -1,27 +1,4 @@
-use std::io;
-
-use prost::{bytes::BytesMut, Message as _};
-
-use crate::schema::Codec;
-
 pub type Key = super::attempt::Key;
 pub type Value = crate::types::generated::agglayer::storage::v0::SettlementAttemptResult;
 
-impl Codec for Value {
-    fn encode_into<W: io::Write>(&self, mut writer: W) -> Result<(), crate::schema::CodecError> {
-        let len = self.encoded_len();
-
-        let mut buf = BytesMut::new();
-        buf.reserve(len);
-
-        <Value as prost::Message>::encode(self, &mut buf)?;
-
-        writer.write_all(&buf)?;
-
-        Ok(())
-    }
-
-    fn decode(buf: &[u8]) -> Result<Self, crate::schema::CodecError> {
-        <Value as prost::Message>::decode(buf).map_err(Into::into)
-    }
-}
+crate::schema::impl_codec_using_protobuf_for!(Value);

--- a/crates/agglayer-storage/src/types/settlement/job.rs
+++ b/crates/agglayer-storage/src/types/settlement/job.rs
@@ -1,27 +1,4 @@
-use std::io;
-
-use prost::{bytes::BytesMut, Message as _};
-
-use crate::schema::Codec;
-
 pub type Key = ulid::Ulid;
 pub type Value = crate::types::generated::agglayer::storage::v0::SettlementJob;
 
-impl Codec for Value {
-    fn encode_into<W: io::Write>(&self, mut writer: W) -> Result<(), crate::schema::CodecError> {
-        let len = self.encoded_len();
-
-        let mut buf = BytesMut::new();
-        buf.reserve(len);
-
-        <Value as prost::Message>::encode(self, &mut buf)?;
-
-        writer.write_all(&buf)?;
-
-        Ok(())
-    }
-
-    fn decode(buf: &[u8]) -> Result<Self, crate::schema::CodecError> {
-        <Value as prost::Message>::decode(buf).map_err(Into::into)
-    }
-}
+crate::schema::impl_codec_using_protobuf_for!(Value);


### PR DESCRIPTION
This refactor centralizes protobuf Codec implementations in agglayer-storage
with a reusable schema macro.

It replaces duplicated prost encode/decode blocks for settlement job,
settlement attempt, settlement attempt result, disabled network, network
info, and migration record storage types while preserving behavior.

Validation:
- cargo test -p agglayer-storage -- --test-threads=1