### PR TITLE
fix(storage): use prefix iterator for settlement history

### DIFF
--- a/crates/agglayer-storage/src/storage/iterators.rs
+++ b/crates/agglayer-storage/src/storage/iterators.rs
@@ -86,15 +86,6 @@ impl<'a, C: ColumnSchema> ColumnIterator<'a, C> {
         }
     }
 
-    /// Seeks to the first entry whose key is greater than or equal to `key`.
-    pub fn seek(&mut self, key: &C::Key) -> Result<(), DBError> {
-        let encoded = C::Key::encode(key)?;
-        self.iter.seek(&encoded);
-        self.status = IteratorStatus::Initialized;
-
-        Ok(())
-    }
-
     fn parse_key_value(&self) -> KeyValueResult<C::Key, C::Value> {
         let key = self.iter.key().map(C::Key::decode).transpose()?;
         let value = self.iter.value().map(C::Value::decode).transpose()?;

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -232,6 +232,17 @@ impl DB {
         Ok(ColumnIterator::new(iterator, direction))
     }
 
+    pub(crate) fn prefix_iterator<C: ColumnSchema, P: Codec>(
+        &self,
+        prefix: &P,
+    ) -> Result<ColumnIterator<'_, C>, DBError> {
+        let cf = self.cf::<C>()?;
+        let prefix = prefix.encode()?;
+        let iterator = self.rocksdb.prefix_iterator_cf(&cf, prefix).into();
+
+        Ok(ColumnIterator::new(iterator, Direction::Forward))
+    }
+
     pub(crate) fn delete<C: ColumnSchema>(&self, key: &C::Key) -> Result<(), DBError> {
         let cf = self.cf::<C>()?;
         let key = key.encode()?;

--- a/crates/agglayer-storage/src/stores/state/settlement/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/settlement/mod.rs
@@ -1,7 +1,7 @@
 use agglayer_types::{
     SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobId, SettlementJobResult,
 };
-use rocksdb::{Direction, ReadOptions, WriteBatch};
+use rocksdb::WriteBatch;
 
 use super::StateStore;
 use crate::{
@@ -73,28 +73,16 @@ impl SettlementReader for StateStore {
         &self,
         settlement_job_id: &SettlementJobId,
     ) -> Result<Vec<(u64, SettlementAttempt)>, Error> {
-        let mut iterator = self.db.iter_with_direction::<SettlementAttemptsColumn>(
-            ReadOptions::default(),
-            Direction::Forward,
-        )?;
-        iterator.seek(&SettlementAttemptKey {
-            settlement_job_id: *settlement_job_id,
-            attempt_sequence_number: 0,
-        })?;
-
-        iterator
-            .map(|entry| -> Result<Option<(u64, SettlementAttempt)>, Error> {
+        self.db
+            .prefix_iterator::<SettlementAttemptsColumn, _>(settlement_job_id)?
+            .map(|entry| -> Result<(u64, SettlementAttempt), Error> {
                 let (key, attempt) = entry?;
-                if key.settlement_job_id != *settlement_job_id {
-                    return Ok(None);
-                }
 
-                Ok(Some((
+                Ok((
                     key.attempt_sequence_number,
                     SettlementAttempt::try_from(attempt)?,
-                )))
+                ))
             })
-            .map_while(|entry| entry.transpose())
             .collect::<Result<Vec<_>, _>>()
     }
 
@@ -102,32 +90,16 @@ impl SettlementReader for StateStore {
         &self,
         settlement_job_id: &SettlementJobId,
     ) -> Result<Vec<(u64, SettlementAttemptResult)>, Error> {
-        let mut iterator = self
-            .db
-            .iter_with_direction::<SettlementAttemptResultsColumn>(
-                ReadOptions::default(),
-                Direction::Forward,
-            )?;
-        iterator.seek(&SettlementAttemptKey {
-            settlement_job_id: *settlement_job_id,
-            attempt_sequence_number: 0,
-        })?;
+        self.db
+            .prefix_iterator::<SettlementAttemptResultsColumn, _>(settlement_job_id)?
+            .map(|entry| -> Result<(u64, SettlementAttemptResult), Error> {
+                let (key, result) = entry?;
 
-        iterator
-            .map(
-                |entry| -> Result<Option<(u64, SettlementAttemptResult)>, Error> {
-                    let (key, result) = entry?;
-                    if key.settlement_job_id != *settlement_job_id {
-                        return Ok(None);
-                    }
-
-                    Ok(Some((
-                        key.attempt_sequence_number,
-                        SettlementAttemptResult::try_from(result)?,
-                    )))
-                },
-            )
-            .map_while(|entry| entry.transpose())
+                Ok((
+                    key.attempt_sequence_number,
+                    SettlementAttemptResult::try_from(result)?,
+                ))
+            })
             .collect::<Result<Vec<_>, _>>()
     }
 }


### PR DESCRIPTION
Use RocksDB prefix iteration for settlement attempt history reads.

Settlement attempts and attempt results now iterate from the encoded
SettlementJobId prefix, so RocksDB enforces the job boundary instead of
storage code seeking and checking each decoded key.

Fixes #1539.

Verified with:
- cargo make blast-radius
- cargo check --workspace --tests --all-features
- mdbook build docs/knowledge-base/
- cargo make ci-all
- cargo nextest run --workspace
- cargo make pp-check-vkey-change
- git diff --check