### PR TITLE
fix: Switch workflow to use CLAUDE_API_KEY

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
           prompt: |
             Review this pull request for:
             - Bugs and logic errors


### PR DESCRIPTION
Switching from wrong key to `CLAUDE_API_KEY`