### PR TITLE
fix(storage): migrate proof CFs to proto-backed format

### DIFF
--- a/crates/agglayer-storage/src/columns/epochs/proofs/mod.rs
+++ b/crates/agglayer-storage/src/columns/epochs/proofs/mod.rs
@@ -1,19 +1,41 @@
 use agglayer_types::{CertificateIndex, Proof};
 
-use crate::columns::PER_EPOCH_PROOFS_CF;
+use crate::{
+    columns::{PER_EPOCH_PROOFS_CF, PER_EPOCH_PROOFS_PROTO_CF},
+    types::LegacyProof,
+};
 
-/// Column family for the proofs in an epoch.
+/// Legacy column family for the proofs in an epoch.
+///
+/// Kept readable so the proto migration can backfill existing rows. Runtime
+/// reads and writes go through [`ProofPerIndexProtoColumn`].
+///
+/// ## Column definition
+///
+/// | key                | value         |
+/// | --                 | --            |
+/// | `CertificateIndex` | `LegacyProof` |
+pub struct ProofPerIndexColumn;
+
+impl crate::schema::ColumnSchema for ProofPerIndexColumn {
+    type Key = CertificateIndex;
+    type Value = LegacyProof;
+
+    const COLUMN_FAMILY_NAME: &'static str = PER_EPOCH_PROOFS_CF;
+}
+
+/// Proto-backed column family for the proofs in an epoch.
 ///
 /// ## Column definition
 ///
 /// | key                | value   |
 /// | --                 | --      |
 /// | `CertificateIndex` | `Proof` |
-pub struct ProofPerIndexColumn;
+pub struct ProofPerIndexProtoColumn;
 
-impl crate::schema::ColumnSchema for ProofPerIndexColumn {
+impl crate::schema::ColumnSchema for ProofPerIndexProtoColumn {
     type Key = CertificateIndex;
     type Value = Proof;
 
-    const COLUMN_FAMILY_NAME: &'static str = PER_EPOCH_PROOFS_CF;
+    const COLUMN_FAMILY_NAME: &'static str = PER_EPOCH_PROOFS_PROTO_CF;
 }

--- a/crates/agglayer-storage/src/columns/mod.rs
+++ b/crates/agglayer-storage/src/columns/mod.rs
@@ -25,6 +25,7 @@ pub const PER_EPOCH_CERTIFICATES_CF: &str = "per_epoch_certificates_cf";
 pub const PER_EPOCH_CERTIFICATES_PROTO_CF: &str = "per_epoch_certificates_proto_cf";
 pub const PER_EPOCH_METADATA_CF: &str = "per_epoch_metadata_cf";
 pub const PER_EPOCH_PROOFS_CF: &str = "per_epoch_proofs_cf";
+pub const PER_EPOCH_PROOFS_PROTO_CF: &str = "per_epoch_proofs_proto_cf";
 pub const PER_EPOCH_END_CHECKPOINT_CF: &str = "per_epoch_end_checkpoint_cf";
 pub const PER_EPOCH_START_CHECKPOINT_CF: &str = "per_epoch_start_checkpoint_cf";
 
@@ -68,6 +69,7 @@ pub const CHECKPOINT_COLUMN_OPTIONS: ColumnOptions = ColumnOptions {
 pub const PENDING_QUEUE_CF: &str = "pending_queue_cf";
 pub const PENDING_QUEUE_PROTO_CF: &str = "pending_queue_proto_cf";
 pub const PROOF_PER_CERTIFICATE_CF: &str = "proof_per_certificate_cf";
+pub const PROOF_PER_CERTIFICATE_PROTO_CF: &str = "proof_per_certificate_proto_cf";
 
 // debug CFs
 pub const DEBUG_CERTIFICATES_CF: &str = "debug_certificates";

--- a/crates/agglayer-storage/src/columns/proof_per_certificate/mod.rs
+++ b/crates/agglayer-storage/src/columns/proof_per_certificate/mod.rs
@@ -1,22 +1,43 @@
 use agglayer_types::{CertificateId, Proof};
 
-use super::{ColumnSchema, PROOF_PER_CERTIFICATE_CF};
+use super::{ColumnSchema, PROOF_PER_CERTIFICATE_CF, PROOF_PER_CERTIFICATE_PROTO_CF};
+use crate::types::LegacyProof;
 
 #[cfg(test)]
 mod tests;
 
-/// Column family that returns the generated proof for one certificate.
+/// Legacy column family that returns the generated proof for one certificate.
+///
+/// Kept readable so the proto migration can backfill existing rows. Runtime
+/// reads and writes go through [`ProofPerCertificateProtoColumn`].
+///
+/// ## Column definition
+///
+/// | key             | value         |
+/// | --              | --            |
+/// | `CertificateId` | `LegacyProof` |
+pub struct ProofPerCertificateColumn;
+
+impl ColumnSchema for ProofPerCertificateColumn {
+    type Key = CertificateId;
+    type Value = LegacyProof;
+
+    const COLUMN_FAMILY_NAME: &'static str = PROOF_PER_CERTIFICATE_CF;
+}
+
+/// Proto-backed column family that returns the generated proof for one
+/// certificate.
 ///
 /// ## Column definition
 ///
 /// | key             | value   |
 /// | --              | --      |
 /// | `CertificateId` | `Proof` |
-pub struct ProofPerCertificateColumn;
+pub struct ProofPerCertificateProtoColumn;
 
-impl ColumnSchema for ProofPerCertificateColumn {
+impl ColumnSchema for ProofPerCertificateProtoColumn {
     type Key = CertificateId;
     type Value = Proof;
 
-    const COLUMN_FAMILY_NAME: &'static str = PROOF_PER_CERTIFICATE_CF;
+    const COLUMN_FAMILY_NAME: &'static str = PROOF_PER_CERTIFICATE_PROTO_CF;
 }

--- a/crates/agglayer-storage/src/stores/migration_helpers.rs
+++ b/crates/agglayer-storage/src/stores/migration_helpers.rs
@@ -103,7 +103,8 @@ where
 }
 
 /// Stream every row in the legacy proof CF `L` into the proto CF `P`, skipping
-/// rows whose bytes cannot be decoded as a proof.
+/// rows whose bytes cannot be decoded as a proof or re-encoded into the proto
+/// envelope.
 pub(crate) fn copy_legacy_proof_cf_into_proto<L, P>(
     db: &DbAccess,
     label: &str,
@@ -121,8 +122,23 @@ where
         match db.get::<L>(&key) {
             Ok(Some(legacy)) => {
                 let proof = Proof::from(legacy);
-                db.put::<P>(&key, &proof)?;
-                migrated += 1;
+                match db.put::<P>(&key, &proof) {
+                    Ok(()) => migrated += 1,
+                    Err(DBMigrationErrorDetails::Database(DBError::CodecError(codec_error))) => {
+                        error!(
+                            legacy_cf = L::COLUMN_FAMILY_NAME,
+                            proto_cf = P::COLUMN_FAMILY_NAME,
+                            label,
+                            ?key,
+                            error = %codec_error,
+                            "skipping legacy proof row that cannot be re-encoded into the proto \
+                             CF; the legacy bytes remain on disk for operator cleanup, but runtime \
+                             reads will not surface this proof after migration",
+                        );
+                        skipped += 1;
+                    }
+                    Err(other) => return Err(other),
+                }
             }
             Ok(None) => {
                 debug!(

--- a/crates/agglayer-storage/src/stores/migration_helpers.rs
+++ b/crates/agglayer-storage/src/stores/migration_helpers.rs
@@ -1,4 +1,4 @@
-//! Shared building blocks for the certificate proto-CF migrations.
+//! Shared building blocks for the certificate/proof proto-CF migrations.
 //!
 //! The three certificate-bearing stores (pending, per-epoch, debug) all run
 //! the same shape of backfill at startup: iterate the legacy CF, decode
@@ -24,13 +24,13 @@
 //! so operators see the impact even if they only have warn-level logging
 //! enabled.
 
-use agglayer_types::Certificate;
+use agglayer_types::{Certificate, Proof};
 use tracing::{debug, error, info, warn};
 
 use crate::{
     schema::ColumnSchema,
     storage::{DBError, DBMigrationErrorDetails, DbAccess},
-    types::LegacyCertificate,
+    types::{LegacyCertificate, LegacyProof},
 };
 
 /// Stream every row in the legacy certificate CF `L` into the proto CF `P`,
@@ -62,6 +62,69 @@ where
                 // Race-y: the key was visible to the iterator but has gone
                 // by the time we try to read it. Should not happen during
                 // normal startup migrations, but log just in case.
+                debug!(
+                    cf = L::COLUMN_FAMILY_NAME,
+                    label,
+                    ?key,
+                    "legacy CF key vanished between iterate and read"
+                );
+            }
+            Err(DBMigrationErrorDetails::Database(DBError::CodecError(codec_error))) => {
+                error!(
+                    cf = L::COLUMN_FAMILY_NAME,
+                    label,
+                    ?key,
+                    error = %codec_error,
+                    "skipping unparsable legacy row during proto migration; this row is also \
+                     unreadable through the current runtime codec",
+                );
+                skipped += 1;
+            }
+            Err(other) => return Err(other),
+        }
+    }
+
+    if skipped > 0 {
+        warn!(
+            cf = L::COLUMN_FAMILY_NAME,
+            label,
+            migrated,
+            skipped,
+            "completed proto migration with skipped rows; investigate skipped rows in the legacy \
+             CF before they are dropped in the follow-up cleanup",
+        );
+    } else {
+        info!(
+            cf = L::COLUMN_FAMILY_NAME,
+            label, migrated, "completed proto migration",
+        );
+    }
+    Ok(())
+}
+
+/// Stream every row in the legacy proof CF `L` into the proto CF `P`, skipping
+/// rows whose bytes cannot be decoded as a proof.
+pub(crate) fn copy_legacy_proof_cf_into_proto<L, P>(
+    db: &DbAccess,
+    label: &str,
+) -> Result<(), DBMigrationErrorDetails>
+where
+    L: ColumnSchema<Value = LegacyProof>,
+    P: ColumnSchema<Value = Proof, Key = L::Key>,
+    L::Key: std::fmt::Debug,
+{
+    let mut migrated = 0_usize;
+    let mut skipped = 0_usize;
+
+    for key in db.keys::<L>()? {
+        let key = key?;
+        match db.get::<L>(&key) {
+            Ok(Some(legacy)) => {
+                let proof = Proof::from(legacy);
+                db.put::<P>(&key, &proof)?;
+                migrated += 1;
+            }
+            Ok(None) => {
                 debug!(
                     cf = L::COLUMN_FAMILY_NAME,
                     label,

--- a/crates/agglayer-storage/src/stores/pending/cf_definitions.rs
+++ b/crates/agglayer-storage/src/stores/pending/cf_definitions.rs
@@ -3,7 +3,7 @@ use crate::{
         latest_pending_certificate_per_network::LatestPendingCertificatePerNetworkColumn,
         latest_proven_certificate_per_network::LatestProvenCertificatePerNetworkColumn,
         pending_queue::{PendingQueueColumn, PendingQueueProtoColumn},
-        proof_per_certificate::ProofPerCertificateColumn,
+        proof_per_certificate::{ProofPerCertificateColumn, ProofPerCertificateProtoColumn},
     },
     schema::ColumnDescriptor,
 };
@@ -23,4 +23,5 @@ pub const PENDING_DB: &[ColumnDescriptor] = &[
     ColumnDescriptor::new::<PendingQueueColumn>(),
     ColumnDescriptor::new::<PendingQueueProtoColumn>(),
     ColumnDescriptor::new::<ProofPerCertificateColumn>(),
+    ColumnDescriptor::new::<ProofPerCertificateProtoColumn>(),
 ];

--- a/crates/agglayer-storage/src/stores/pending/mod.rs
+++ b/crates/agglayer-storage/src/stores/pending/mod.rs
@@ -13,7 +13,7 @@ use crate::{
             LatestProvenCertificatePerNetworkColumn, ProvenCertificate,
         },
         pending_queue::{PendingQueueColumn, PendingQueueKey, PendingQueueProtoColumn},
-        proof_per_certificate::ProofPerCertificateColumn,
+        proof_per_certificate::{ProofPerCertificateColumn, ProofPerCertificateProtoColumn},
     },
     error::Error,
     schema::{Codec as _, ColumnDescriptor, ColumnSchema as _},
@@ -38,6 +38,10 @@ impl PendingStore {
                 &[ColumnDescriptor::new::<PendingQueueProtoColumn>()],
                 backfill_pending_certificates_proto_from_legacy_bincode,
             )?
+            .add_cfs(
+                &[ColumnDescriptor::new::<ProofPerCertificateProtoColumn>()],
+                backfill_pending_proofs_proto_from_legacy_bincode,
+            )?
             .finalize(cf_definitions::PENDING_DB)
     }
 
@@ -61,7 +65,7 @@ impl PendingStore {
         let cf = self
             .db
             .raw_rocksdb()
-            .cf_handle(ProofPerCertificateColumn::COLUMN_FAMILY_NAME)
+            .cf_handle(ProofPerCertificateProtoColumn::COLUMN_FAMILY_NAME)
             .ok_or(DBError::ColumnFamilyNotFound)?;
 
         let Some(bytes) = self
@@ -92,6 +96,15 @@ fn backfill_pending_certificates_proto_from_legacy_bincode(
     super::migration_helpers::copy_legacy_certificate_cf_into_proto::<
         PendingQueueColumn,
         PendingQueueProtoColumn,
+    >(db, "pending")
+}
+
+fn backfill_pending_proofs_proto_from_legacy_bincode(
+    db: &crate::storage::DbAccess,
+) -> Result<(), crate::storage::DBMigrationErrorDetails> {
+    super::migration_helpers::copy_legacy_proof_cf_into_proto::<
+        ProofPerCertificateColumn,
+        ProofPerCertificateProtoColumn,
     >(db, "pending")
 }
 
@@ -148,7 +161,7 @@ impl PendingCertificateWriter for PendingStore {
     ) -> Result<(), Error> {
         Ok(self
             .db
-            .put::<ProofPerCertificateColumn>(certificate_id, proof)?)
+            .put::<ProofPerCertificateProtoColumn>(certificate_id, proof)?)
     }
 
     fn remove_generated_proof(
@@ -157,7 +170,7 @@ impl PendingCertificateWriter for PendingStore {
     ) -> Result<(), Error> {
         Ok(self
             .db
-            .delete::<ProofPerCertificateColumn>(certificate_id)?)
+            .delete::<ProofPerCertificateProtoColumn>(certificate_id)?)
     }
 
     fn set_latest_proven_certificate_per_network(
@@ -241,7 +254,7 @@ impl PendingCertificateReader for PendingStore {
         let cf = self
             .db
             .raw_rocksdb()
-            .cf_handle(ProofPerCertificateColumn::COLUMN_FAMILY_NAME)
+            .cf_handle(ProofPerCertificateProtoColumn::COLUMN_FAMILY_NAME)
             .ok_or(Error::from(DBError::ColumnFamilyNotFound))?;
 
         let encoded_keys: Result<Vec<_>, _> = keys

--- a/crates/agglayer-storage/src/stores/pending/tests.rs
+++ b/crates/agglayer-storage/src/stores/pending/tests.rs
@@ -8,10 +8,10 @@ use super::PendingStore;
 use crate::{
     columns::{
         pending_queue::{PendingQueueColumn, PendingQueueKey, PendingQueueProtoColumn},
-        proof_per_certificate::ProofPerCertificateColumn,
+        proof_per_certificate::{ProofPerCertificateColumn, ProofPerCertificateProtoColumn},
     },
     error::Error,
-    schema::{Codec as _, ColumnSchema as _},
+    schema::{bincode_codec, Codec as _, ColumnSchema as _},
     stores::{PendingCertificateReader as _, PendingCertificateWriter as _},
     tests::TempDBDir,
     types::generated::agglayer::storage::v0,
@@ -81,12 +81,48 @@ fn write_raw_certificate_bytes(
     db.raw_rocksdb().put_cf(&cf, key, value).unwrap();
 }
 
-fn write_raw_proof_bytes(store: &PendingStore, certificate_id: CertificateId, value: Vec<u8>) {
+fn read_raw_proto_proof_bytes(store: &PendingStore, certificate_id: CertificateId) -> Vec<u8> {
     let key = certificate_id.encode().unwrap();
     let cf = store
         .db
         .raw_rocksdb()
+        .cf_handle(ProofPerCertificateProtoColumn::COLUMN_FAMILY_NAME)
+        .unwrap();
+
+    store
+        .db
+        .raw_rocksdb()
+        .get_cf(&cf, key)
+        .unwrap()
+        .unwrap()
+        .to_vec()
+}
+
+fn write_raw_legacy_proof_bytes(
+    path: &std::path::Path,
+    certificate_id: CertificateId,
+    value: Vec<u8>,
+) {
+    let db = crate::storage::DB::open_cf(path, super::cf_definitions::PENDING_DB_V0).unwrap();
+    let key = certificate_id.encode().unwrap();
+    let cf = db
+        .raw_rocksdb()
         .cf_handle(ProofPerCertificateColumn::COLUMN_FAMILY_NAME)
+        .unwrap();
+
+    db.raw_rocksdb().put_cf(&cf, key, value).unwrap();
+}
+
+fn write_raw_proto_proof_bytes(
+    store: &PendingStore,
+    certificate_id: CertificateId,
+    value: Vec<u8>,
+) {
+    let key = certificate_id.encode().unwrap();
+    let cf = store
+        .db
+        .raw_rocksdb()
+        .cf_handle(ProofPerCertificateProtoColumn::COLUMN_FAMILY_NAME)
         .unwrap();
 
     store.db.raw_rocksdb().put_cf(&cf, key, value).unwrap();
@@ -98,6 +134,17 @@ fn load_v0_certificate_bytes(name: &str) -> Vec<u8> {
         .join(name);
     let hex = std::fs::read_to_string(path).unwrap();
     hex::decode(hex.trim()).unwrap()
+}
+
+fn load_legacy_proof_bytes(proof: &Proof) -> Vec<u8> {
+    bincode_codec().serialize(proof).unwrap()
+}
+
+fn assert_same_proof(left: &Proof, right: &Proof) {
+    assert_eq!(
+        bincode_codec().serialize(left).unwrap(),
+        bincode_codec().serialize(right).unwrap()
+    );
 }
 
 #[test]
@@ -115,6 +162,28 @@ fn insert_pending_certificate_writes_proto_bytes() {
     let decoded = Certificate::try_from(proto).unwrap();
 
     assert_eq!(decoded, certificate);
+}
+
+#[test]
+fn insert_generated_proof_writes_proto_bytes() {
+    let (_tmp, store) = store();
+    let certificate_id = CertificateId::new([3; 32].into());
+    let expected = Proof::dummy();
+
+    store
+        .insert_generated_proof(&certificate_id, &expected)
+        .unwrap();
+
+    let raw = read_raw_proto_proof_bytes(&store, certificate_id);
+    let proto = v0::PessimisticStoredProof::decode(raw.as_slice())
+        .expect("pending proofs should be stored as storage proto");
+    let decoded = Proof::decode(raw.as_slice()).unwrap();
+
+    assert_same_proof(&decoded, &expected);
+    assert_eq!(
+        proto.proof.unwrap().proof_system,
+        v0::ProofSystem::Sp1 as i32
+    );
 }
 
 #[test]
@@ -165,11 +234,37 @@ fn reopening_pending_store_migrates_legacy_rows_to_proto() {
 }
 
 #[test]
+fn reopening_pending_store_migrates_legacy_proof_rows_to_proto() {
+    let tmp = TempDBDir::new();
+    let certificate_id = CertificateId::new([4; 32].into());
+    let expected = Proof::dummy();
+    let legacy = load_legacy_proof_bytes(&expected);
+
+    write_raw_legacy_proof_bytes(&tmp.path, certificate_id, legacy);
+
+    let store = PendingStore::new_with_path(&tmp.path).unwrap();
+    let migrated = store.get_proof(certificate_id).unwrap().unwrap();
+
+    assert_same_proof(&migrated, &expected);
+
+    let raw = read_raw_proto_proof_bytes(&store, certificate_id);
+    let proto = v0::PessimisticStoredProof::decode(raw.as_slice())
+        .expect("legacy pending proof rows should be copied");
+    let decoded = Proof::decode(raw.as_slice()).unwrap();
+
+    assert_same_proof(&decoded, &expected);
+    assert_eq!(
+        proto.proof.unwrap().proof_system,
+        v0::ProofSystem::Sp1 as i32
+    );
+}
+
+#[test]
 fn get_proof_reports_unreadable_pending_proof() {
     let (_tmp, store) = store();
     let certificate_id = CertificateId::new([7; 32].into());
 
-    write_raw_proof_bytes(&store, certificate_id, b"not a proof".to_vec());
+    write_raw_proto_proof_bytes(&store, certificate_id, b"not a proof".to_vec());
 
     let err = store.get_proof(certificate_id).unwrap_err();
 
@@ -185,9 +280,25 @@ fn multi_get_proof_reports_unreadable_pending_proofs() {
     store
         .insert_generated_proof(&valid_id, &Proof::dummy())
         .unwrap();
-    write_raw_proof_bytes(&store, invalid_id, b"not a proof".to_vec());
+    write_raw_proto_proof_bytes(&store, invalid_id, b"not a proof".to_vec());
 
     let err = store.multi_get_proof(&[valid_id, invalid_id]).unwrap_err();
 
     assert!(matches!(err, Error::UnreadableProof { id, .. } if id == invalid_id));
+}
+
+#[test]
+fn reopening_pending_store_skips_unparsable_legacy_proof_rows() {
+    let tmp = TempDBDir::new();
+    let good_id = CertificateId::new([0x11; 32].into());
+    let bad_id = CertificateId::new([0x22; 32].into());
+    let expected = Proof::dummy();
+
+    write_raw_legacy_proof_bytes(&tmp.path, good_id, load_legacy_proof_bytes(&expected));
+    write_raw_legacy_proof_bytes(&tmp.path, bad_id, b"not a proof".to_vec());
+
+    let store = PendingStore::new_with_path(&tmp.path).expect("migration should not abort");
+
+    assert_same_proof(&store.get_proof(good_id).unwrap().unwrap(), &expected);
+    assert!(store.get_proof(bad_id).unwrap().is_none());
 }

--- a/crates/agglayer-storage/src/stores/pending/tests.rs
+++ b/crates/agglayer-storage/src/stores/pending/tests.rs
@@ -98,6 +98,23 @@ fn read_raw_proto_proof_bytes(store: &PendingStore, certificate_id: CertificateI
         .to_vec()
 }
 
+fn read_raw_legacy_proof_bytes(store: &PendingStore, certificate_id: CertificateId) -> Vec<u8> {
+    let key = certificate_id.encode().unwrap();
+    let cf = store
+        .db
+        .raw_rocksdb()
+        .cf_handle(ProofPerCertificateColumn::COLUMN_FAMILY_NAME)
+        .unwrap();
+
+    store
+        .db
+        .raw_rocksdb()
+        .get_cf(&cf, key)
+        .unwrap()
+        .unwrap()
+        .to_vec()
+}
+
 fn write_raw_legacy_proof_bytes(
     path: &std::path::Path,
     certificate_id: CertificateId,
@@ -138,6 +155,14 @@ fn load_v0_certificate_bytes(name: &str) -> Vec<u8> {
 
 fn load_legacy_proof_bytes(proof: &Proof) -> Vec<u8> {
     bincode_codec().serialize(proof).unwrap()
+}
+
+fn malformed_legacy_proof_bytes() -> Vec<u8> {
+    let mut proof = Proof::dummy();
+    let Proof::SP1(sp1) = &mut proof;
+    sp1.public_values
+        .write_slice(b"not a pessimistic proof output");
+    load_legacy_proof_bytes(&proof)
 }
 
 fn assert_same_proof(left: &Proof, right: &Proof) {
@@ -301,4 +326,22 @@ fn reopening_pending_store_skips_unparsable_legacy_proof_rows() {
 
     assert_same_proof(&store.get_proof(good_id).unwrap().unwrap(), &expected);
     assert!(store.get_proof(bad_id).unwrap().is_none());
+}
+
+#[test]
+fn reopening_pending_store_skips_legacy_proof_rows_that_fail_proto_reencode() {
+    let tmp = TempDBDir::new();
+    let good_id = CertificateId::new([0x33; 32].into());
+    let bad_id = CertificateId::new([0x44; 32].into());
+    let expected = Proof::dummy();
+    let bad_legacy = malformed_legacy_proof_bytes();
+
+    write_raw_legacy_proof_bytes(&tmp.path, good_id, load_legacy_proof_bytes(&expected));
+    write_raw_legacy_proof_bytes(&tmp.path, bad_id, bad_legacy.clone());
+
+    let store = PendingStore::new_with_path(&tmp.path).expect("migration should not abort");
+
+    assert_same_proof(&store.get_proof(good_id).unwrap().unwrap(), &expected);
+    assert!(store.get_proof(bad_id).unwrap().is_none());
+    assert_eq!(read_raw_legacy_proof_bytes(&store, bad_id), bad_legacy);
 }

--- a/crates/agglayer-storage/src/stores/per_epoch/cf_definitions.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/cf_definitions.rs
@@ -3,7 +3,7 @@ use crate::{
         certificates::{CertificatePerIndexColumn, CertificatePerIndexProtoColumn},
         end_checkpoint::EndCheckpointColumn,
         metadata::PerEpochMetadataColumn,
-        proofs::ProofPerIndexColumn,
+        proofs::{ProofPerIndexColumn, ProofPerIndexProtoColumn},
         start_checkpoint::StartCheckpointColumn,
     },
     schema::ColumnDescriptor,
@@ -24,6 +24,7 @@ pub const EPOCHS_DB: &[ColumnDescriptor] = &[
     ColumnDescriptor::new::<CertificatePerIndexProtoColumn>(),
     ColumnDescriptor::new::<PerEpochMetadataColumn>(),
     ColumnDescriptor::new::<ProofPerIndexColumn>(),
+    ColumnDescriptor::new::<ProofPerIndexProtoColumn>(),
     ColumnDescriptor::new::<StartCheckpointColumn>(),
     ColumnDescriptor::new::<EndCheckpointColumn>(),
 ];

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         certificates::{CertificatePerIndexColumn, CertificatePerIndexProtoColumn},
         end_checkpoint::EndCheckpointColumn,
         metadata::PerEpochMetadataColumn,
-        proofs::ProofPerIndexColumn,
+        proofs::{ProofPerIndexColumn, ProofPerIndexProtoColumn},
         start_checkpoint::StartCheckpointColumn,
     },
     error::{CertificateCandidateError, Error},
@@ -59,6 +59,10 @@ impl<PendingStore, StateStore> PerEpochStore<PendingStore, StateStore> {
             .add_cfs(
                 &[ColumnDescriptor::new::<CertificatePerIndexProtoColumn>()],
                 backfill_epoch_certificates_proto_from_legacy_bincode,
+            )?
+            .add_cfs(
+                &[ColumnDescriptor::new::<ProofPerIndexProtoColumn>()],
+                backfill_epoch_proofs_proto_from_legacy_bincode,
             )?
             .finalize(cf_definitions::EPOCHS_DB)
     }
@@ -270,6 +274,15 @@ fn backfill_epoch_certificates_proto_from_legacy_bincode(
     >(db, "epoch")
 }
 
+fn backfill_epoch_proofs_proto_from_legacy_bincode(
+    db: &crate::storage::DbAccess,
+) -> Result<(), crate::storage::DBMigrationErrorDetails> {
+    super::migration_helpers::copy_legacy_proof_cf_into_proto::<
+        ProofPerIndexColumn,
+        ProofPerIndexProtoColumn,
+    >(db, "epoch")
+}
+
 impl<PendingStore, StateStore> PerEpochWriter for PerEpochStore<PendingStore, StateStore>
 where
     PendingStore: PendingCertificateReader + PendingCertificateWriter,
@@ -430,7 +443,7 @@ where
             .put::<CertificatePerIndexProtoColumn>(&certificate_index, &certificate)?;
 
         self.db
-            .put::<ProofPerIndexColumn>(&certificate_index, &proof)?;
+            .put::<ProofPerIndexProtoColumn>(&certificate_index, &proof)?;
 
         // Removing the certificate and proof from the pending store
         self.pending_store.remove_generated_proof(&certificate_id)?;
@@ -517,7 +530,7 @@ where
     }
 
     fn get_proof_at_index(&self, index: CertificateIndex) -> Result<Option<Proof>, Error> {
-        Ok(self.db.get::<ProofPerIndexColumn>(&index)?)
+        Ok(self.db.get::<ProofPerIndexProtoColumn>(&index)?)
     }
 
     fn get_start_checkpoint(&self) -> &BTreeMap<NetworkId, Height> {

--- a/crates/agglayer-storage/src/stores/per_epoch/tests.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/tests.rs
@@ -19,10 +19,11 @@ use crate::{
     columns::epochs::{
         certificates::{CertificatePerIndexColumn, CertificatePerIndexProtoColumn},
         end_checkpoint::EndCheckpointColumn,
+        proofs::{ProofPerIndexColumn, ProofPerIndexProtoColumn},
         start_checkpoint::StartCheckpointColumn,
     },
     error::Error,
-    schema::{Codec as _, ColumnSchema as _},
+    schema::{bincode_codec, Codec as _, ColumnSchema as _},
     stores::{
         epochs::EpochsStore,
         interfaces::writer::{PerEpochWriter, StateWriter},
@@ -97,6 +98,26 @@ fn read_raw_proto_epoch_certificate_bytes(
         .to_vec()
 }
 
+fn read_raw_proto_epoch_proof_bytes(
+    store: &PerEpochStore<PendingStore, StateStore>,
+    index: CertificateIndex,
+) -> Vec<u8> {
+    let key = index.encode().unwrap();
+    let cf = store
+        .db
+        .raw_rocksdb()
+        .cf_handle(ProofPerIndexProtoColumn::COLUMN_FAMILY_NAME)
+        .unwrap();
+
+    store
+        .db
+        .raw_rocksdb()
+        .get_cf(&cf, key)
+        .unwrap()
+        .unwrap()
+        .to_vec()
+}
+
 fn load_v0_certificate_bytes(name: &str) -> Vec<u8> {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src/types/certificate/tests/encoded")
@@ -120,11 +141,37 @@ fn write_raw_epoch_certificate_bytes(
     db.raw_rocksdb().put_cf(&cf, key, value).unwrap();
 }
 
+fn write_raw_epoch_legacy_proof_bytes(
+    path: &std::path::Path,
+    index: CertificateIndex,
+    value: Vec<u8>,
+) {
+    let db = crate::storage::DB::open_cf(path, super::cf_definitions::EPOCHS_DB_V0).unwrap();
+    let key = index.encode().unwrap();
+    let cf = db
+        .raw_rocksdb()
+        .cf_handle(ProofPerIndexColumn::COLUMN_FAMILY_NAME)
+        .unwrap();
+
+    db.raw_rocksdb().put_cf(&cf, key, value).unwrap();
+}
+
 fn seed_epoch_checkpoints(path: &std::path::Path, network_id: NetworkId, height: Height) {
     let db = crate::storage::DB::open_cf(path, super::cf_definitions::EPOCHS_DB_V0).unwrap();
     db.put::<StartCheckpointColumn>(&network_id, &height)
         .unwrap();
     db.put::<EndCheckpointColumn>(&network_id, &height).unwrap();
+}
+
+fn load_legacy_proof_bytes(proof: &Proof) -> Vec<u8> {
+    bincode_codec().serialize(proof).unwrap()
+}
+
+fn assert_same_proof(left: &Proof, right: &Proof) {
+    assert_eq!(
+        bincode_codec().serialize(left).unwrap(),
+        bincode_codec().serialize(right).unwrap()
+    );
 }
 
 #[rstest]
@@ -160,6 +207,46 @@ fn add_certificate_writes_proto_bytes_to_epoch_store(
     let decoded = Certificate::try_from(proto).unwrap();
 
     assert_eq!(decoded, certificate);
+}
+
+#[rstest]
+fn add_certificate_writes_proto_proof_bytes_to_epoch_store(
+    store: PerEpochStore<PendingStore, StateStore>,
+) {
+    let network = NetworkId::new(2);
+    let height = Height::ZERO;
+    let certificate = Certificate::new_for_test(network, height);
+    let certificate_id = certificate.hash();
+    let expected = Proof::dummy();
+    let pending_store = store.pending_store.clone();
+    let state_store = store.state_store.clone();
+
+    state_store
+        .insert_certificate_header(&certificate, CertificateStatus::Proven)
+        .unwrap();
+
+    pending_store
+        .insert_pending_certificate(network, height, &certificate)
+        .unwrap();
+
+    pending_store
+        .insert_generated_proof(&certificate_id, &expected)
+        .unwrap();
+
+    let (_, index) = store
+        .add_certificate(certificate_id, agglayer_types::ExecutionMode::Default)
+        .unwrap();
+
+    let raw = read_raw_proto_epoch_proof_bytes(&store, index);
+    let proto = v0::PessimisticStoredProof::decode(raw.as_slice())
+        .expect("epoch proofs should be stored as proto");
+    let decoded = Proof::decode(raw.as_slice()).unwrap();
+
+    assert_same_proof(&decoded, &expected);
+    assert_eq!(
+        proto.proof.unwrap().proof_system,
+        v0::ProofSystem::Sp1 as i32
+    );
 }
 
 #[rstest]
@@ -224,6 +311,50 @@ fn reopening_epoch_store_migrates_legacy_certificate_rows_to_proto() {
     assert_eq!(
         read_raw_legacy_epoch_certificate_bytes(&store, index),
         legacy
+    );
+}
+
+#[test]
+fn reopening_epoch_store_migrates_legacy_proof_rows_to_proto() {
+    let tmp = TempDBDir::new();
+    let config = Arc::new(Config::new(&tmp.path));
+    let epoch_number = EpochNumber::ZERO;
+    let epoch_path = config.storage.epoch_db_path(epoch_number);
+    let pending_store =
+        Arc::new(PendingStore::new_with_path(&config.storage.pending_db_path).unwrap());
+    let state_store = Arc::new(
+        StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop()).unwrap(),
+    );
+    let expected = Proof::dummy();
+    let index = CertificateIndex::ZERO;
+    let network_id = NetworkId::new(15);
+    let height = Height::ZERO;
+
+    seed_epoch_checkpoints(&epoch_path, network_id, height);
+    write_raw_epoch_legacy_proof_bytes(&epoch_path, index, load_legacy_proof_bytes(&expected));
+
+    let store = PerEpochStore::try_open(
+        config,
+        epoch_number,
+        pending_store,
+        state_store,
+        Some(std::iter::once((network_id, height)).collect()),
+        BackupClient::noop(),
+    )
+    .unwrap();
+
+    let migrated = store.get_proof_at_index(index).unwrap().unwrap();
+    assert_same_proof(&migrated, &expected);
+
+    let raw = read_raw_proto_epoch_proof_bytes(&store, index);
+    let proto = v0::PessimisticStoredProof::decode(raw.as_slice())
+        .expect("legacy epoch proof rows should migrate");
+    let decoded = Proof::decode(raw.as_slice()).unwrap();
+
+    assert_same_proof(&decoded, &expected);
+    assert_eq!(
+        proto.proof.unwrap().proof_system,
+        v0::ProofSystem::Sp1 as i32
     );
 }
 

--- a/crates/agglayer-storage/src/stores/per_epoch/tests.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/tests.rs
@@ -118,6 +118,26 @@ fn read_raw_proto_epoch_proof_bytes(
         .to_vec()
 }
 
+fn read_raw_legacy_epoch_proof_bytes(
+    store: &PerEpochStore<PendingStore, StateStore>,
+    index: CertificateIndex,
+) -> Vec<u8> {
+    let key = index.encode().unwrap();
+    let cf = store
+        .db
+        .raw_rocksdb()
+        .cf_handle(ProofPerIndexColumn::COLUMN_FAMILY_NAME)
+        .unwrap();
+
+    store
+        .db
+        .raw_rocksdb()
+        .get_cf(&cf, key)
+        .unwrap()
+        .unwrap()
+        .to_vec()
+}
+
 fn load_v0_certificate_bytes(name: &str) -> Vec<u8> {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src/types/certificate/tests/encoded")
@@ -165,6 +185,14 @@ fn seed_epoch_checkpoints(path: &std::path::Path, network_id: NetworkId, height:
 
 fn load_legacy_proof_bytes(proof: &Proof) -> Vec<u8> {
     bincode_codec().serialize(proof).unwrap()
+}
+
+fn malformed_legacy_proof_bytes() -> Vec<u8> {
+    let mut proof = Proof::dummy();
+    let Proof::SP1(sp1) = &mut proof;
+    sp1.public_values
+        .write_slice(b"not a pessimistic proof output");
+    load_legacy_proof_bytes(&proof)
 }
 
 fn assert_same_proof(left: &Proof, right: &Proof) {
@@ -355,6 +383,49 @@ fn reopening_epoch_store_migrates_legacy_proof_rows_to_proto() {
     assert_eq!(
         proto.proof.unwrap().proof_system,
         v0::ProofSystem::Sp1 as i32
+    );
+}
+
+#[test]
+fn reopening_epoch_store_skips_legacy_proof_rows_that_fail_proto_reencode() {
+    let tmp = TempDBDir::new();
+    let config = Arc::new(Config::new(&tmp.path));
+    let epoch_number = EpochNumber::ZERO;
+    let epoch_path = config.storage.epoch_db_path(epoch_number);
+    let pending_store =
+        Arc::new(PendingStore::new_with_path(&config.storage.pending_db_path).unwrap());
+    let state_store = Arc::new(
+        StateStore::new_with_path(&config.storage.state_db_path, BackupClient::noop()).unwrap(),
+    );
+    let expected = Proof::dummy();
+    let good_index = CertificateIndex::ZERO;
+    let bad_index = CertificateIndex::new(1);
+    let bad_legacy = malformed_legacy_proof_bytes();
+    let network_id = NetworkId::new(15);
+    let height = Height::ZERO;
+
+    seed_epoch_checkpoints(&epoch_path, network_id, height);
+    write_raw_epoch_legacy_proof_bytes(&epoch_path, good_index, load_legacy_proof_bytes(&expected));
+    write_raw_epoch_legacy_proof_bytes(&epoch_path, bad_index, bad_legacy.clone());
+
+    let store = PerEpochStore::try_open(
+        config,
+        epoch_number,
+        pending_store,
+        state_store,
+        Some(std::iter::once((network_id, height)).collect()),
+        BackupClient::noop(),
+    )
+    .expect("migration should not abort");
+
+    assert_same_proof(
+        &store.get_proof_at_index(good_index).unwrap().unwrap(),
+        &expected,
+    );
+    assert!(store.get_proof_at_index(bad_index).unwrap().is_none());
+    assert_eq!(
+        read_raw_legacy_epoch_proof_bytes(&store, bad_index),
+        bad_legacy
     );
 }
 

--- a/crates/agglayer-storage/src/types/mod.rs
+++ b/crates/agglayer-storage/src/types/mod.rs
@@ -1,6 +1,6 @@
 use agglayer_types::{
     primitives::Digest, CertificateHeader, CertificateId, CertificateIndex, EpochNumber, Height,
-    NetworkId, Proof,
+    NetworkId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -14,6 +14,7 @@ pub(crate) mod settlement;
 
 #[cfg(test)]
 pub(crate) mod codec_tests;
+pub(crate) use proof::LegacyProof;
 #[cfg(test)]
 mod proto_roundtrip;
 #[cfg(any(test, feature = "testutils"))]
@@ -74,7 +75,6 @@ crate::schema::impl_codec_using_bincode_for!(
     NetworkId,
     PerEpochMetadataKey,
     PerEpochMetadataValue,
-    Proof,
     SmtKey,
     SmtValue,
 );

--- a/crates/agglayer-storage/src/types/proof.rs
+++ b/crates/agglayer-storage/src/types/proof.rs
@@ -1,12 +1,28 @@
 use agglayer_sp1::{version_kind, ProofError, ProofExt};
-use agglayer_types::aggchain_proof::{Proof as TypedProof, SP1StarkWithContext};
+use agglayer_tries::roots::LocalExitRoot;
+use agglayer_types::{
+    aggchain_proof::{Proof as AggchainProof, SP1StarkWithContext},
+    bincode,
+    primitives::Digest,
+    Proof as StoredProof,
+};
+use pessimistic_proof::PessimisticProofOutput;
 
-use crate::types::generated::agglayer::storage::v0 as proto;
+use crate::{schema::CodecError, types::generated::agglayer::storage::v0 as proto};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProofConversionError {
     #[error(transparent)]
     Sp1(#[from] ProofError),
+
+    #[error("missing field `{0}`")]
+    MissingField(&'static str),
+
+    #[error("invalid data for `{field}`: {reason}")]
+    InvalidData {
+        field: &'static str,
+        reason: String,
+    },
 
     #[error("unsupported proof system `{proof_system}`")]
     UnsupportedProofSystem { proof_system: i32 },
@@ -15,10 +31,40 @@ pub enum ProofConversionError {
     UnsupportedProofMode { mode: i32 },
 }
 
-impl TryFrom<&TypedProof> for proto::Proof {
+#[derive(Debug, Clone)]
+pub struct LegacyProof(pub StoredProof);
+
+impl From<LegacyProof> for StoredProof {
+    fn from(LegacyProof(proof): LegacyProof) -> Self {
+        proof
+    }
+}
+
+fn expect_bytes<const N: usize>(
+    bytes: &[u8],
+    field: &'static str,
+) -> Result<[u8; N], ProofConversionError> {
+    bytes.try_into().map_err(|_| ProofConversionError::InvalidData {
+        field,
+        reason: format!("expected {N} bytes, got {}", bytes.len()),
+    })
+}
+
+fn stored_proof_mode(proof: &StoredProof) -> i32 {
+    match proof {
+        StoredProof::SP1(sp1) => match agglayer_sp1::ProofMode::from(&sp1.proof) {
+            agglayer_sp1::ProofMode::Core => proto::ProofMode::Unspecified as i32,
+            agglayer_sp1::ProofMode::Compressed => proto::ProofMode::Compressed as i32,
+            agglayer_sp1::ProofMode::Plonk => proto::ProofMode::Plonk as i32,
+            agglayer_sp1::ProofMode::Groth16 => proto::ProofMode::Groth16 as i32,
+        },
+    }
+}
+
+impl TryFrom<&AggchainProof> for proto::Proof {
     type Error = ProofConversionError;
 
-    fn try_from(value: &TypedProof) -> Result<Self, Self::Error> {
+    fn try_from(value: &AggchainProof) -> Result<Self, Self::Error> {
         let sp1 = value.sp1();
         version_kind(&sp1.version)?;
 
@@ -32,7 +78,7 @@ impl TryFrom<&TypedProof> for proto::Proof {
     }
 }
 
-impl TryFrom<proto::Proof> for TypedProof {
+impl TryFrom<proto::Proof> for AggchainProof {
     type Error = ProofConversionError;
 
     fn try_from(value: proto::Proof) -> Result<Self, Self::Error> {
@@ -49,7 +95,7 @@ impl TryFrom<proto::Proof> for TypedProof {
         let version = value.version;
         version_kind(&version)?;
 
-        Ok(TypedProof::SP1Stark(SP1StarkWithContext {
+        Ok(AggchainProof::SP1Stark(SP1StarkWithContext {
             proof: value.proof.to_vec(),
             vkey: value.vkey.to_vec(),
             version,
@@ -57,30 +103,280 @@ impl TryFrom<proto::Proof> for TypedProof {
     }
 }
 
+impl From<PessimisticProofOutput> for proto::PessimisticProofOutput {
+    fn from(value: PessimisticProofOutput) -> Self {
+        Self {
+            prev_local_exit_root: Some(proto::LocalExitRoot {
+                value: Digest::from(value.prev_local_exit_root).0.to_vec().into(),
+            }),
+            prev_pessimistic_root: Some(proto::PessimisticRoot {
+                value: value.prev_pessimistic_root.0.to_vec().into(),
+            }),
+            l1_info_root: Some(proto::L1InfoRoot {
+                value: value.l1_info_root.0.to_vec().into(),
+            }),
+            origin_network: value.origin_network.to_u32(),
+            aggchain_hash: Some(proto::AggchainHash {
+                value: value.aggchain_hash.0.to_vec().into(),
+            }),
+            new_local_exit_root: Some(proto::LocalExitRoot {
+                value: Digest::from(value.new_local_exit_root).0.to_vec().into(),
+            }),
+            new_pessimistic_root: Some(proto::PessimisticRoot {
+                value: value.new_pessimistic_root.0.to_vec().into(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<proto::PessimisticProofOutput> for PessimisticProofOutput {
+    type Error = ProofConversionError;
+
+    fn try_from(value: proto::PessimisticProofOutput) -> Result<Self, Self::Error> {
+        let prev_local_exit_root = value
+            .prev_local_exit_root
+            .ok_or(ProofConversionError::MissingField("prev_local_exit_root"))?;
+        let prev_pessimistic_root = value
+            .prev_pessimistic_root
+            .ok_or(ProofConversionError::MissingField("prev_pessimistic_root"))?;
+        let l1_info_root = value
+            .l1_info_root
+            .ok_or(ProofConversionError::MissingField("l1_info_root"))?;
+        let aggchain_hash = value
+            .aggchain_hash
+            .ok_or(ProofConversionError::MissingField("aggchain_hash"))?;
+        let new_local_exit_root = value
+            .new_local_exit_root
+            .ok_or(ProofConversionError::MissingField("new_local_exit_root"))?;
+        let new_pessimistic_root = value
+            .new_pessimistic_root
+            .ok_or(ProofConversionError::MissingField("new_pessimistic_root"))?;
+
+        Ok(Self {
+            prev_local_exit_root: LocalExitRoot::from(Digest::from(expect_bytes::<32>(
+                prev_local_exit_root.value.as_ref(),
+                "prev_local_exit_root",
+            )?)),
+            prev_pessimistic_root: Digest::from(expect_bytes::<32>(
+                prev_pessimistic_root.value.as_ref(),
+                "prev_pessimistic_root",
+            )?),
+            l1_info_root: Digest::from(expect_bytes::<32>(
+                l1_info_root.value.as_ref(),
+                "l1_info_root",
+            )?),
+            origin_network: value.origin_network.into(),
+            aggchain_hash: Digest::from(expect_bytes::<32>(
+                aggchain_hash.value.as_ref(),
+                "aggchain_hash",
+            )?),
+            new_local_exit_root: LocalExitRoot::from(Digest::from(expect_bytes::<32>(
+                new_local_exit_root.value.as_ref(),
+                "new_local_exit_root",
+            )?)),
+            new_pessimistic_root: Digest::from(expect_bytes::<32>(
+                new_pessimistic_root.value.as_ref(),
+                "new_pessimistic_root",
+            )?),
+        })
+    }
+}
+
+impl TryFrom<&StoredProof> for proto::PessimisticStoredProof {
+    type Error = ProofConversionError;
+
+    fn try_from(value: &StoredProof) -> Result<Self, Self::Error> {
+        match value {
+            StoredProof::SP1(sp1) => {
+                let public_values = if sp1.public_values.as_slice().is_empty() {
+                    None
+                } else {
+                    Some(proto::PessimisticProofOutput::from(
+                        PessimisticProofOutput::bincode_codec()
+                            .deserialize::<PessimisticProofOutput>(sp1.public_values.as_slice())
+                            .map_err(|error| ProofConversionError::InvalidData {
+                                field: "public_values",
+                                reason: error.to_string(),
+                            })?,
+                    ))
+                };
+
+                Ok(Self {
+                    proof: Some(proto::Proof {
+                        proof_system: proto::ProofSystem::Sp1 as i32,
+                        version: sp1.sp1_version.clone(),
+                        mode: stored_proof_mode(value),
+                        proof: bincode::default()
+                            .serialize(&sp1.proof)
+                            .map_err(|error| ProofConversionError::InvalidData {
+                                field: "proof",
+                                reason: error.to_string(),
+                            })?
+                            .into(),
+                        vkey: bincode::default()
+                            .serialize(&sp1.tee_proof)
+                            .map_err(|error| ProofConversionError::InvalidData {
+                                field: "tee_proof",
+                                reason: error.to_string(),
+                            })?
+                            .into(),
+                    }),
+                    public_values,
+                })
+            }
+        }
+    }
+}
+
+impl TryFrom<proto::PessimisticStoredProof> for StoredProof {
+    type Error = ProofConversionError;
+
+    fn try_from(value: proto::PessimisticStoredProof) -> Result<Self, Self::Error> {
+        let proof = value
+            .proof
+            .ok_or(ProofConversionError::MissingField("proof"))?;
+
+        if proof.proof_system != proto::ProofSystem::Sp1 as i32 {
+            return Err(ProofConversionError::UnsupportedProofSystem {
+                proof_system: proof.proof_system,
+            });
+        }
+
+        let public_values = value
+            .public_values
+            .map(TryInto::try_into)
+            .transpose()?
+            .map(|output: PessimisticProofOutput| {
+                PessimisticProofOutput::bincode_codec()
+                    .serialize(&output)
+                    .map_err(|error| ProofConversionError::InvalidData {
+                        field: "public_values",
+                        reason: error.to_string(),
+                    })
+            })
+            .transpose()?;
+
+        let mut stored = StoredProof::dummy();
+        let StoredProof::SP1(sp1) = &mut stored;
+
+        sp1.proof = bincode::default()
+            .deserialize(&proof.proof)
+            .map_err(|error| ProofConversionError::InvalidData {
+                field: "proof",
+                reason: error.to_string(),
+            })?;
+        sp1.public_values = Default::default();
+        sp1.public_values
+            .write_slice(public_values.as_deref().unwrap_or(&[]));
+        sp1.sp1_version = proof.version;
+        sp1.tee_proof = if proof.vkey.is_empty() {
+            None
+        } else {
+            bincode::default()
+                .deserialize(&proof.vkey)
+                .map_err(|error| ProofConversionError::InvalidData {
+                    field: "tee_proof",
+                    reason: error.to_string(),
+                })?
+        };
+
+        Ok(stored)
+    }
+}
+
+impl crate::schema::Codec for StoredProof {
+    fn encode_into<W: std::io::Write>(&self, mut writer: W) -> Result<(), CodecError> {
+        let proto = proto::PessimisticStoredProof::try_from(self)
+            .map_err(|error| CodecError::Conversion(error.to_string()))?;
+        let mut buf = prost::bytes::BytesMut::with_capacity(
+            <proto::PessimisticStoredProof as prost::Message>::encoded_len(&proto),
+        );
+
+        <proto::PessimisticStoredProof as prost::Message>::encode(&proto, &mut buf)?;
+        writer.write_all(&buf)?;
+
+        Ok(())
+    }
+
+    fn decode(buf: &[u8]) -> Result<Self, CodecError> {
+        let proto = <proto::PessimisticStoredProof as prost::Message>::decode(buf)?;
+        StoredProof::try_from(proto).map_err(|error| CodecError::Conversion(error.to_string()))
+    }
+}
+
+impl crate::schema::Codec for LegacyProof {
+    fn encode_into<W: std::io::Write>(&self, _writer: W) -> Result<(), CodecError> {
+        Err(CodecError::Conversion(
+            "LegacyProof is decode-only".to_string(),
+        ))
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, CodecError> {
+        let proof = bincode::default().deserialize(bytes)?;
+        Ok(Self(proof))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use agglayer_sp1::ProofError;
     use agglayer_types::{
-        aggchain_proof::Proof as TypedProof, testutils::dummy_sp1_stark_proof_with_version,
+        aggchain_proof::Proof as AggchainProof, testutils::dummy_sp1_stark_proof_with_version,
+        Proof as StoredProof,
     };
 
     use super::*;
-    use crate::types::generated::agglayer::storage::v0::{ProofMode, ProofSystem};
+    use crate::{
+        schema::Codec as _,
+        types::generated::agglayer::storage::v0::{ProofMode, ProofSystem},
+    };
+
+    fn sample_pessimistic_output(seed: u8) -> PessimisticProofOutput {
+        PessimisticProofOutput {
+            prev_local_exit_root: LocalExitRoot::new(Digest([seed; 32].into())),
+            prev_pessimistic_root: Digest([seed.wrapping_add(1); 32].into()),
+            l1_info_root: Digest([seed.wrapping_add(2); 32].into()),
+            origin_network: u32::from(seed).into(),
+            aggchain_hash: Digest([seed.wrapping_add(3); 32].into()),
+            new_local_exit_root: LocalExitRoot::new(Digest([seed.wrapping_add(4); 32].into())),
+            new_pessimistic_root: Digest([seed.wrapping_add(5); 32].into()),
+        }
+    }
+
+    fn sample_stored_proof() -> StoredProof {
+        let mut proof = StoredProof::dummy();
+        let StoredProof::SP1(sp1) = &mut proof;
+        sp1.sp1_version = "v6.2.1".to_owned();
+        sp1.public_values.write_slice(
+            PessimisticProofOutput::bincode_codec()
+                .serialize(&sample_pessimistic_output(0x11))
+                .unwrap()
+                .as_slice(),
+        );
+        sp1.tee_proof = Some(vec![0xAA, 0xBB, 0xCC]);
+        proof
+    }
+
+    fn assert_same_stored_proof(left: &StoredProof, right: &StoredProof) {
+        let left = bincode::default().serialize(left).unwrap();
+        let right = bincode::default().serialize(right).unwrap();
+        assert_eq!(left, right);
+    }
 
     #[test]
-    fn proof_proto_roundtrip_is_lossless_for_writable_versions() {
+    fn aggchain_proof_proto_roundtrip_is_lossless_for_writable_versions() {
         let proof = dummy_sp1_stark_proof_with_version("v5.2.2");
 
         let proto = proto::Proof::try_from(&proof).unwrap();
-        let decoded = TypedProof::try_from(proto).unwrap();
+        let decoded = AggchainProof::try_from(proto).unwrap();
 
         assert_eq!(decoded, proof);
     }
 
     #[test]
-    fn proof_proto_stores_sp1_bytes_directly() {
+    fn aggchain_proof_proto_stores_sp1_bytes_directly() {
         let proof = dummy_sp1_stark_proof_with_version("v6.0.1");
-        let TypedProof::SP1Stark(sp1) = &proof;
+        let AggchainProof::SP1Stark(sp1) = &proof;
 
         let proto = proto::Proof::try_from(&proof).unwrap();
 
@@ -89,11 +385,11 @@ mod tests {
     }
 
     #[test]
-    fn proof_proto_reads_direct_sp1_bytes() {
+    fn aggchain_proof_proto_reads_direct_sp1_bytes() {
         let proof = dummy_sp1_stark_proof_with_version("v6.0.1");
-        let TypedProof::SP1Stark(sp1) = &proof;
+        let AggchainProof::SP1Stark(sp1) = &proof;
 
-        let decoded = TypedProof::try_from(proto::Proof {
+        let decoded = AggchainProof::try_from(proto::Proof {
             proof_system: ProofSystem::Sp1 as i32,
             version: sp1.version.clone(),
             mode: ProofMode::Compressed as i32,
@@ -106,18 +402,18 @@ mod tests {
     }
 
     #[test]
-    fn proof_proto_reads_supported_read_only_versions() {
+    fn aggchain_proof_proto_reads_supported_read_only_versions() {
         let proof = dummy_sp1_stark_proof_with_version("v5.2.2");
-        let TypedProof::SP1Stark(expected) = proof.clone();
+        let AggchainProof::SP1Stark(expected) = proof.clone();
 
         let mut proto = proto::Proof::try_from(&proof).unwrap();
         proto.version = "v6.0.1".to_owned();
 
-        let decoded = TypedProof::try_from(proto).unwrap();
+        let decoded = AggchainProof::try_from(proto).unwrap();
 
         assert_eq!(
             decoded,
-            TypedProof::SP1Stark(SP1StarkWithContext {
+            AggchainProof::SP1Stark(SP1StarkWithContext {
                 version: "v6.0.1".to_owned(),
                 ..expected
             })
@@ -125,17 +421,17 @@ mod tests {
     }
 
     #[test]
-    fn proof_proto_roundtrip_is_lossless_for_read_only_versions() {
+    fn aggchain_proof_proto_roundtrip_is_lossless_for_read_only_versions() {
         let proof = dummy_sp1_stark_proof_with_version("v6.0.1");
 
         let proto = proto::Proof::try_from(&proof).unwrap();
-        let decoded = TypedProof::try_from(proto).unwrap();
+        let decoded = AggchainProof::try_from(proto).unwrap();
 
         assert_eq!(decoded, proof);
     }
 
     #[test]
-    fn proof_proto_writes_supported_read_only_versions() {
+    fn aggchain_proof_proto_writes_supported_read_only_versions() {
         let proof = dummy_sp1_stark_proof_with_version("v6.0.1");
 
         let proto = proto::Proof::try_from(&proof).unwrap();
@@ -144,9 +440,9 @@ mod tests {
     }
 
     #[test]
-    fn proof_proto_rejects_unknown_write_version() {
+    fn aggchain_proof_proto_rejects_unknown_write_version() {
         let mut proof = dummy_sp1_stark_proof_with_version("v6.0.1");
-        let TypedProof::SP1Stark(sp1) = &mut proof;
+        let AggchainProof::SP1Stark(sp1) = &mut proof;
         sp1.version = "v7.0.0".to_owned();
 
         let err = proto::Proof::try_from(&proof).unwrap_err();
@@ -158,12 +454,12 @@ mod tests {
     }
 
     #[test]
-    fn proof_proto_rejects_unknown_read_version() {
+    fn aggchain_proof_proto_rejects_unknown_read_version() {
         let proof = dummy_sp1_stark_proof_with_version("v5.2.2");
         let mut proto = proto::Proof::try_from(&proof).unwrap();
         proto.version = "v7.0.0".to_owned();
 
-        let err = TypedProof::try_from(proto).unwrap_err();
+        let err = AggchainProof::try_from(proto).unwrap_err();
 
         assert!(matches!(
             err,
@@ -172,8 +468,8 @@ mod tests {
     }
 
     #[test]
-    fn proof_proto_preserves_opaque_sp1_bytes() {
-        let decoded = TypedProof::try_from(proto::Proof {
+    fn aggchain_proof_proto_preserves_opaque_sp1_bytes() {
+        let decoded = AggchainProof::try_from(proto::Proof {
             proof_system: ProofSystem::Sp1 as i32,
             version: "v5.2.2".to_owned(),
             mode: ProofMode::Compressed as i32,
@@ -184,7 +480,7 @@ mod tests {
 
         assert_eq!(
             decoded,
-            TypedProof::SP1Stark(SP1StarkWithContext {
+            AggchainProof::SP1Stark(SP1StarkWithContext {
                 proof: vec![0xde, 0xad, 0xbe, 0xef],
                 vkey: vec![0xca, 0xfe],
                 version: "v5.2.2".to_owned(),
@@ -193,8 +489,8 @@ mod tests {
     }
 
     #[test]
-    fn proof_proto_rejects_unsupported_system() {
-        let unsupported_system = TypedProof::try_from(proto::Proof {
+    fn aggchain_proof_proto_rejects_unsupported_system() {
+        let unsupported_system = AggchainProof::try_from(proto::Proof {
             proof_system: ProofSystem::Unspecified as i32,
             version: "v5.2.2".to_owned(),
             mode: ProofMode::Compressed as i32,
@@ -207,5 +503,37 @@ mod tests {
             unsupported_system,
             ProofConversionError::UnsupportedProofSystem { .. }
         ));
+    }
+
+    #[test]
+    fn stored_proof_codec_roundtrip_uses_pessimistic_wrapper() {
+        let proof = sample_stored_proof();
+
+        let bytes = proof.encode().unwrap();
+        let proto = <proto::PessimisticStoredProof as prost::Message>::decode(bytes.as_slice())
+            .unwrap();
+        let decoded = StoredProof::decode(bytes.as_slice()).unwrap();
+
+        assert_same_stored_proof(&decoded, &proof);
+        assert_eq!(
+            proto.proof.unwrap().version,
+            "v6.2.1",
+            "storage proof version should live in the proto envelope"
+        );
+        assert!(proto.public_values.is_some());
+    }
+
+    #[test]
+    fn stored_proof_codec_allows_empty_public_values() {
+        let proof = StoredProof::dummy();
+
+        let bytes = proof.encode().unwrap();
+        let proto = <proto::PessimisticStoredProof as prost::Message>::decode(bytes.as_slice())
+            .unwrap();
+        let decoded = StoredProof::decode(bytes.as_slice()).unwrap();
+
+        assert_same_stored_proof(&decoded, &proof);
+        assert!(proto.public_values.is_none());
+        assert_eq!(proto.proof.unwrap().mode, proto::ProofMode::Unspecified as i32);
     }
 }

--- a/crates/agglayer-storage/src/types/proof.rs
+++ b/crates/agglayer-storage/src/types/proof.rs
@@ -19,10 +19,7 @@ pub enum ProofConversionError {
     MissingField(&'static str),
 
     #[error("invalid data for `{field}`: {reason}")]
-    InvalidData {
-        field: &'static str,
-        reason: String,
-    },
+    InvalidData { field: &'static str, reason: String },
 
     #[error("unsupported proof system `{proof_system}`")]
     UnsupportedProofSystem { proof_system: i32 },
@@ -44,10 +41,12 @@ fn expect_bytes<const N: usize>(
     bytes: &[u8],
     field: &'static str,
 ) -> Result<[u8; N], ProofConversionError> {
-    bytes.try_into().map_err(|_| ProofConversionError::InvalidData {
-        field,
-        reason: format!("expected {N} bytes, got {}", bytes.len()),
-    })
+    bytes
+        .try_into()
+        .map_err(|_| ProofConversionError::InvalidData {
+            field,
+            reason: format!("expected {N} bytes, got {}", bytes.len()),
+        })
 }
 
 fn stored_proof_mode(proof: &StoredProof) -> i32 {
@@ -510,8 +509,8 @@ mod tests {
         let proof = sample_stored_proof();
 
         let bytes = proof.encode().unwrap();
-        let proto = <proto::PessimisticStoredProof as prost::Message>::decode(bytes.as_slice())
-            .unwrap();
+        let proto =
+            <proto::PessimisticStoredProof as prost::Message>::decode(bytes.as_slice()).unwrap();
         let decoded = StoredProof::decode(bytes.as_slice()).unwrap();
 
         assert_same_stored_proof(&decoded, &proof);
@@ -528,12 +527,15 @@ mod tests {
         let proof = StoredProof::dummy();
 
         let bytes = proof.encode().unwrap();
-        let proto = <proto::PessimisticStoredProof as prost::Message>::decode(bytes.as_slice())
-            .unwrap();
+        let proto =
+            <proto::PessimisticStoredProof as prost::Message>::decode(bytes.as_slice()).unwrap();
         let decoded = StoredProof::decode(bytes.as_slice()).unwrap();
 
         assert_same_stored_proof(&decoded, &proof);
         assert!(proto.public_values.is_none());
-        assert_eq!(proto.proof.unwrap().mode, proto::ProofMode::Unspecified as i32);
+        assert_eq!(
+            proto.proof.unwrap().mode,
+            proto::ProofMode::Unspecified as i32
+        );
     }
 }


### PR DESCRIPTION
This migrates the pending and per-epoch proof column families to proto-backed storage and keeps the legacy proof CFs readable only for startup backfill.

The key part of the fix is to keep two proof types separate.
The existing aggchain proof conversions in agglayer-storage are still the right boundary for certificate paths.
The rows stored in the pending and per-epoch proof CFs use agglayer_types::Proof instead, so this patch adds a dedicated storage codec for that type rather than reusing the certificate conversion path.

The storage shape now mirrors the earlier certificate migration work:
legacy proof CF remains present and readable
startup migration copies readable legacy rows into a new proto proof CF
runtime reads and writes target only the proto proof CF
unparsable legacy rows are skipped with logging instead of aborting the whole migration step

Validation on the native WSL copy:
CARGO_BUILD_JOBS=4 cargo test -p agglayer-storage
221 passed
0 failed

Closes #1529