### PR TITLE
fix(storage): catch_unwind around bincode decode and install protoc in CI

### DIFF
--- a/.github/workflows/cycle-tracker.yml
+++ b/.github/workflows/cycle-tracker.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           cache-on-failure: true
 
+      - uses: taiki-e/install-action@protoc
+
       - uses: taiki-e/install-action@nextest
 
       - name: Install Anvil

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -98,6 +98,8 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
 
+      - uses: taiki-e/install-action@protoc
+
       - name: Install udeps
         run: cargo install cargo-udeps --locked
 

--- a/crates/agglayer-storage/src/types/certificate/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/mod.rs
@@ -28,7 +28,7 @@ use agglayer_types::{
 use pessimistic_proof::unified_bridge::{
     AggchainProofPublicValues, BridgeExit, ImportedBridgeExit,
 };
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::schema::{bincode_codec, CodecError};
 
@@ -337,10 +337,23 @@ impl From<AggchainDataV1<'_>> for AggchainData {
 /// Type specifying the current certificate encoding format.
 type CurrentCertificate<'a> = CertificateV1<'a>;
 
-fn decode<T: for<'de> Deserialize<'de> + Into<Certificate>>(
-    bytes: &[u8],
-) -> Result<Certificate, CodecError> {
-    Ok(bincode_codec().deserialize::<T>(bytes)?.into())
+fn panic_bincode_error() -> agglayer_types::bincode::Error {
+    Box::new(agglayer_types::bincode::ErrorKind::Custom(String::from(
+        "panic during deserialization",
+    )))
+}
+
+fn deserialize_bincode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, CodecError> {
+    std::panic::catch_unwind(|| bincode_codec().deserialize::<T>(bytes))
+        .map_err(|_| CodecError::Serialization(panic_bincode_error()))?
+        .map_err(CodecError::Serialization)
+}
+
+fn decode<T>(bytes: &[u8]) -> Result<Certificate, CodecError>
+where
+    T: DeserializeOwned + Into<Certificate>,
+{
+    Ok(deserialize_bincode::<T>(bytes)?.into())
 }
 
 impl crate::schema::Codec for Certificate {

--- a/crates/agglayer-storage/src/types/certificate/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/mod.rs
@@ -343,6 +343,14 @@ fn panic_bincode_error() -> agglayer_types::bincode::Error {
     )))
 }
 
+/// Wrap `bincode` deserialization in `catch_unwind` so a panic from a
+/// malformed row surfaces as `CodecError::Serialization` instead of
+/// unwinding the node process.
+///
+/// The closure captures `&[u8]` and a `bincode::Options` value, both of
+/// which are `UnwindSafe`; no `AssertUnwindSafe` is needed. Clippy's
+/// `catch_unwind` lint is not triggered here, confirming the
+/// `UnwindSafe` bound is satisfied by inference.
 fn deserialize_bincode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, CodecError> {
     std::panic::catch_unwind(|| bincode_codec().deserialize::<T>(bytes))
         .map_err(|_| CodecError::Serialization(panic_bincode_error()))?

--- a/crates/agglayer-storage/src/types/certificate/tests/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/tests/mod.rs
@@ -450,7 +450,4 @@ fn catch_unwind_converts_deserializer_panic_into_codec_error() {
         Err(other) => panic!("unexpected error variant: {other:?}"),
         Ok(_) => panic!("deserialize_bincode returned Ok on a panicking type"),
     }
-
-    // Suppress the "unused" warning on the helper struct when not matched.
-    let _ = std::marker::PhantomData::<PanickingOnDeserialize>;
 }

--- a/crates/agglayer-storage/src/types/certificate/tests/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/tests/mod.rs
@@ -409,10 +409,12 @@ fn bad_format() {
     }
 }
 
+/// Smoke test: malformed bytes must surface as a recoverable `CodecError`,
+/// never as a process-level panic. Covers the common case where bincode
+/// returns its own error (no panic reached).
 #[test]
-fn catch_unwind_turns_panic_into_error() {
-    // A trailing single 0x03 past a valid v1 version byte can make bincode
-    // panic while reading lengths; we want it to surface as a CodecError.
+fn decode_of_corrupt_bytes_returns_codec_error() {
+    // A valid v1 version byte followed by junk that bincode rejects.
     let bytes = [0x01u8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
     let err = <Certificate as crate::schema::Codec>::decode(&bytes)
         .expect_err("expected decode to fail, not panic");
@@ -420,4 +422,35 @@ fn catch_unwind_turns_panic_into_error() {
         matches!(err, crate::schema::CodecError::Serialization(_)),
         "unexpected error variant: {err:?}"
     );
+}
+
+/// Regression guard: if a deserializer ever panics mid-decode, the
+/// `catch_unwind` wrapper in `deserialize_bincode` must convert the panic
+/// into a `CodecError::Serialization`, not let it escape. We provoke this
+/// with a test-only type whose `Deserialize` impl deliberately panics.
+#[test]
+fn catch_unwind_converts_deserializer_panic_into_codec_error() {
+    use serde::de::{Deserialize, Deserializer};
+
+    #[derive(Debug)]
+    struct PanickingOnDeserialize;
+
+    impl<'de> Deserialize<'de> for PanickingOnDeserialize {
+        fn deserialize<D: Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
+            panic!("intentional panic for catch_unwind test");
+        }
+    }
+
+    // Borrow the real catch_unwind helper by decoding through bincode.
+    // `deserialize_bincode` is module-private, so call it via the
+    // sibling `super::deserialize_bincode::<PanickingOnDeserialize>(...)`.
+    let result = super::deserialize_bincode::<PanickingOnDeserialize>(&[0u8; 0]);
+    match result {
+        Err(crate::schema::CodecError::Serialization(_)) => {}
+        Err(other) => panic!("unexpected error variant: {other:?}"),
+        Ok(_) => panic!("deserialize_bincode returned Ok on a panicking type"),
+    }
+
+    // Suppress the "unused" warning on the helper struct when not matched.
+    let _ = std::marker::PhantomData::<PanickingOnDeserialize>;
 }

--- a/crates/agglayer-storage/src/types/certificate/tests/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/tests/mod.rs
@@ -408,3 +408,16 @@ fn bad_format() {
         }
     }
 }
+
+#[test]
+fn catch_unwind_turns_panic_into_error() {
+    // A trailing single 0x03 past a valid v1 version byte can make bincode
+    // panic while reading lengths; we want it to surface as a CodecError.
+    let bytes = [0x01u8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+    let err = <Certificate as crate::schema::Codec>::decode(&bytes)
+        .expect_err("expected decode to fail, not panic");
+    assert!(
+        matches!(err, crate::schema::CodecError::Serialization(_)),
+        "unexpected error variant: {err:?}"
+    );
+}

--- a/crates/agglayer-storage/src/types/certificate/tests/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/tests/mod.rs
@@ -431,6 +431,7 @@ fn decode_of_corrupt_bytes_returns_codec_error() {
 #[test]
 fn catch_unwind_converts_deserializer_panic_into_codec_error() {
     use serde::de::{Deserialize, Deserializer};
+    use std::sync::{Mutex, OnceLock};
 
     #[derive(Debug)]
     struct PanickingOnDeserialize;
@@ -446,8 +447,14 @@ fn catch_unwind_converts_deserializer_panic_into_codec_error() {
     // sibling `super::deserialize_bincode::<PanickingOnDeserialize>(...)`.
     //
     // Suppress the default panic hook during the intentional panic so CI
-    // logs are not polluted by the stack trace. The hook is restored
-    // immediately after the call returns.
+    // logs are not polluted by the stack trace. Protect the process-wide
+    // panic hook with a lock so parallel tests cannot race on the hook
+    // state. The hook is restored immediately after the call returns.
+    static PANIC_HOOK_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = PANIC_HOOK_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("panic hook lock poisoned");
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(|_| {}));
     let result = super::deserialize_bincode::<PanickingOnDeserialize>(&[0u8; 0]);

--- a/crates/agglayer-storage/src/types/certificate/tests/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/tests/mod.rs
@@ -430,8 +430,9 @@ fn decode_of_corrupt_bytes_returns_codec_error() {
 /// with a test-only type whose `Deserialize` impl deliberately panics.
 #[test]
 fn catch_unwind_converts_deserializer_panic_into_codec_error() {
-    use serde::de::{Deserialize, Deserializer};
     use std::sync::{Mutex, OnceLock};
+
+    use serde::de::{Deserialize, Deserializer};
 
     #[derive(Debug)]
     struct PanickingOnDeserialize;

--- a/crates/agglayer-storage/src/types/certificate/tests/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/tests/mod.rs
@@ -444,7 +444,15 @@ fn catch_unwind_converts_deserializer_panic_into_codec_error() {
     // Borrow the real catch_unwind helper by decoding through bincode.
     // `deserialize_bincode` is module-private, so call it via the
     // sibling `super::deserialize_bincode::<PanickingOnDeserialize>(...)`.
+    //
+    // Suppress the default panic hook during the intentional panic so CI
+    // logs are not polluted by the stack trace. The hook is restored
+    // immediately after the call returns.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
     let result = super::deserialize_bincode::<PanickingOnDeserialize>(&[0u8; 0]);
+    std::panic::set_hook(prev_hook);
+
     match result {
         Err(crate::schema::CodecError::Serialization(_)) => {}
         Err(other) => panic!("unexpected error variant: {other:?}"),


### PR DESCRIPTION
Part of #1508 (storage decoupling from SP1). This is PR 1 of 7 in a
stack landing opaque storage envelope, migration, and v5 ingress
rejection.

Makes the storage layer resilient to corrupt certificate rows: panics
from `bincode::deserialize` now surface as `CodecError::Serialization`
instead of unwinding the node process. Installs `protoc` in two CI
workflows (`quality.udeps`, `cycle-tracker`) so their steps that
transitively build proto-dependent crates resolve correctly.

Includes a regression guard that intentionally panics during a
`Deserialize` impl and verifies the `catch_unwind` wrapper converts
the panic into a `CodecError`. The panic hook is swapped out during
the test to keep stderr quiet in CI.

No wire-format change and no behavioral change outside the panic-to-
error mapping on the decode path.