### PR TITLE
feat(storage): map settlement jobs by certificate id

### DIFF
--- a/crates/agglayer-storage/src/columns/mod.rs
+++ b/crates/agglayer-storage/src/columns/mod.rs
@@ -33,6 +33,7 @@ pub const SETTLEMENT_ATTEMPT_PER_WALLET_CF: &str = "settlement_attempt_per_walle
 pub const SETTLEMENT_ATTEMPT_RESULTS_CF: &str = "settlement_attempt_results_cf";
 pub const SETTLEMENT_JOBS_CF: &str = "settlement_jobs_cf";
 pub const SETTLEMENT_JOB_RESULTS_CF: &str = "settlement_job_results_cf";
+pub const SETTLEMENT_JOB_ID_PER_CERTIFICATE_CF: &str = "settlement_job_id_per_certificate_cf";
 
 pub const SETTLEMENT_ATTEMPTS_COLUMN_OPTIONS: ColumnOptions = ColumnOptions {
     compression: crate::schema::options::ColumnCompressionType::Lz4,
@@ -88,6 +89,7 @@ pub(crate) mod debug_certificates;
 pub(crate) mod settlement_attempt_per_wallet;
 pub(crate) mod settlement_attempt_results;
 pub(crate) mod settlement_attempts;
+pub(crate) mod settlement_job_id_per_certificate;
 pub(crate) mod settlement_job_results;
 pub(crate) mod settlement_jobs;
 

--- a/crates/agglayer-storage/src/columns/settlement_job_id_per_certificate/mod.rs
+++ b/crates/agglayer-storage/src/columns/settlement_job_id_per_certificate/mod.rs
@@ -1,0 +1,14 @@
+use crate::{columns::SETTLEMENT_JOB_ID_PER_CERTIFICATE_CF, schema::ColumnSchema};
+
+#[cfg(test)]
+mod tests;
+
+/// Column family containing the settlement job id per certificate.
+pub(crate) struct SettlementJobIdPerCertificateColumn;
+
+impl ColumnSchema for SettlementJobIdPerCertificateColumn {
+    type Key = crate::types::settlement::job_id_per_certificate::Key;
+    type Value = crate::types::settlement::job_id_per_certificate::Value;
+
+    const COLUMN_FAMILY_NAME: &'static str = SETTLEMENT_JOB_ID_PER_CERTIFICATE_CF;
+}

--- a/crates/agglayer-storage/src/columns/settlement_job_id_per_certificate/tests.rs
+++ b/crates/agglayer-storage/src/columns/settlement_job_id_per_certificate/tests.rs
@@ -1,0 +1,21 @@
+use agglayer_types::CertificateId;
+use ulid::Ulid;
+
+use crate::{
+    schema::Codec as _,
+    types::settlement::job_id_per_certificate::{Key, Value},
+};
+
+#[test]
+fn settlement_job_id_per_certificate_roundtrip_codec() {
+    let key = CertificateId::for_test(0x11);
+    let value = Ulid::from(42u128);
+
+    let encoded_key = key.encode().expect("Unable to encode key");
+    let decoded_key = Key::decode(&encoded_key).expect("Unable to decode key");
+    assert_eq!(decoded_key, key);
+
+    let encoded_value = value.encode().expect("Unable to encode value");
+    let decoded_value = Value::decode(&encoded_value).expect("Unable to decode value");
+    assert_eq!(decoded_value, value);
+}

--- a/crates/agglayer-storage/src/storage/migration/mod.rs
+++ b/crates/agglayer-storage/src/storage/migration/mod.rs
@@ -195,6 +195,38 @@ impl Builder {
         })?)
     }
 
+    /// Ensures that the given column families exist.
+    ///
+    /// This migration step creates missing column families while preserving
+    /// existing ones.
+    pub fn ensure_cfs(self, cfs: &[ColumnDescriptor]) -> Result<Self, DBOpenError> {
+        let missing_cfs: Vec<_> = cfs
+            .iter()
+            .filter(|descriptor| !self.cf_exists(descriptor.name()))
+            .cloned()
+            .collect();
+
+        if missing_cfs.is_empty() {
+            debug!("All requested column families already exist, skipping migration step");
+            return Ok(Self {
+                step: self.step + 1,
+                ..self
+            });
+        }
+
+        Ok(self.perform_step(move |db| {
+            for descriptor in &missing_cfs {
+                let cf = descriptor.name();
+
+                let opts = DB::options(descriptor.options());
+                debug!("Creating missing column family {cf:?}");
+                db.db.rocksdb.create_cf(cf, &opts).map_err(DBError::from)?;
+            }
+
+            Ok(())
+        })?)
+    }
+
     /// Completes the migration process and returns the database.
     ///
     /// This method validates that all declared migration steps have been

--- a/crates/agglayer-storage/src/stores/interfaces/reader/settlement_reader.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/reader/settlement_reader.rs
@@ -1,4 +1,4 @@
-use agglayer_types::{SettlementJob, SettlementJobResult};
+use agglayer_types::{CertificateId, SettlementJob, SettlementJobResult};
 use ulid::Ulid;
 
 use crate::error::Error;
@@ -8,6 +8,18 @@ use crate::error::Error;
 /// This trait is intentionally limited to point lookups and metadata-style
 /// reads. Missing records are returned as `Ok(None)`.
 pub trait SettlementReader: Send + Sync {
+    /// Returns the settlement job id linked to `certificate_id`, if present.
+    fn get_settlement_job_id_for_certificate(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<Ulid>, Error>;
+
+    /// Returns the settlement job linked to `certificate_id`, if present.
+    fn get_settlement_job_for_certificate(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<SettlementJob>, Error>;
+
     /// Returns the settlement job for `settlement_job_id`, if present.
     fn get_settlement_job(&self, settlement_job_id: &Ulid) -> Result<Option<SettlementJob>, Error>;
 

--- a/crates/agglayer-storage/src/stores/interfaces/writer/settlement_writer.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/writer/settlement_writer.rs
@@ -1,5 +1,5 @@
 use agglayer_types::{
-    SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobResult,
+    CertificateId, SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobResult,
 };
 use ulid::Ulid;
 
@@ -10,6 +10,17 @@ use crate::error::Error;
 /// All write operations in this trait are insert-only: implementations must
 /// reject attempts to overwrite an existing key.
 pub trait SettlementWriter: Send + Sync {
+    /// Inserts the settlement job id for `certificate_id`.
+    ///
+    /// This is an insert-only operation and must fail if
+    /// `certificate_id` already has an associated settlement job id. The
+    /// parent settlement job must already exist.
+    fn insert_settlement_job_id_for_certificate(
+        &self,
+        certificate_id: &CertificateId,
+        settlement_job_id: &Ulid,
+    ) -> Result<(), Error>;
+
     /// Inserts a settlement job under `settlement_job_id`.
     ///
     /// This is an insert-only operation and must fail if

--- a/crates/agglayer-storage/src/stores/state/cf_definitions.rs
+++ b/crates/agglayer-storage/src/stores/state/cf_definitions.rs
@@ -35,3 +35,7 @@ pub const STATE_DB: &[ColumnDescriptor] = &[
     ColumnDescriptor::new::<SettlementAttemptResultsColumn>(),
     ColumnDescriptor::new::<SettlementAttemptPerWalletColumn>(),
 ];
+
+/// Migration step 1: add certificate -> settlement job mapping.
+pub const STATE_DB_MIGRATION_STEP_1_ADD_CFS: &[ColumnDescriptor] =
+    &[ColumnDescriptor::new::<SettlementJobIdPerCertificateColumn>()];

--- a/crates/agglayer-storage/src/stores/state/cf_definitions.rs
+++ b/crates/agglayer-storage/src/stores/state/cf_definitions.rs
@@ -10,6 +10,7 @@ use crate::{
         settlement_attempt_per_wallet::SettlementAttemptPerWalletColumn,
         settlement_attempt_results::SettlementAttemptResultsColumn,
         settlement_attempts::SettlementAttemptsColumn,
+        settlement_job_id_per_certificate::SettlementJobIdPerCertificateColumn,
         settlement_job_results::SettlementJobResultsColumn, settlement_jobs::SettlementJobsColumn,
     },
     schema::ColumnDescriptor,
@@ -27,6 +28,7 @@ pub const STATE_DB: &[ColumnDescriptor] = &[
     ColumnDescriptor::new::<NetworkInfoColumn>(),
     ColumnDescriptor::new::<DisabledNetworksColumn>(),
     // Settlement related CFs
+    ColumnDescriptor::new::<SettlementJobIdPerCertificateColumn>(),
     ColumnDescriptor::new::<SettlementJobsColumn>(),
     ColumnDescriptor::new::<SettlementJobResultsColumn>(),
     ColumnDescriptor::new::<SettlementAttemptsColumn>(),

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -55,7 +55,9 @@ pub struct StateStore {
 
 impl StateStore {
     pub fn init_db(path: &Path) -> Result<DB, crate::storage::DBOpenError> {
-        DB::open_cf(path, cf_definitions::STATE_DB)
+        DB::builder(path, cf_definitions::STATE_DB)?
+            .ensure_cfs(cf_definitions::STATE_DB_MIGRATION_STEP_1_ADD_CFS)?
+            .finalize(cf_definitions::STATE_DB)
     }
 
     pub fn new(db: Arc<DB>, backup_client: BackupClient) -> Self {

--- a/crates/agglayer-storage/src/stores/state/settlement/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/settlement/mod.rs
@@ -1,5 +1,5 @@
 use agglayer_types::{
-    SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobResult,
+    CertificateId, SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobResult,
 };
 use rocksdb::WriteBatch;
 use ulid::Ulid;
@@ -10,6 +10,7 @@ use crate::{
         settlement_attempt_per_wallet::SettlementAttemptPerWalletColumn,
         settlement_attempt_results::SettlementAttemptResultsColumn,
         settlement_attempts::SettlementAttemptsColumn,
+        settlement_job_id_per_certificate::SettlementJobIdPerCertificateColumn,
         settlement_job_results::SettlementJobResultsColumn, settlement_jobs::SettlementJobsColumn,
     },
     error::Error,
@@ -48,6 +49,34 @@ impl StateStore {
 }
 
 impl SettlementReader for StateStore {
+    fn get_settlement_job_id_for_certificate(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<Ulid>, Error> {
+        Ok(self
+            .db
+            .get::<SettlementJobIdPerCertificateColumn>(certificate_id)?)
+    }
+
+    fn get_settlement_job_for_certificate(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<SettlementJob>, Error> {
+        let Some(settlement_job_id) = self.get_settlement_job_id_for_certificate(certificate_id)?
+        else {
+            return Ok(None);
+        };
+
+        let settlement_job = self.get_settlement_job(&settlement_job_id)?;
+        match settlement_job {
+            Some(settlement_job) => Ok(Some(settlement_job)),
+            None => Err(Error::Unexpected(format!(
+                "Settlement job mapping exists for certificate {certificate_id} but settlement \
+                 job {settlement_job_id} is missing",
+            ))),
+        }
+    }
+
     fn get_settlement_job(&self, settlement_job_id: &Ulid) -> Result<Option<SettlementJob>, Error> {
         Ok(self
             .db
@@ -69,6 +98,36 @@ impl SettlementReader for StateStore {
 }
 
 impl SettlementWriter for StateStore {
+    fn insert_settlement_job_id_for_certificate(
+        &self,
+        certificate_id: &CertificateId,
+        settlement_job_id: &Ulid,
+    ) -> Result<(), Error> {
+        if self
+            .db
+            .get::<SettlementJobIdPerCertificateColumn>(certificate_id)?
+            .is_some()
+        {
+            return Err(Error::UnprocessedAction(format!(
+                "Settlement job id already exists for certificate {certificate_id}"
+            )));
+        }
+
+        if self
+            .db
+            .get::<SettlementJobsColumn>(settlement_job_id)?
+            .is_none()
+        {
+            return Err(Error::UnprocessedAction(format!(
+                "Settlement job does not exist for id {settlement_job_id}"
+            )));
+        }
+
+        Ok(self
+            .db
+            .put::<SettlementJobIdPerCertificateColumn>(certificate_id, settlement_job_id)?)
+    }
+
     fn insert_settlement_job(
         &self,
         settlement_job_id: &Ulid,

--- a/crates/agglayer-storage/src/stores/state/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/tests.rs
@@ -15,6 +15,7 @@ use pessimistic_proof::{
 use rstest::{fixture, rstest};
 use tracing::info;
 
+use super::cf_definitions;
 use crate::{
     backup::BackupClient,
     columns::{
@@ -28,8 +29,6 @@ use crate::{
     stores::{state::StateStore, SettlementReader as _, StateReader as _, StateWriter as _},
     tests::TempDBDir,
 };
-
-use super::cf_definitions;
 
 mod disabled_networks;
 mod metadata;

--- a/crates/agglayer-storage/src/stores/state/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/tests.rs
@@ -17,13 +17,19 @@ use tracing::info;
 
 use crate::{
     backup::BackupClient,
-    columns::latest_settled_certificate_per_network::{
-        LatestSettledCertificatePerNetworkColumn, SettledCertificate,
+    columns::{
+        latest_settled_certificate_per_network::{
+            LatestSettledCertificatePerNetworkColumn, SettledCertificate,
+        },
+        SETTLEMENT_JOB_ID_PER_CERTIFICATE_CF,
     },
     error::Error,
-    stores::{state::StateStore, StateReader as _, StateWriter as _},
+    storage::DB,
+    stores::{state::StateStore, SettlementReader as _, StateReader as _, StateWriter as _},
     tests::TempDBDir,
 };
+
+use super::cf_definitions;
 
 mod disabled_networks;
 mod metadata;
@@ -47,6 +53,55 @@ fn can_retrieve_list_of_network() {
     )
     .expect("Unable to put certificate into storage");
     assert!(store.get_active_networks().unwrap().len() == 1);
+}
+
+#[test]
+fn init_db_adds_settlement_job_id_per_certificate_cf_for_legacy_schema() {
+    let tmp = TempDBDir::new();
+
+    {
+        let legacy_state_db: Vec<_> = cf_definitions::STATE_DB
+            .iter()
+            .filter(|cf| cf.name() != SETTLEMENT_JOB_ID_PER_CERTIFICATE_CF)
+            .cloned()
+            .collect();
+
+        let _db = DB::open_cf(tmp.path.as_path(), &legacy_state_db)
+            .expect("legacy schema db initialization should succeed");
+    }
+
+    let db = Arc::new(
+        StateStore::init_db(tmp.path.as_path())
+            .expect("state db initialization should add missing settlement mapping cf"),
+    );
+    let store = StateStore::new(db, BackupClient::noop());
+
+    assert_eq!(
+        store
+            .get_settlement_job_id_for_certificate(&CertificateId::for_test(9))
+            .expect("mapping lookup should succeed on upgraded db"),
+        None,
+    );
+}
+
+#[test]
+fn fresh_init_db_remains_readable_by_legacy_state_schema() {
+    let tmp = TempDBDir::new();
+
+    let legacy_state_db: Vec<_> = cf_definitions::STATE_DB
+        .iter()
+        .filter(|cf| cf.name() != SETTLEMENT_JOB_ID_PER_CERTIFICATE_CF)
+        .cloned()
+        .collect();
+
+    let db = StateStore::init_db(tmp.path.as_path())
+        .expect("fresh state db initialization should succeed");
+    drop(db);
+
+    DB::builder(tmp.path.as_path(), &legacy_state_db)
+        .expect("legacy state db builder should open fresh db")
+        .finalize(&legacy_state_db)
+        .expect("legacy state db schema should still open after fresh init");
 }
 
 fn equal_state(lhs: &LocalNetworkStateData, rhs: &LocalNetworkStateData) -> bool {

--- a/crates/agglayer-storage/src/stores/state/tests/settlement.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/settlement.rs
@@ -4,8 +4,9 @@ use std::{
 };
 
 use agglayer_types::{
-    Address, ContractCallOutcome, ContractCallResult, Digest, Nonce, SettlementAttempt,
-    SettlementAttemptResult, SettlementJob, SettlementJobResult, SettlementTxHash, B256, U256,
+    Address, CertificateId, ContractCallOutcome, ContractCallResult, Digest, Nonce,
+    SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobResult,
+    SettlementTxHash, B256, U256,
 };
 use ulid::Ulid;
 
@@ -15,6 +16,7 @@ use crate::{
         settlement_attempt_per_wallet::SettlementAttemptPerWalletColumn,
         settlement_attempt_results::SettlementAttemptResultsColumn,
         settlement_attempts::SettlementAttemptsColumn,
+        settlement_job_id_per_certificate::SettlementJobIdPerCertificateColumn,
         settlement_job_results::SettlementJobResultsColumn, settlement_jobs::SettlementJobsColumn,
     },
     error::Error,
@@ -91,6 +93,59 @@ fn insert_settlement_job_succeeds_once() {
     assert!(store
         .insert_settlement_job(&mk_ulid(1), &mk_settlement_job(1))
         .is_ok());
+}
+
+#[test]
+fn insert_settlement_job_id_for_certificate_succeeds_once() {
+    let (_tmp, _db, store) = setup_store();
+    let certificate_id = CertificateId::for_test(1);
+    let settlement_job_id = mk_ulid(1001);
+
+    store
+        .insert_settlement_job(&settlement_job_id, &mk_settlement_job(1))
+        .expect("job insert must succeed");
+
+    assert!(store
+        .insert_settlement_job_id_for_certificate(&certificate_id, &settlement_job_id)
+        .is_ok());
+}
+
+#[test]
+fn insert_settlement_job_id_for_certificate_duplicate_fails() {
+    let (_tmp, db, store) = setup_store();
+    let certificate_id = CertificateId::for_test(2);
+    let first_settlement_job_id = mk_ulid(1002);
+    let second_settlement_job_id = mk_ulid(1003);
+
+    store
+        .insert_settlement_job(&first_settlement_job_id, &mk_settlement_job(2))
+        .expect("first job insert must succeed");
+    store
+        .insert_settlement_job(&second_settlement_job_id, &mk_settlement_job(3))
+        .expect("second job insert must succeed");
+
+    store
+        .insert_settlement_job_id_for_certificate(&certificate_id, &first_settlement_job_id)
+        .expect("first insert must succeed");
+
+    let res =
+        store.insert_settlement_job_id_for_certificate(&certificate_id, &second_settlement_job_id);
+    assert!(matches!(res, Err(Error::UnprocessedAction(_))));
+
+    assert_eq!(
+        db.get::<SettlementJobIdPerCertificateColumn>(&certificate_id)
+            .expect("Unable to read stored value"),
+        Some(first_settlement_job_id)
+    );
+}
+
+#[test]
+fn insert_settlement_job_id_for_certificate_without_job_fails() {
+    let (_tmp, _db, store) = setup_store();
+    let certificate_id = CertificateId::for_test(3);
+
+    let res = store.insert_settlement_job_id_for_certificate(&certificate_id, &mk_ulid(404));
+    assert!(matches!(res, Err(Error::UnprocessedAction(_))));
 }
 
 #[test]
@@ -247,6 +302,84 @@ fn get_settlement_job_returns_none_when_missing() {
             .expect("read must succeed"),
         None
     );
+}
+
+#[test]
+fn get_settlement_job_id_for_certificate_returns_none_when_missing() {
+    let (_tmp, _db, store) = setup_store();
+    assert_eq!(
+        store
+            .get_settlement_job_id_for_certificate(&CertificateId::for_test(4))
+            .expect("read must succeed"),
+        None
+    );
+}
+
+#[test]
+fn get_settlement_job_for_certificate_returns_none_when_missing() {
+    let (_tmp, _db, store) = setup_store();
+    assert_eq!(
+        store
+            .get_settlement_job_for_certificate(&CertificateId::for_test(5))
+            .expect("read must succeed"),
+        None
+    );
+}
+
+#[test]
+fn get_settlement_job_id_for_certificate_returns_value_after_insert() {
+    let (_tmp, _db, store) = setup_store();
+    let certificate_id = CertificateId::for_test(6);
+    let settlement_job_id = mk_ulid(1005);
+
+    store
+        .insert_settlement_job(&settlement_job_id, &mk_settlement_job(5))
+        .expect("job insert must succeed");
+    store
+        .insert_settlement_job_id_for_certificate(&certificate_id, &settlement_job_id)
+        .expect("mapping insert must succeed");
+
+    assert_eq!(
+        store
+            .get_settlement_job_id_for_certificate(&certificate_id)
+            .expect("read must succeed"),
+        Some(settlement_job_id)
+    );
+}
+
+#[test]
+fn get_settlement_job_for_certificate_returns_value_after_insert() {
+    let (_tmp, _db, store) = setup_store();
+    let certificate_id = CertificateId::for_test(7);
+    let settlement_job_id = mk_ulid(1006);
+    let settlement_job = mk_settlement_job(7);
+
+    store
+        .insert_settlement_job(&settlement_job_id, &settlement_job)
+        .expect("job insert must succeed");
+    store
+        .insert_settlement_job_id_for_certificate(&certificate_id, &settlement_job_id)
+        .expect("mapping insert must succeed");
+
+    assert_eq!(
+        store
+            .get_settlement_job_for_certificate(&certificate_id)
+            .expect("read must succeed"),
+        Some(settlement_job)
+    );
+}
+
+#[test]
+fn get_settlement_job_for_certificate_fails_when_mapping_points_to_missing_job() {
+    let (_tmp, db, store) = setup_store();
+    let certificate_id = CertificateId::for_test(8);
+    let missing_settlement_job_id = mk_ulid(9999);
+
+    db.put::<SettlementJobIdPerCertificateColumn>(&certificate_id, &missing_settlement_job_id)
+        .expect("mapping insert must succeed");
+
+    let res = store.get_settlement_job_for_certificate(&certificate_id);
+    assert!(matches!(res, Err(Error::Unexpected(_))));
 }
 
 #[test]

--- a/crates/agglayer-storage/src/types/settlement/job_id_per_certificate.rs
+++ b/crates/agglayer-storage/src/types/settlement/job_id_per_certificate.rs
@@ -1,0 +1,2 @@
+pub type Key = agglayer_types::CertificateId;
+pub type Value = super::job::Key;

--- a/crates/agglayer-storage/src/types/settlement/mod.rs
+++ b/crates/agglayer-storage/src/types/settlement/mod.rs
@@ -3,5 +3,6 @@ pub(crate) mod attempt_per_wallet;
 pub(crate) mod attempt_result;
 pub(crate) mod compat;
 pub(crate) mod job;
+pub(crate) mod job_id_per_certificate;
 pub(crate) mod job_result;
 mod primitives;

--- a/crates/agglayer-types/src/certificate/id.rs
+++ b/crates/agglayer-types/src/certificate/id.rs
@@ -25,6 +25,12 @@ impl CertificateId {
         CertificateId(id)
     }
 
+    /// Creates a deterministic certificate id for tests.
+    #[cfg(feature = "testutils")]
+    pub fn for_test(seed: u8) -> CertificateId {
+        CertificateId::new(Digest::from([seed; 32]))
+    }
+
     pub const fn as_digest(&self) -> &Digest {
         &self.0
     }


### PR DESCRIPTION
This adds a certificate-keyed index for settlement jobs in storage so
callers can resolve settlement data directly from a certificate id.

- add settlement_job_id_per_certificate column family, schema types,
  and registration
- add insert/get APIs for certificate-to-job mapping and direct job
  lookup by certificate id
- add codec and state-store tests for success, duplicate inserts, and
  missing-parent cases

Refs #1430