### PR TITLE
refactor(settlement): read terminal results from storage with generic store wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,7 @@ name = "agglayer-settlement-service"
 version = "0.1.0"
 dependencies = [
  "agglayer-config",
+ "agglayer-storage",
  "agglayer-types",
  "alloy",
  "derive_more 2.1.1",

--- a/crates/agglayer-settlement-service/Cargo.toml
+++ b/crates/agglayer-settlement-service/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 agglayer-config.workspace = true
+agglayer-storage.workspace = true
 agglayer-types.workspace = true
 
 alloy.workspace = true

--- a/crates/agglayer-settlement-service/src/settlement_service.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service.rs
@@ -8,16 +8,32 @@ use tokio_util::sync::CancellationToken;
 use tracing::error;
 use ulid::Ulid;
 
-use crate::settlement_task::{SettlementTask, TaskAdminCommand};
+use crate::settlement_task::{SettlementStore, SettlementTask, TaskAdminCommand};
 
 const ADMIN_CHANNEL_BUFFER_SIZE: usize = 10;
 
 /// The Settlement Service is responsible for managing settlement jobs and
 /// answering settlement result requests.
-#[derive(Clone)]
-pub struct SettlementService {
+pub struct SettlementService<S>
+where
+    S: SettlementStore,
+{
     admin_command_senders: Arc<Mutex<HashMap<Ulid, mpsc::Sender<TaskAdminCommand>>>>,
     result_watchers: Arc<Mutex<HashMap<Ulid, watch::Receiver<Option<SettlementJobResult>>>>>,
+    settlement_store: Arc<S>,
+}
+
+impl<S> Clone for SettlementService<S>
+where
+    S: SettlementStore,
+{
+    fn clone(&self) -> Self {
+        Self {
+            admin_command_senders: self.admin_command_senders.clone(),
+            result_watchers: self.result_watchers.clone(),
+            settlement_store: self.settlement_store.clone(),
+        }
+    }
 }
 
 pub struct SettlementJobWatcher {
@@ -40,14 +56,19 @@ pub enum RetrievedSettlementResult {
     Completed(SettlementJobResult),
 }
 
-impl SettlementService {
+impl<S> SettlementService<S>
+where
+    S: SettlementStore + 'static,
+{
     pub async fn start(
         _config: SettlementServiceConfig,
+        settlement_store: Arc<S>,
         cancellation_token: CancellationToken,
     ) -> eyre::Result<Self> {
         let this = Self {
             admin_command_senders: Arc::new(Mutex::new(HashMap::new())),
             result_watchers: Arc::new(Mutex::new(HashMap::new())),
+            settlement_store,
         };
         tokio::task::spawn(Self::cancellation_token_proxy(
             cancellation_token,
@@ -110,7 +131,8 @@ impl SettlementService {
     ) -> eyre::Result<SettlementJobWatcher> {
         let (admin_sender, admin_receiver) = mpsc::channel(ADMIN_CHANNEL_BUFFER_SIZE);
         let (result_sender, result_receiver) = watch::channel(None);
-        let (job_id, mut task) = SettlementTask::create(job, admin_receiver).await?;
+        let (job_id, mut task) =
+            SettlementTask::create(job, admin_receiver, self.settlement_store.clone()).await?;
         self.admin_command_senders
             .lock()
             .await
@@ -140,6 +162,16 @@ impl SettlementService {
         &self,
         job_id: Ulid,
     ) -> eyre::Result<RetrievedSettlementResult> {
+        if let Some(result) = self
+            .settlement_store
+            .get_settlement_job_result(&job_id)
+            .wrap_err_with(|| {
+                format!("Failed to read settlement job terminal result for id {job_id}")
+            })?
+        {
+            return Ok(RetrievedSettlementResult::Completed(result));
+        }
+
         if let Some(watcher) = self.result_watchers.lock().await.get(&job_id) {
             return match watcher.borrow().as_ref() {
                 None => Ok(RetrievedSettlementResult::Pending(SettlementJobWatcher {
@@ -149,14 +181,41 @@ impl SettlementService {
                 Some(result) => Ok(RetrievedSettlementResult::Completed(result.clone())),
             };
         }
-        // TODO: check rocksdb for completed settlement job results
-        todo!()
+
+        if self
+            .settlement_store
+            .get_settlement_job(&job_id)
+            .wrap_err_with(|| format!("Failed to check settlement job existence for id {job_id}"))?
+            .is_none()
+        {
+            return Err(eyre::eyre!("No settlement job found for id {job_id}"));
+        }
+
+        let watcher = {
+            let mut watchers = self.result_watchers.lock().await;
+
+            watchers
+                .entry(job_id)
+                .or_insert_with(|| {
+                    let (_sender, watcher) = watch::channel(None);
+                    watcher
+                })
+                .clone()
+        };
+
+        Ok(RetrievedSettlementResult::Pending(SettlementJobWatcher {
+            watcher,
+            job_id,
+        }))
     }
 }
 
 pub struct RequestNewSettlement(pub SettlementJob);
 
-impl tower::Service<RequestNewSettlement> for SettlementService {
+impl<S> tower::Service<RequestNewSettlement> for SettlementService<S>
+where
+    S: SettlementStore + 'static,
+{
     type Response = SettlementJobWatcher;
     type Error = eyre::Error;
     type Future = Pin<Box<dyn Future<Output = eyre::Result<Self::Response>>>>;
@@ -176,7 +235,10 @@ impl tower::Service<RequestNewSettlement> for SettlementService {
 
 pub struct RetrieveSettlementResult(pub Ulid);
 
-impl tower::Service<RetrieveSettlementResult> for SettlementService {
+impl<S> tower::Service<RetrieveSettlementResult> for SettlementService<S>
+where
+    S: SettlementStore + 'static,
+{
     type Response = RetrievedSettlementResult;
     type Error = eyre::Error;
     type Future = Pin<Box<dyn Future<Output = eyre::Result<Self::Response>>>>;
@@ -199,7 +261,10 @@ pub enum AdminCommand {
     ReloadAndRestartTask(Ulid),
 }
 
-impl tower::Service<AdminCommand> for SettlementService {
+impl<S> tower::Service<AdminCommand> for SettlementService<S>
+where
+    S: SettlementStore + 'static,
+{
     type Response = ();
     type Error = eyre::Error;
     type Future = Pin<Box<dyn Future<Output = eyre::Result<Self::Response>>>>;
@@ -221,5 +286,182 @@ impl tower::Service<AdminCommand> for SettlementService {
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::PathBuf, sync::Arc};
+
+    use agglayer_storage::{
+        backup::BackupClient,
+        stores::{state::StateStore, SettlementWriter as _},
+    };
+    use agglayer_types::{
+        Address, ContractCallOutcome, ContractCallResult, Digest, SettlementJob,
+        SettlementJobResult, SettlementTxHash, B256, U256,
+    };
+
+    use super::*;
+
+    struct TempStateDbDir(PathBuf);
+
+    impl TempStateDbDir {
+        fn new() -> Self {
+            let path = std::env::temp_dir()
+                .join(format!("agglayer-settlement-service-tests-{}", Ulid::new()));
+
+            std::fs::create_dir_all(&path).expect("temporary test directory should be created");
+
+            Self(path)
+        }
+
+        fn path(&self) -> &std::path::Path {
+            self.0.as_path()
+        }
+    }
+
+    impl Drop for TempStateDbDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn mk_stored_job(seed: u8) -> SettlementJob {
+        SettlementJob {
+            contract_address: Address::from([seed; 20]),
+            calldata: vec![seed, seed.wrapping_add(1)].into(),
+            eth_value: U256::from(seed as u64),
+            gas_limit: 21_000,
+            max_fee_per_gas_ceiling: 1_000,
+            max_fee_per_gas_floor: 500,
+            max_fee_per_gas_increase_percents: 125,
+            max_priority_fee_per_gas_ceiling: 1_000,
+            max_priority_fee_per_gas_floor: 500,
+            max_priority_fee_per_gas_increase_percents: 125,
+        }
+    }
+
+    fn mk_stored_result(seed: u8) -> SettlementJobResult {
+        SettlementJobResult::ContractCall(ContractCallResult {
+            outcome: ContractCallOutcome::Success,
+            metadata: vec![seed, seed.wrapping_add(1)].into(),
+            block_hash: B256::from([seed; 32]),
+            block_number: seed as u64,
+            tx_hash: SettlementTxHash::new(Digest::from([seed.wrapping_add(2); 32])),
+        })
+    }
+
+    fn mk_in_memory_result(seed: u8) -> SettlementJobResult {
+        SettlementJobResult::ContractCall(ContractCallResult {
+            outcome: ContractCallOutcome::Revert,
+            metadata: vec![seed, seed.wrapping_add(10)].into(),
+            block_hash: B256::from([seed.wrapping_add(11); 32]),
+            block_number: seed as u64 + 1_000,
+            tx_hash: SettlementTxHash::new(Digest::from([seed.wrapping_add(12); 32])),
+        })
+    }
+
+    fn mk_state_store(path: &std::path::Path) -> Arc<StateStore> {
+        Arc::new(
+            StateStore::new_with_path(path, BackupClient::noop()).expect("state store should open"),
+        )
+    }
+
+    #[tokio::test]
+    async fn retrieve_uses_stored_terminal_result_before_watcher() {
+        let tmp = TempStateDbDir::new();
+        let state_store = mk_state_store(tmp.path());
+        let cancellation_token = CancellationToken::new();
+        let service = SettlementService::start(
+            SettlementServiceConfig::default(),
+            state_store.clone(),
+            cancellation_token.clone(),
+        )
+        .await
+        .expect("settlement service should start");
+
+        let job_id = Ulid::new();
+        let stored_result = mk_stored_result(1);
+
+        state_store
+            .insert_settlement_job(&job_id, &mk_stored_job(1))
+            .expect("job insert should succeed");
+        state_store
+            .insert_settlement_job_result(&job_id, &stored_result)
+            .expect("job result insert should succeed");
+
+        let (_sender, watcher) = watch::channel(Some(mk_in_memory_result(2)));
+        service.result_watchers.lock().await.insert(job_id, watcher);
+
+        let retrieved = service
+            .retrieve_settlement_result(job_id)
+            .await
+            .expect("retrieval should succeed");
+
+        match retrieved {
+            RetrievedSettlementResult::Completed(result) => {
+                assert_eq!(result, stored_result);
+            }
+            RetrievedSettlementResult::Pending(_) => panic!("expected completed result"),
+        }
+
+        cancellation_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn retrieve_returns_pending_when_job_exists_without_terminal_result() {
+        let tmp = TempStateDbDir::new();
+        let state_store = mk_state_store(tmp.path());
+        let cancellation_token = CancellationToken::new();
+        let service = SettlementService::start(
+            SettlementServiceConfig::default(),
+            state_store.clone(),
+            cancellation_token.clone(),
+        )
+        .await
+        .expect("settlement service should start");
+
+        let job_id = Ulid::new();
+
+        state_store
+            .insert_settlement_job(&job_id, &mk_stored_job(3))
+            .expect("job insert should succeed");
+
+        let retrieved = service
+            .retrieve_settlement_result(job_id)
+            .await
+            .expect("retrieval should succeed");
+
+        match retrieved {
+            RetrievedSettlementResult::Pending(mut watcher) => {
+                assert!(watcher.watcher().borrow().is_none());
+            }
+            RetrievedSettlementResult::Completed(_) => panic!("expected pending result"),
+        }
+
+        cancellation_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn retrieve_fails_for_unknown_job_id() {
+        let tmp = TempStateDbDir::new();
+        let state_store = mk_state_store(tmp.path());
+        let cancellation_token = CancellationToken::new();
+        let service = SettlementService::start(
+            SettlementServiceConfig::default(),
+            state_store,
+            cancellation_token.clone(),
+        )
+        .await
+        .expect("settlement service should start");
+
+        let result = service.retrieve_settlement_result(Ulid::new()).await;
+        assert!(result.is_err(), "unknown job should fail");
+        let error = result.err().expect("result should be an error");
+
+        assert!(error.to_string().contains("No settlement job found for id"));
+
+        cancellation_token.cancel();
     }
 }

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -1,9 +1,10 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::OnceLock,
+    sync::{Arc, OnceLock},
     time::{Duration, SystemTime},
 };
 
+use agglayer_storage::stores::{SettlementReader, SettlementWriter};
 use agglayer_types::{
     ClientError, ClientErrorType, ContractCallOutcome, ContractCallResult, Digest, Nonce,
     SettlementAttempt, SettlementAttemptNumber, SettlementAttemptResult, SettlementJob,
@@ -19,8 +20,11 @@ use ulid::Ulid;
 
 type TxEnvelope = EthereumTxEnvelope<TxEip4844Variant>;
 
-pub enum StoredSettlementJob {
-    Pending(SettlementTask),
+pub enum StoredSettlementJob<S>
+where
+    S: SettlementStore,
+{
+    Pending(SettlementTask<S>),
     Completed(SettlementJob, SettlementJobResult),
 }
 
@@ -34,9 +38,17 @@ struct ActiveSettlementAttempt {
     result: Option<SettlementAttemptResult>,
 }
 
-pub struct SettlementTask {
+pub trait SettlementStore: SettlementReader + SettlementWriter {}
+
+impl<T> SettlementStore for T where T: SettlementReader + SettlementWriter {}
+
+pub struct SettlementTask<S>
+where
+    S: SettlementStore,
+{
     id: Ulid,
     job: SettlementJob,
+    settlement_store: Arc<S>,
     admin_commands: mpsc::Receiver<TaskAdminCommand>,
     attempts:
         BTreeMap<(Address, Nonce), BTreeMap<SettlementAttemptNumber, ActiveSettlementAttempt>>,
@@ -44,10 +56,14 @@ pub struct SettlementTask {
 
 static ID_GENERATOR: OnceLock<std::sync::Mutex<ulid::Generator>> = OnceLock::new();
 
-impl SettlementTask {
+impl<S> SettlementTask<S>
+where
+    S: SettlementStore,
+{
     pub async fn create(
         job: SettlementJob,
         admin_commands: mpsc::Receiver<TaskAdminCommand>,
+        settlement_store: Arc<S>,
     ) -> eyre::Result<(Ulid, Self)> {
         let id = loop {
             if let Ok(id) = ID_GENERATOR
@@ -63,6 +79,7 @@ impl SettlementTask {
         let this = Self {
             id,
             job,
+            settlement_store,
             admin_commands,
             attempts: BTreeMap::new(),
         };
@@ -73,7 +90,8 @@ impl SettlementTask {
     pub async fn load(
         id: Ulid,
         admin_commands: mpsc::Receiver<TaskAdminCommand>,
-    ) -> eyre::Result<StoredSettlementJob> {
+        settlement_store: Arc<S>,
+    ) -> eyre::Result<StoredSettlementJob<S>> {
         let (job, result) = Self::load_settlement_job_from_db(id).await?;
         if let Some(result) = result {
             Ok(StoredSettlementJob::Completed(job, result))
@@ -81,6 +99,7 @@ impl SettlementTask {
             let mut this = SettlementTask {
                 id,
                 job,
+                settlement_store,
                 admin_commands,
                 attempts: BTreeMap::new(),
             };
@@ -446,21 +465,34 @@ impl SettlementTask {
         _wallet: Address,
         _nonce: Nonce,
         _attempt_number: SettlementAttemptNumber,
-        _tx_result: ContractCallResult,
+        tx_result: ContractCallResult,
     ) {
-        // TODO: Record a settlement job as successful to db, with the given result. All
-        // attempts with the same nonce should be marked as nonce already used, and
-        // attempts with different nonces as having seen a successful settlement
-        // elsewhere.
-        // XREF: https://github.com/agglayer/agglayer/issues/1317
-        todo!()
+        let tx_result = SettlementJobResult::ContractCall(tx_result);
+
+        if let Err(error) = self
+            .settlement_store
+            .insert_settlement_job_result(&self.id, &tx_result)
+        {
+            warn!(
+                ?error,
+                settlement_job_id = %self.id,
+                "Failed to persist successful settlement job result"
+            );
+        }
     }
 
-    async fn write_job_revert_to_db(&self, _result: &ContractCallResult) {
-        // TODO: Record a settlement job as reverted to db, with the given result. All
-        // attempts should already have been marked as nonce already used or revert, so
-        // no need to update them, but maybe run a sanity-check.
-        // XREF: https://github.com/agglayer/agglayer/issues/1317
-        todo!()
+    async fn write_job_revert_to_db(&self, result: &ContractCallResult) {
+        let tx_result = SettlementJobResult::ContractCall(result.clone());
+
+        if let Err(error) = self
+            .settlement_store
+            .insert_settlement_job_result(&self.id, &tx_result)
+        {
+            warn!(
+                ?error,
+                settlement_job_id = %self.id,
+                "Failed to persist reverted settlement job result"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- read settlement terminal results from `settlement_job_results` before consulting in-memory watchers, so retrieval works across service restarts.
- persist terminal settlement outcomes (success/revert) from settlement tasks into storage.
- replace `Arc<dyn SettlementStore>` with generic `Arc<S>` wiring in settlement service/task to match the repository's generic store pattern.
- add settlement-service tests for stored-result precedence, pending known jobs, and unknown job IDs.

## Testing
- `cargo test -p agglayer-settlement-service`
- `cargo check --workspace --all-targets`