### PR TITLE
fix(config): accept bare filename config paths

### DIFF
--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -139,12 +139,8 @@ impl Config {
 
         let path = path
             .parent()
-            .ok_or_else(|| ConfigurationError::UnableToReadConfigFile {
-                path: path.to_path_buf(),
-                source: std::io::Error::other(
-                    "Unable to determine the parent folder of the configuration file",
-                ),
-            })?;
+            .filter(|path| !path.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
 
         let config_with_path = ConfigDeserializer { path };
 
@@ -248,7 +244,7 @@ impl<'de> DeserializeSeed<'de> for ConfigDeserializer<'_> {
                 .storage
                 .path_contextualized(&self.path.canonicalize().map_err(|error| {
                     serde::de::Error::custom(format!(
-                        "Unable to canonicalize the storage path: {error}"
+                        "Unable to canonicalize the configuration directory: {error}"
                     ))
                 })?);
 

--- a/crates/agglayer-config/tests/bare_filename_config.rs
+++ b/crates/agglayer-config/tests/bare_filename_config.rs
@@ -1,0 +1,27 @@
+use std::path::{Path, PathBuf};
+
+use agglayer_config::Config;
+use pretty_assertions::assert_eq;
+
+struct CurrentDirGuard(PathBuf);
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.0).unwrap();
+    }
+}
+
+#[test]
+fn bare_filename_config_path_uses_current_directory() {
+    let original_dir = std::env::current_dir().unwrap();
+    let tests_dir = original_dir.join("tests");
+    std::env::set_current_dir(&tests_dir).unwrap();
+    let _current_dir_guard = CurrentDirGuard(original_dir);
+
+    let config = Config::try_load(Path::new("bare_filename_config.toml")).unwrap();
+
+    assert_eq!(
+        config.storage.state_db_path,
+        tests_dir.canonicalize().unwrap().join("storage/state")
+    );
+}

--- a/crates/agglayer-config/tests/bare_filename_config.toml
+++ b/crates/agglayer-config/tests/bare_filename_config.toml
@@ -1,0 +1,1 @@
+[full-node-rpcs]


### PR DESCRIPTION
Allow config loading to handle paths like agglayer.toml without requiring a parent directory.

This keeps local CLI and node startup paths usable when operators pass a bare filename from the current working directory.