### PR TITLE
ci: sync PR size to GitHub Projects

### DIFF
--- a/.github/agents/pr-size-rater.agent.md
+++ b/.github/agents/pr-size-rater.agent.md
@@ -1,0 +1,142 @@
+---
+name: pr-size-rater
+description: Classifies pull request size by reviewer effort and semantic complexity rather than raw diff size. Discounts mechanical churn such as lockfile updates, generated files, formatting-only changes, and bulk renames when they do not meaningfully increase review cost.
+target: github-copilot
+tools: ["github/*", "read", "search"]
+disable-model-invocation: true
+---
+
+You are a pull request sizing specialist.
+
+Your goal is to classify the size of a pull request based on **review effort and semantic complexity**, not raw lines changed.
+
+## Core principle
+A PR's size means: **How much focused reviewer effort is required to understand the intent, assess correctness, assess risk, and approve safely?**
+
+Do **not** treat a PR as large only because the diff is numerically large.
+
+## Always evaluate these factors
+1. **Meaningful change surface**
+   - How many files require real human reasoning?
+   - How many modules, layers, or domains are touched?
+   - Is the change localized or cross-cutting?
+
+2. **Behavioral complexity**
+   - Does the PR change runtime behavior, business logic, or public interfaces?
+   - Does it alter persistence, schemas, contracts, background jobs, caching, auth, permissions, concurrency, or error handling?
+
+3. **Risk and rollback difficulty**
+   - Would a mistake be costly or hard to detect?
+   - Is the change easy to validate and easy to revert?
+   - Are there migrations, config changes, or deployment concerns?
+
+4. **Review context required**
+   - Can a reviewer understand this in one local area?
+   - Or must they reconstruct system-wide intent across multiple files?
+
+5. **Testing burden**
+   - Does the reviewer need to reason through many edge cases, integration paths, or compatibility concerns?
+
+## Explicit discounts
+Discount or mostly ignore the following **when they are mechanical and do not add real review cost**:
+- lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `poetry.lock`, `Cargo.lock`, etc.)
+- generated files
+- snapshots
+- vendored assets
+- formatting-only edits
+- comment-only changes
+- bulk renames or moves with no behavior change
+- boilerplate repeated consistently
+- version bumps where the main work is changing package metadata and regenerating a lockfile
+
+## Dependency upgrade rule
+Dependency upgrade PRs must **not** be classified by lockfile size alone.
+
+Treat a dependency upgrade as **cheap** when most of the diff is one or more version bumps plus lockfile regeneration and:
+- code changes are absent or minimal
+- there is no migration or manual refactor
+- the upgrade is routine and low-risk
+- runtime behavior is expected to remain the same
+
+Treat a dependency upgrade as **more expensive** when any of the following are true:
+- it is a major-version upgrade
+- application code had to change to adapt APIs
+- config, build, or deployment behavior changed
+- tests needed meaningful updates
+- release notes imply breaking or risky behavior
+- multiple packages changed in ways that interact
+
+## Stacked PR rule
+When the PR is part of a stack, classify only the **incremental diff against its base branch**, not the cumulative size of the stack.
+
+## Size buckets
+Use exactly one of these buckets:
+
+### XS
+Very cheap to review.
+Typical cases:
+- docs, comments, or tests only
+- one tiny localized fix
+- formatting only
+- mechanical rename with no behavior change
+- routine dependency bump with mostly lockfile churn and little or no code impact
+
+### S
+Cheap review with limited reasoning.
+Typical cases:
+- one localized behavior change
+- one or two meaningful files
+- small config update with obvious impact
+- routine library upgrade with a tiny amount of adaptation code
+
+### M
+Moderate review cost.
+Typical cases:
+- several meaningful files
+- one feature slice contained in one subsystem
+- moderate refactor in a local area
+- dependency upgrade with some real code or test adaptation
+- behavior changes that require careful but still bounded review
+
+### L
+Expensive review.
+Typical cases:
+- cross-module or cross-layer changes
+- public API or contract changes
+- schema, migration, auth, caching, performance-critical, or concurrency-sensitive work
+- refactors that require reconstructing intent across many meaningful files
+- multiple interacting changes bundled together
+
+### XL
+Very expensive review.
+Typical cases:
+- broad cross-cutting architecture changes
+- breaking changes across multiple subsystems
+- high-risk migrations or rollouts
+- very large PRs that should likely be split for review
+
+## Classification guidance
+Prefer the **smallest** label that still reflects real reviewer effort.
+
+Do not inflate the size because of raw additions/deletions if most churn is discounted.
+Do inflate the size when a seemingly small diff changes a risky area or requires deep reasoning.
+
+## Output format
+Return exactly this structure:
+
+Size: <XS|S|M|L|XL>
+Suggested label: <size/xs|size/s|size/m|size/l|size/xl>
+Review effort: <one short phrase, for example "~5 minutes" or "~25 minutes">
+Why:
+- <bullet 1>
+- <bullet 2>
+- <bullet 3>
+Discounted churn:
+- <bullet or "None">
+Escalators:
+- <bullet or "None">
+
+## Final checks before answering
+- Ask yourself whether lockfiles, generated files, or formatting artificially inflated the diff.
+- Ask yourself whether the change is actually risky even if the diff is small.
+- Prefer consistency with prior sizing decisions in the repository when evidence is available.

--- a/.github/agents/pr-size-rater.agent.md
+++ b/.github/agents/pr-size-rater.agent.md
@@ -10,6 +10,8 @@ You are a pull request sizing specialist.
 
 Your goal is to classify the size of a pull request based on **review effort and semantic complexity**, not raw lines changed.
 
+The result should map directly to the GitHub Project `Size` field using the values `XS`, `S`, `M`, `L`, or `XL`.
+
 ## Core principle
 A PR's size means: **How much focused reviewer effort is required to understand the intent, assess correctness, assess risk, and approve safely?**
 
@@ -116,7 +118,7 @@ Typical cases:
 - very large PRs that should likely be split for review
 
 ## Classification guidance
-Prefer the **smallest** label that still reflects real reviewer effort.
+Prefer the **smallest** size bucket that still reflects real reviewer effort.
 
 Do not inflate the size because of raw additions/deletions if most churn is discounted.
 Do inflate the size when a seemingly small diff changes a risky area or requires deep reasoning.
@@ -125,7 +127,6 @@ Do inflate the size when a seemingly small diff changes a risky area or requires
 Return exactly this structure:
 
 Size: <XS|S|M|L|XL>
-Suggested label: <size/xs|size/s|size/m|size/l|size/xl>
 Review effort: <one short phrase, for example "~5 minutes" or "~25 minutes">
 Why:
 - <bullet 1>

--- a/.github/instructions/pr-sizing.instructions.md
+++ b/.github/instructions/pr-sizing.instructions.md
@@ -1,0 +1,33 @@
+---
+applyTo: "**"
+---
+
+When reviewing a pull request, classify its size by **review effort and semantic complexity**, not raw line count.
+
+Use these labels: `size/xs`, `size/s`, `size/m`, `size/l`, `size/xl`.
+
+Discount mechanical churn when it does not add real review cost:
+- lockfiles
+- generated files
+- snapshots
+- formatting-only edits
+- comment-only changes
+- bulk renames or moves with no behavior change
+- boilerplate repeated consistently
+
+For dependency upgrades, do **not** treat lockfile size as review size. A version bump plus lockfile regeneration with little or no code adaptation is usually `size/xs` or `size/s`. Escalate only when the upgrade is major, requires code/config/test changes, or changes runtime behavior.
+
+Classify by reviewer effort:
+- `size/xs`: trivial docs/tests/formatting or routine dependency bump
+- `size/s`: localized change in one area, cheap review
+- `size/m`: several meaningful files or one contained feature slice
+- `size/l`: cross-module, risky, or contract-changing work
+- `size/xl`: broad cross-cutting or split-worthy PR
+
+When the PR is part of a stack, judge only the incremental diff against its base branch.
+
+When you comment on PR size, always include:
+1. the chosen label
+2. 2-3 reasons
+3. any discounted churn
+4. any escalators that increased the size

--- a/.github/instructions/pr-sizing.instructions.md
+++ b/.github/instructions/pr-sizing.instructions.md
@@ -4,7 +4,7 @@ applyTo: "**"
 
 When reviewing a pull request, classify its size by **review effort and semantic complexity**, not raw line count.
 
-Use these labels: `size/xs`, `size/s`, `size/m`, `size/l`, `size/xl`.
+Use the GitHub Project `Size` field values: `XS`, `S`, `M`, `L`, `XL`.
 
 Discount mechanical churn when it does not add real review cost:
 - lockfiles
@@ -15,19 +15,19 @@ Discount mechanical churn when it does not add real review cost:
 - bulk renames or moves with no behavior change
 - boilerplate repeated consistently
 
-For dependency upgrades, do **not** treat lockfile size as review size. A version bump plus lockfile regeneration with little or no code adaptation is usually `size/xs` or `size/s`. Escalate only when the upgrade is major, requires code/config/test changes, or changes runtime behavior.
+For dependency upgrades, do **not** treat lockfile size as review size. A version bump plus lockfile regeneration with little or no code adaptation is usually `XS` or `S`. Escalate only when the upgrade is major, requires code/config/test changes, or changes runtime behavior.
 
 Classify by reviewer effort:
-- `size/xs`: trivial docs/tests/formatting or routine dependency bump
-- `size/s`: localized change in one area, cheap review
-- `size/m`: several meaningful files or one contained feature slice
-- `size/l`: cross-module, risky, or contract-changing work
-- `size/xl`: broad cross-cutting or split-worthy PR
+- `XS`: trivial docs/tests/formatting or routine dependency bump
+- `S`: localized change in one area, cheap review
+- `M`: several meaningful files or one contained feature slice
+- `L`: cross-module, risky, or contract-changing work
+- `XL`: broad cross-cutting or split-worthy PR
 
 When the PR is part of a stack, judge only the incremental diff against its base branch.
 
 When you comment on PR size, always include:
-1. the chosen label
+1. the chosen size
 2. 2-3 reasons
 3. any discounted churn
 4. any escalators that increased the size

--- a/.github/workflows/pr-size-to-project.yml
+++ b/.github/workflows/pr-size-to-project.yml
@@ -1,0 +1,670 @@
+name: Sync PR size to GitHub Project
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-size-project-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-pr-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute PR size and write it to the project item
+        uses: actions/github-script@v7
+        env:
+          PROJECT_OWNER: ${{ vars.PR_SIZE_PROJECT_OWNER }}
+          PROJECT_NUMBER: ${{ vars.PR_SIZE_PROJECT_NUMBER }}
+          SIZE_FIELD_NAME: ${{ vars.PR_SIZE_FIELD_NAME }}
+          AUTO_ADD_TO_PROJECT: ${{ vars.PR_SIZE_AUTO_ADD }}
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            const projectOwner = (process.env.PROJECT_OWNER || owner).trim();
+            const projectNumber = Number(process.env.PROJECT_NUMBER || '');
+            const sizeFieldName = (process.env.SIZE_FIELD_NAME || 'Size').trim();
+            const autoAddToProject = String(process.env.AUTO_ADD_TO_PROJECT || 'false').toLowerCase() === 'true';
+            const projectsToken = process.env.PROJECTS_TOKEN;
+
+            if (!projectNumber) {
+              core.setFailed('Missing repository variable PR_SIZE_PROJECT_NUMBER.');
+              return;
+            }
+            if (!projectsToken) {
+              core.setFailed('Missing secret PROJECTS_TOKEN.');
+              return;
+            }
+
+            // IMPORTANT:
+            // This workflow intentionally does not check out or execute pull request code.
+            // It only reads pull request metadata via the API, which is safer on pull_request_target.
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const lockfileNames = new Set([
+              'package-lock.json',
+              'pnpm-lock.yaml',
+              'yarn.lock',
+              'poetry.lock',
+              'pipfile.lock',
+              'cargo.lock',
+              'gemfile.lock',
+              'composer.lock',
+              'packages.lock.json',
+              'podfile.lock',
+            ]);
+
+            const manifestNames = new Set([
+              'package.json',
+              'pnpm-workspace.yaml',
+              'requirements.txt',
+              'requirements-dev.txt',
+              'pyproject.toml',
+              'poetry.toml',
+              'pipfile',
+              'cargo.toml',
+              'go.mod',
+              'go.sum',
+              'pom.xml',
+              'build.gradle',
+              'build.gradle.kts',
+              'gradle.properties',
+              'settings.gradle',
+              'settings.gradle.kts',
+              'composer.json',
+              'gemfile',
+              '.tool-versions',
+              '.nvmrc',
+            ]);
+
+            const docExts = new Set(['md', 'mdx', 'rst', 'adoc', 'txt']);
+            const testMarkers = [
+              '/test/',
+              '/tests/',
+              '__tests__',
+              '__snapshots__',
+              '.spec.',
+              '.test.',
+              '_spec.',
+              '_test.',
+            ];
+            const generatedMarkers = [
+              '/dist/',
+              '/build/',
+              '/coverage/',
+              '/vendor/',
+              '/third_party/',
+              '/generated/',
+              '/gen/',
+              '.snap',
+              '.min.js',
+              '.min.css',
+            ];
+            const buildConfigMarkers = [
+              '.github/workflows/',
+              'eslint',
+              'prettier',
+              'ruff',
+              'mypy',
+              'pyright',
+              'tsconfig',
+              'babel',
+              'vite',
+              'vitest',
+              'jest',
+              'webpack',
+              'rollup',
+              'turbo',
+              'nx',
+              'biome',
+              'lint',
+            ];
+            const runtimeConfigMarkers = [
+              'docker-compose',
+              'dockerfile',
+              'helm/',
+              'k8s/',
+              'kubernetes/',
+              'terraform/',
+              '.tf',
+              'nginx',
+              'fly.toml',
+              'procfile',
+              'deploy',
+              'deployment',
+            ];
+            const riskyMarkers = [
+              'auth',
+              'oauth',
+              'permission',
+              'policy',
+              'role',
+              'security',
+              'token',
+              'session',
+              'billing',
+              'payment',
+              'cache',
+              'queue',
+              'worker',
+              'retry',
+              'concurr',
+              'mutex',
+              'lock(',
+              'transaction',
+              'rate limit',
+            ];
+            const migrationMarkers = [
+              'migration',
+              'migrations',
+              'schema',
+              'alembic',
+              'prisma',
+              'db/migrate',
+              'sql',
+              'alter table',
+              'create index',
+              'drop column',
+              'backfill',
+            ];
+
+            function lower(value) {
+              return (value || '').toLowerCase();
+            }
+
+            function basename(path) {
+              return path.split('/').pop() || path;
+            }
+
+            function ext(path) {
+              const base = basename(path);
+              const idx = base.lastIndexOf('.');
+              return idx === -1 ? '' : base.slice(idx + 1).toLowerCase();
+            }
+
+            function hasAny(text, needles) {
+              return needles.some((needle) => text.includes(needle));
+            }
+
+            function isLockfile(path) {
+              const p = lower(path);
+              return lockfileNames.has(basename(p));
+            }
+
+            function isManifest(path) {
+              const p = lower(path);
+              return manifestNames.has(basename(p));
+            }
+
+            function isDoc(path) {
+              const p = lower(path);
+              return p.startsWith('docs/') || p === 'readme.md' || p === 'changelog.md' || docExts.has(ext(p));
+            }
+
+            function isTest(path) {
+              const p = lower(path);
+              return hasAny(p, testMarkers);
+            }
+
+            function isGenerated(path, patch = '') {
+              const p = lower(path);
+              const patchText = lower(patch);
+              return hasAny(p, generatedMarkers) || patchText.includes('generated by');
+            }
+
+            function isRenameOnly(file) {
+              if (file.status !== 'renamed') return false;
+              if (!file.patch) return true;
+              return file.changes <= 20;
+            }
+
+            function isFormattingOnly(patch = '') {
+              const trimmed = patch.trim();
+              if (!trimmed) return false;
+              const lines = trimmed.split('\n').filter((line) => line.startsWith('+') || line.startsWith('-'));
+              if (lines.length === 0) return false;
+              return lines.every((line) => {
+                const body = line.slice(1).trim();
+                if (!body) return true;
+                if (/^[{}()[\],.;]+$/.test(body)) return true;
+                return false;
+              });
+            }
+
+            function isBuildConfig(path) {
+              const p = lower(path);
+              return hasAny(p, buildConfigMarkers) || p.endsWith('.github/dependabot.yml');
+            }
+
+            function isRuntimeConfig(path) {
+              const p = lower(path);
+              return hasAny(p, runtimeConfigMarkers);
+            }
+
+            function topArea(path) {
+              const parts = path.split('/');
+              return parts.length > 1 ? parts[0] : '(root)';
+            }
+
+            function hasRiskySignal(path, patch = '') {
+              const haystack = `${lower(path)}\n${lower(patch)}`;
+              return hasAny(haystack, riskyMarkers);
+            }
+
+            function hasMigrationSignal(path, patch = '') {
+              const haystack = `${lower(path)}\n${lower(patch)}`;
+              return hasAny(haystack, migrationMarkers);
+            }
+
+            let score = 0;
+            let manifestFiles = 0;
+            let docFiles = 0;
+            let testFiles = 0;
+            let buildConfigFiles = 0;
+            let runtimeConfigFiles = 0;
+            let appCodeFiles = 0;
+            let manualAppChanges = 0;
+            let riskySignals = 0;
+            let migrationSignals = 0;
+            const discounted = [];
+            const appAreas = new Set();
+
+            for (const file of files) {
+              const path = file.filename;
+              const patch = file.patch || '';
+
+              if (isLockfile(path)) {
+                discounted.push(`${path} (lockfile)`);
+                continue;
+              }
+              if (isGenerated(path, patch)) {
+                discounted.push(`${path} (generated or snapshot)`);
+                continue;
+              }
+              if (isRenameOnly(file)) {
+                discounted.push(`${path} (rename or move)`);
+                continue;
+              }
+              if (isFormattingOnly(patch)) {
+                discounted.push(`${path} (formatting only)`);
+                continue;
+              }
+
+              if (isDoc(path)) {
+                docFiles += 1;
+                score += 0.5;
+                continue;
+              }
+              if (isTest(path)) {
+                testFiles += 1;
+                score += 0.75;
+                continue;
+              }
+              if (isManifest(path)) {
+                manifestFiles += 1;
+                score += manifestFiles === 1 ? 1 : 0.5;
+                continue;
+              }
+              if (isRuntimeConfig(path)) {
+                runtimeConfigFiles += 1;
+                score += 2;
+                continue;
+              }
+              if (isBuildConfig(path)) {
+                buildConfigFiles += 1;
+                score += 1;
+                continue;
+              }
+
+              appCodeFiles += 1;
+              manualAppChanges += Math.min(file.changes || 0, 250);
+              appAreas.add(topArea(path));
+
+              if (hasRiskySignal(path, patch)) riskySignals += 1;
+              if (hasMigrationSignal(path, patch)) migrationSignals += 1;
+            }
+
+            if (appCodeFiles > 0) {
+              score += appAreas.size * 2;
+              score += Math.min(3, Math.max(0, appCodeFiles - appAreas.size)) * 0.5;
+              score += Math.min(3, manualAppChanges / 300);
+            }
+            score += riskySignals * 2;
+            score += migrationSignals * 1.5;
+
+            const dependencyOnlySurface = manifestFiles > 0 && appCodeFiles === 0 && runtimeConfigFiles === 0 && riskySignals === 0 && migrationSignals === 0;
+            if (dependencyOnlySurface) {
+              if (buildConfigFiles === 0 && testFiles === 0 && docFiles === 0) {
+                score = Math.min(score, 2.5);
+              } else {
+                score = Math.min(score, 5);
+              }
+            }
+
+            if ((riskySignals > 0 || migrationSignals > 0 || runtimeConfigFiles > 0) && testFiles === 0) {
+              score += 2;
+            }
+
+            let size = 'XS';
+            if (score > 22) size = 'XL';
+            else if (score > 13) size = 'L';
+            else if (score > 7) size = 'M';
+            else if (score > 3) size = 'S';
+
+            const reasons = [];
+            if (dependencyOnlySurface) {
+              reasons.push('Mostly dependency metadata changes; lockfile churn is discounted.');
+            }
+            if (appCodeFiles > 0) {
+              reasons.push(`${appCodeFiles} meaningful code file(s) across ${appAreas.size} logical area(s).`);
+            }
+            if (runtimeConfigFiles > 0) {
+              reasons.push(`${runtimeConfigFiles} runtime or deployment config file(s) changed.`);
+            }
+            if (riskySignals > 0) {
+              reasons.push('Risk-sensitive paths or patches detected (auth, permissions, cache, queue, or similar).');
+            }
+            if (migrationSignals > 0) {
+              reasons.push('Migration or schema-related work detected.');
+            }
+            if (testFiles > 0) {
+              reasons.push(`${testFiles} test file(s) changed, which lowers review uncertainty.`);
+            } else if (riskySignals > 0 || migrationSignals > 0 || runtimeConfigFiles > 0) {
+              reasons.push('Risky surface changed without test updates, which increases review cost.');
+            }
+            if (reasons.length === 0) {
+              reasons.push('Small localized surface with little manual review work.');
+            }
+
+            core.info(`Computed PR size ${size} (score ${score.toFixed(1)}).`);
+            core.info(`Reasons: ${reasons.join(' | ')}`);
+            if (discounted.length > 0) {
+              core.info(`Discounted churn: ${discounted.slice(0, 10).join(', ')}${discounted.length > 10 ? ' ...' : ''}`);
+            }
+
+            async function projectGraphQL(query, variables) {
+              const response = await fetch('https://api.github.com/graphql', {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${projectsToken}`,
+                  'Content-Type': 'application/json',
+                  'User-Agent': 'pr-size-to-project-workflow',
+                },
+                body: JSON.stringify({ query, variables }),
+              });
+
+              const json = await response.json();
+              if (!response.ok || json.errors) {
+                const message = json.errors ? JSON.stringify(json.errors) : JSON.stringify(json);
+                throw new Error(`GraphQL request failed: ${message}`);
+              }
+              return json.data;
+            }
+
+            const projectQuery = `
+              query($owner: String!, $number: Int!, $fieldsAfter: String, $itemsAfter: String) {
+                organization(login: $owner) {
+                  projectV2(number: $number) {
+                    id
+                    fields(first: 100, after: $fieldsAfter) {
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                      nodes {
+                        __typename
+                        ... on ProjectV2FieldCommon {
+                          id
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          options {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }
+                    items(first: 100, after: $itemsAfter) {
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                      nodes {
+                        id
+                        content {
+                          __typename
+                          ... on PullRequest {
+                            id
+                            number
+                            url
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                user(login: $owner) {
+                  projectV2(number: $number) {
+                    id
+                    fields(first: 100, after: $fieldsAfter) {
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                      nodes {
+                        __typename
+                        ... on ProjectV2FieldCommon {
+                          id
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          options {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }
+                    items(first: 100, after: $itemsAfter) {
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                      nodes {
+                        id
+                        content {
+                          __typename
+                          ... on PullRequest {
+                            id
+                            number
+                            url
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const firstPage = await projectGraphQL(projectQuery, {
+              owner: projectOwner,
+              number: projectNumber,
+              fieldsAfter: null,
+              itemsAfter: null,
+            });
+
+            const project = firstPage.organization?.projectV2 || firstPage.user?.projectV2;
+            if (!project) {
+              core.setFailed(`Could not find project ${projectOwner} #${projectNumber}.`);
+              return;
+            }
+
+            let field = project.fields.nodes.find((node) => (node.name || '').toLowerCase() === sizeFieldName.toLowerCase());
+            let fieldsCursor = project.fields.pageInfo.endCursor;
+            let fieldsHasNextPage = project.fields.pageInfo.hasNextPage;
+
+            while (!field && fieldsHasNextPage) {
+              const nextPage = await projectGraphQL(projectQuery, {
+                owner: projectOwner,
+                number: projectNumber,
+                fieldsAfter: fieldsCursor,
+                itemsAfter: null,
+              });
+              const nextProject = nextPage.organization?.projectV2 || nextPage.user?.projectV2;
+              const fields = nextProject?.fields;
+              if (!fields) break;
+              field = fields.nodes.find((node) => (node.name || '').toLowerCase() === sizeFieldName.toLowerCase());
+              fieldsCursor = fields.pageInfo.endCursor;
+              fieldsHasNextPage = fields.pageInfo.hasNextPage;
+            }
+
+            if (!field) {
+              core.setFailed(`Could not find a project field named "${sizeFieldName}".`);
+              return;
+            }
+
+            let item = project.items.nodes.find((node) => node.content?.__typename === 'PullRequest' && (node.content.id === pr.node_id || node.content.number === pr.number));
+            let cursor = project.items.pageInfo.endCursor;
+            let hasNextPage = project.items.pageInfo.hasNextPage;
+
+            while (!item && hasNextPage) {
+              const nextPage = await projectGraphQL(projectQuery, {
+                owner: projectOwner,
+                number: projectNumber,
+                fieldsAfter: null,
+                itemsAfter: cursor,
+              });
+              const nextProject = nextPage.organization?.projectV2 || nextPage.user?.projectV2;
+              const items = nextProject?.items;
+              if (!items) break;
+              item = items.nodes.find((node) => node.content?.__typename === 'PullRequest' && (node.content.id === pr.node_id || node.content.number === pr.number));
+              cursor = items.pageInfo.endCursor;
+              hasNextPage = items.pageInfo.hasNextPage;
+            }
+
+            if (!item && autoAddToProject) {
+              const addItemMutation = `
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                    item {
+                      id
+                    }
+                  }
+                }
+              `;
+              const added = await projectGraphQL(addItemMutation, {
+                projectId: project.id,
+                contentId: pr.node_id,
+              });
+              item = added.addProjectV2ItemById?.item || null;
+            }
+
+            if (!item) {
+              core.warning(`No project item linked to PR #${pr.number} was found in project ${projectOwner} #${projectNumber}. Set PR_SIZE_AUTO_ADD=true if you want this workflow to add it automatically.`);
+              return;
+            }
+
+            const optionAliases = {
+              XS: ['xs', 'size/xs', 'size-xs', 'x-small', 'x small'],
+              S: ['s', 'size/s', 'size-s', 'small'],
+              M: ['m', 'size/m', 'size-m', 'medium'],
+              L: ['l', 'size/l', 'size-l', 'large'],
+              XL: ['xl', 'size/xl', 'size-xl', 'x-large', 'x large'],
+            };
+
+            if (field.__typename === 'ProjectV2SingleSelectField') {
+              const wantedNames = new Set(optionAliases[size]);
+              const option = (field.options || []).find((candidate) => wantedNames.has((candidate.name || '').toLowerCase()));
+              if (!option) {
+                core.setFailed(`Field "${sizeFieldName}" exists, but no matching single-select option was found for size ${size}. Expected one of: ${optionAliases[size].join(', ')}`);
+                return;
+              }
+
+              const updateSingleSelectMutation = `
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { singleSelectOptionId: $optionId }
+                    }
+                  ) {
+                    projectV2Item {
+                      id
+                    }
+                  }
+                }
+              `;
+
+              await projectGraphQL(updateSingleSelectMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: field.id,
+                optionId: option.id,
+              });
+            } else {
+              const updateTextMutation = `
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { text: $text }
+                    }
+                  ) {
+                    projectV2Item {
+                      id
+                    }
+                  }
+                }
+              `;
+
+              await projectGraphQL(updateTextMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: field.id,
+                text: size,
+              });
+            }
+
+            await core.summary
+              .addHeading('PR size synced to project')
+              .addTable([
+                [
+                  { data: 'Pull request', header: true },
+                  { data: 'Size', header: true },
+                  { data: 'Score', header: true },
+                  { data: 'Field', header: true },
+                ],
+                [
+                  `#${pr.number}`,
+                  size,
+                  score.toFixed(1),
+                  sizeFieldName,
+                ],
+              ])
+              .addList(reasons)
+              .write();

--- a/.github/workflows/pr-size-to-project.yml
+++ b/.github/workflows/pr-size-to-project.yml
@@ -586,11 +586,11 @@ jobs:
             }
 
             const optionAliases = {
-              XS: ['xs', 'size/xs', 'size-xs', 'x-small', 'x small'],
-              S: ['s', 'size/s', 'size-s', 'small'],
-              M: ['m', 'size/m', 'size-m', 'medium'],
-              L: ['l', 'size/l', 'size-l', 'large'],
-              XL: ['xl', 'size/xl', 'size-xl', 'x-large', 'x large'],
+              XS: ['xs', 'x-small', 'x small'],
+              S: ['s', 'small'],
+              M: ['m', 'medium'],
+              L: ['l', 'large'],
+              XL: ['xl', 'x-large', 'x large'],
             };
 
             if (field.__typename === 'ProjectV2SingleSelectField') {


### PR DESCRIPTION
This adds a PR sizing workflow that classifies review effort from the changed surface and syncs the result to the configured GitHub Project field.

It also adds repository Copilot agent and instruction files so manual review uses the same semantic sizing rules as the workflow.
