### PR TITLE
fix(storage): enforce proof acceptance policy

### DIFF
--- a/crates/agglayer-storage/src/types/proof.rs
+++ b/crates/agglayer-storage/src/types/proof.rs
@@ -1,4 +1,4 @@
-use agglayer_sp1::{version_kind, ProofError, ProofExt};
+use agglayer_sp1::{version_kind, AcceptancePolicy, ProofError, ProofExt};
 use agglayer_types::aggchain_proof::{Proof as TypedProof, SP1StarkWithContext};
 
 use crate::types::generated::agglayer::storage::v0 as proto;
@@ -20,7 +20,7 @@ impl TryFrom<&TypedProof> for proto::Proof {
 
     fn try_from(value: &TypedProof) -> Result<Self, Self::Error> {
         let sp1 = value.sp1();
-        version_kind(&sp1.version)?;
+        value.ensure_readable(&AcceptancePolicy::DEFAULT)?;
 
         Ok(Self {
             proof_system: proto::ProofSystem::Sp1 as i32,
@@ -47,7 +47,13 @@ impl TryFrom<proto::Proof> for TypedProof {
         }
 
         let version = value.version;
-        version_kind(&version)?;
+        let proof_version = version_kind(&version).map_err(|err| match err {
+            ProofError::UnsupportedSp1VersionMajor { version } => {
+                ProofError::UnsupportedReadableSp1Version { version }
+            }
+            other => other,
+        })?;
+        AcceptancePolicy::DEFAULT.ensure_readable(proof_version, &version)?;
 
         Ok(TypedProof::SP1Stark(SP1StarkWithContext {
             proof: value.proof.to_vec(),
@@ -61,7 +67,8 @@ impl TryFrom<proto::Proof> for TypedProof {
 mod tests {
     use agglayer_sp1::ProofError;
     use agglayer_types::{
-        aggchain_proof::Proof as TypedProof, testutils::dummy_sp1_stark_proof_with_version,
+        aggchain_proof::{Proof as TypedProof, SP1StarkWithContext},
+        testutils::dummy_sp1_stark_proof_with_version,
     };
 
     use super::*;
@@ -79,7 +86,7 @@ mod tests {
 
     #[test]
     fn proof_proto_stores_sp1_bytes_directly() {
-        let proof = dummy_sp1_stark_proof_with_version("v6.0.1");
+        let proof = dummy_sp1_stark_proof_with_version("v5.2.2");
         let TypedProof::SP1Stark(sp1) = &proof;
 
         let proto = proto::Proof::try_from(&proof).unwrap();
@@ -90,7 +97,7 @@ mod tests {
 
     #[test]
     fn proof_proto_reads_direct_sp1_bytes() {
-        let proof = dummy_sp1_stark_proof_with_version("v6.0.1");
+        let proof = dummy_sp1_stark_proof_with_version("v5.2.2");
         let TypedProof::SP1Stark(sp1) = &proof;
 
         let decoded = TypedProof::try_from(proto::Proof {
@@ -125,17 +132,7 @@ mod tests {
     }
 
     #[test]
-    fn proof_proto_roundtrip_is_lossless_for_read_only_versions() {
-        let proof = dummy_sp1_stark_proof_with_version("v6.0.1");
-
-        let proto = proto::Proof::try_from(&proof).unwrap();
-        let decoded = TypedProof::try_from(proto).unwrap();
-
-        assert_eq!(decoded, proof);
-    }
-
-    #[test]
-    fn proof_proto_writes_supported_read_only_versions() {
+    fn proof_proto_writes_current_versions() {
         let proof = dummy_sp1_stark_proof_with_version("v6.0.1");
 
         let proto = proto::Proof::try_from(&proof).unwrap();
@@ -144,7 +141,7 @@ mod tests {
     }
 
     #[test]
-    fn proof_proto_rejects_unknown_write_version() {
+    fn proof_proto_rejects_unknown_storage_version() {
         let mut proof = dummy_sp1_stark_proof_with_version("v6.0.1");
         let TypedProof::SP1Stark(sp1) = &mut proof;
         sp1.version = "v7.0.0".to_owned();
@@ -153,7 +150,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            ProofConversionError::Sp1(ProofError::UnsupportedSp1VersionMajor { .. })
+            ProofConversionError::Sp1(ProofError::UnsupportedReadableSp1Version { .. })
         ));
     }
 
@@ -167,7 +164,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            ProofConversionError::Sp1(ProofError::UnsupportedSp1VersionMajor { .. })
+            ProofConversionError::Sp1(ProofError::UnsupportedReadableSp1Version { .. })
         ));
     }
 


### PR DESCRIPTION
Make proof decoding use explicit read and write acceptance policies.

This separates storage reads from new writes so historical supported proof formats stay readable while new writes remain restricted to writable versions.