### PR TITLE
feat(storage): add migration runner

### DIFF
--- a/crates/agglayer-storage/src/diagnostics.rs
+++ b/crates/agglayer-storage/src/diagnostics.rs
@@ -5,9 +5,8 @@
 //! rows whose value bytes fail to decode through
 //! [`crate::types::LegacyCertificate`] — typically pre-existing corruption
 //! in the on-disk data that the migration helper logged-and-skipped. The
-//! scan functions in this module enumerate those rows so the operator can
-//! see them all in one pass and decide what to do (purge via the
-//! `storage-doctor` CLI, restore from backup, etc.).
+//! scan functions in this module enumerate those rows so migration reports
+//! can show operators what to inspect, purge, or restore from backup.
 //!
 //! The scan opens each store in read-only mode and re-iterates the legacy
 //! certificate CFs, attempting to decode each value. It is purely
@@ -18,7 +17,10 @@
 //! (for rollback) but unused at runtime; their contents are exactly what
 //! the scan reports on.
 
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     columns::{
@@ -64,27 +66,41 @@ pub enum ScanError {
         #[source]
         source: std::io::Error,
     },
+
+    #[error("failed to iterate {cf} for {source}: {error}")]
+    LegacyCfIterator {
+        source: String,
+        cf: &'static str,
+        #[source]
+        error: rocksdb::Error,
+    },
+}
+
+struct EpochDirEntry {
+    file_name: OsString,
+    path: PathBuf,
+    is_dir: bool,
 }
 
 /// Scan the legacy `pending_queue` CF in the pending DB and return rows
 /// whose value bytes fail to decode as a `LegacyCertificate`.
 pub fn scan_unparsable_pending_rows(db_path: &Path) -> Result<Vec<UnparsableRow>, ScanError> {
     let db = open_readonly_v0(db_path, PENDING_DB_V0)?;
-    Ok(scan_legacy_cf(
+    scan_legacy_cf(
         &db,
         PendingQueueColumn::COLUMN_FAMILY_NAME,
         "pending".into(),
-    ))
+    )
 }
 
 /// Scan the legacy `debug_certificates` CF in the debug DB.
 pub fn scan_unparsable_debug_rows(db_path: &Path) -> Result<Vec<UnparsableRow>, ScanError> {
     let db = open_readonly_v0(db_path, DEBUG_DB_V0)?;
-    Ok(scan_legacy_cf(
+    scan_legacy_cf(
         &db,
         DebugCertificatesColumn::COLUMN_FAMILY_NAME,
         "debug".into(),
-    ))
+    )
 }
 
 /// Scan the legacy `epoch_certificate_per_index` CF in every numeric
@@ -96,26 +112,66 @@ pub fn scan_unparsable_epoch_rows(epochs_db_path: &Path) -> Result<Vec<Unparsabl
         source,
     })?;
 
-    let mut numeric_dirs: Vec<(u64, PathBuf)> = entries
-        .filter_map(Result::ok)
-        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-        .filter_map(|e| {
-            let n = e.file_name().to_str()?.parse::<u64>().ok()?;
-            Some((n, e.path()))
+    let mut numeric_dirs = collect_numeric_epoch_dirs(entries.map(|entry| {
+        let entry = entry.map_err(|source| ScanError::EpochDir {
+            path: epochs_db_path.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|source| ScanError::EpochDir {
+            path: path.clone(),
+            source,
+        })?;
+
+        Ok(EpochDirEntry {
+            file_name: entry.file_name(),
+            path,
+            is_dir: file_type.is_dir(),
         })
-        .collect();
+    }))?;
     numeric_dirs.sort_by_key(|(n, _)| *n);
 
+    scan_unparsable_epoch_dirs(&numeric_dirs)
+}
+
+fn collect_numeric_epoch_dirs<I>(entries: I) -> Result<Vec<(u64, PathBuf)>, ScanError>
+where
+    I: IntoIterator<Item = Result<EpochDirEntry, ScanError>>,
+{
+    let mut numeric_dirs = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        if !entry.is_dir {
+            continue;
+        }
+        let Some(n) = entry.file_name.to_str().and_then(|s| s.parse::<u64>().ok()) else {
+            continue;
+        };
+        numeric_dirs.push((n, entry.path));
+    }
+    Ok(numeric_dirs)
+}
+
+pub(crate) fn scan_unparsable_epoch_dirs(
+    numeric_dirs: &[(u64, PathBuf)],
+) -> Result<Vec<UnparsableRow>, ScanError> {
     let mut out = Vec::new();
     for (n, path) in numeric_dirs {
-        let db = open_readonly_v0(&path, EPOCHS_DB_V0)?;
-        out.extend(scan_legacy_cf(
-            &db,
-            CertificatePerIndexColumn::COLUMN_FAMILY_NAME,
-            format!("epoch {n}"),
-        ));
+        out.extend(scan_unparsable_epoch_dir(*n, path)?);
     }
     Ok(out)
+}
+
+pub(crate) fn scan_unparsable_epoch_dir(
+    epoch: u64,
+    db_path: &Path,
+) -> Result<Vec<UnparsableRow>, ScanError> {
+    let db = open_readonly_v0(db_path, EPOCHS_DB_V0)?;
+    scan_legacy_cf(
+        &db,
+        CertificatePerIndexColumn::COLUMN_FAMILY_NAME,
+        format!("epoch {epoch}"),
+    )
 }
 
 fn open_readonly_v0(
@@ -132,12 +188,16 @@ fn open_readonly_v0(
 /// value decoding upfront), then attempt `LegacyCertificate::decode` on
 /// each value. Decode failures land in the returned vector with the raw
 /// key bytes as hex; success rows are silently dropped.
-fn scan_legacy_cf(db: &DB, cf_name: &'static str, source: String) -> Vec<UnparsableRow> {
+fn scan_legacy_cf(
+    db: &DB,
+    cf_name: &'static str,
+    source: String,
+) -> Result<Vec<UnparsableRow>, ScanError> {
     let Some(cf) = db.raw_rocksdb().cf_handle(cf_name) else {
         // CF missing on disk: nothing to scan. Shouldn't happen when
         // we've opened with the V0 schema (which lists the legacy CFs),
         // but treat defensively.
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
     let mut iter = db.raw_rocksdb().raw_iterator_cf(&cf);
@@ -157,7 +217,14 @@ fn scan_legacy_cf(db: &DB, cf_name: &'static str, source: String) -> Vec<Unparsa
         }
         iter.next();
     }
-    out
+
+    iter.status().map_err(|error| ScanError::LegacyCfIterator {
+        source,
+        cf: cf_name,
+        error,
+    })?;
+
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -405,6 +472,19 @@ mod tests {
 
         let result = scan_unparsable_epoch_rows(&epochs_dir).unwrap();
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn epoch_scan_discovery_propagates_entry_errors() {
+        let path = PathBuf::from("epochs");
+        let entries: [Result<EpochDirEntry, ScanError>; 1] = [Err(ScanError::EpochDir {
+            path: path.clone(),
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "entry failed"),
+        })];
+
+        let error = collect_numeric_epoch_dirs(entries).unwrap_err();
+
+        assert!(matches!(error, ScanError::EpochDir { path: p, .. } if p == path));
     }
 
     #[test]

--- a/crates/agglayer-storage/src/lib.rs
+++ b/crates/agglayer-storage/src/lib.rs
@@ -10,6 +10,7 @@ pub mod backup;
 pub mod columns;
 pub mod diagnostics;
 pub mod error;
+pub mod migrate;
 pub mod stores;
 pub mod types;
 

--- a/crates/agglayer-storage/src/migrate.rs
+++ b/crates/agglayer-storage/src/migrate.rs
@@ -1,0 +1,648 @@
+//! Operator-facing storage migration runner.
+//!
+//! Runs `init_db` on each storage component (state, pending, debug, every
+//! epoch) **in place** so an operator can converge the on-disk schema to
+//! the current binary's expectations as a separate step from starting the
+//! node. This command is the explicit schema-writing entry point.
+//! Node startup creates missing current-schema stores, opens current stores,
+//! and rejects existing storage that needs migration.
+//!
+//! Designed for production maintenance windows: no staging, no row-by-row
+//! equality check, just executes the migrations and reports per-store
+//! outcomes.
+//!
+//! Report rendering lives in the CLI crate (`agglayer::migrate_report`)
+//! and templates live next to it; this module owns only the migration
+//! data flow and exposes [`MigrateOutcome`] for the CLI to render.
+
+use std::{
+    ffi::OsString,
+    fs,
+    num::NonZeroU64,
+    path::{Path, PathBuf},
+    time::{Duration, Instant, SystemTime},
+};
+
+pub use crate::diagnostics::UnparsableRow;
+use crate::{
+    diagnostics,
+    stores::{
+        debug::DebugStore, pending::PendingStore, per_epoch::PerEpochStore, state::StateStore,
+    },
+};
+
+/// Inputs for a migration run. The four `*_db_path` fields mirror the
+/// fields of the same name on `agglayer_config::storage::StorageConfig`,
+/// so a CLI can fill this in from an `agglayer.toml`. Any field set to
+/// `None` is treated as "store not present in this deployment" and is
+/// skipped rather than failing.
+#[derive(Debug, Clone)]
+pub struct MigrateOptions {
+    pub state_db_path: Option<PathBuf>,
+    pub pending_db_path: Option<PathBuf>,
+    pub debug_db_path: Option<PathBuf>,
+    pub epochs_db_path: Option<PathBuf>,
+    /// Operator-supplied label (`mainnet`, `testnet`, …) used in report
+    /// filenames and headings.
+    pub env_label: String,
+    /// When true, the epoch sweep is bypassed entirely (state, pending,
+    /// debug still run).
+    pub skip_epochs: bool,
+    /// Cap the epoch sweep to the N most-recent epochs (highest numeric
+    /// names first). Useful for operator spot-checks where the active
+    /// data is at the latest epochs and the lowest-numbered ones are
+    /// typically empty.
+    pub latest_epochs: Option<NonZeroU64>,
+}
+
+/// Outcome of a migration run. Aggregates per-store results and a flag
+/// indicating whether any store ended in a fatal state.
+#[derive(Debug)]
+pub struct MigrateOutcome {
+    pub started_at: SystemTime,
+    pub overall_duration: Duration,
+    pub env_label: String,
+    pub state: Option<StoreResult>,
+    pub pending: Option<StoreResult>,
+    pub debug: Option<StoreResult>,
+    pub epochs: EpochsResult,
+}
+
+#[derive(Debug)]
+pub struct StoreResult {
+    pub label: String,
+    pub path: PathBuf,
+    pub duration: Duration,
+    /// `None` on success; `Some(message)` if `init_db` returned an error.
+    pub error: Option<String>,
+    /// Legacy CF rows that the post-migration diagnostics scan flagged as
+    /// undecodable (skipped by the migration helper). Empty when the
+    /// store has no relevant legacy CF (e.g. `state`), when `init_db`
+    /// failed (we did not run the scan), when the scan found no bad rows,
+    /// or when the scan itself failed (see `diagnostics_error`).
+    pub unparsable_rows: Vec<UnparsableRow>,
+    /// Non-fatal diagnostics scan failure for this store.
+    pub diagnostics_error: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct EpochsResult {
+    pub epochs_dir: Option<PathBuf>,
+    pub discovered: usize,
+    pub processed: usize,
+    pub successful: usize,
+    /// Error raised while reading the epoch root before per-epoch discovery.
+    pub discovery_error: Option<String>,
+    pub failed: Vec<EpochFailure>,
+    pub duration: Duration,
+    pub skipped_reason: Option<&'static str>,
+    /// Aggregate of unparsable rows across every epoch that was
+    /// successfully migrated. Each entry's `source` field carries the
+    /// epoch number (e.g. `"epoch 1234"`).
+    pub unparsable_rows: Vec<UnparsableRow>,
+    /// Non-fatal diagnostics scan failures for epochs that migrated
+    /// successfully but could not be inspected for unparsable legacy rows.
+    pub diagnostics_failures: Vec<EpochFailure>,
+}
+
+#[derive(Debug)]
+pub struct EpochFailure {
+    pub epoch: u64,
+    pub error: String,
+}
+
+struct EpochDirEntry {
+    file_name: OsString,
+    path: PathBuf,
+    is_dir: bool,
+}
+
+impl MigrateOutcome {
+    /// Number of fatal store outcomes (any non-`None` `error`, plus
+    /// individual epoch failures).
+    pub fn fatal_count(&self) -> usize {
+        let mut n = 0;
+        for r in [&self.state, &self.pending, &self.debug] {
+            if r.as_ref().and_then(|s| s.error.as_ref()).is_some() {
+                n += 1;
+            }
+        }
+        n + usize::from(self.epochs.discovery_error.is_some()) + self.epochs.failed.len()
+    }
+
+    pub fn is_success(&self) -> bool {
+        self.fatal_count() == 0
+    }
+}
+
+/// Run the migration in place against the paths in `opts`. Per-store
+/// failures are recorded in the outcome rather than propagated, so the
+/// runner always produces a complete report.
+///
+/// Infallible by design: the runner never aborts on a single store's
+/// failure, and report rendering / file IO is the CLI's responsibility.
+pub fn run(opts: MigrateOptions) -> MigrateOutcome {
+    let started_clock = SystemTime::now();
+    let started = Instant::now();
+
+    // This command is the explicit schema-writing entry point. Node startup uses
+    // migrated-or-create open helpers and must not call these migration-capable
+    // paths for existing storage.
+    let state = opts.state_db_path.as_deref().map(migrate_state);
+
+    let pending = opts.pending_db_path.as_deref().map(migrate_pending);
+
+    let debug = opts.debug_db_path.as_deref().map(migrate_debug);
+
+    let epochs = match opts.epochs_db_path.as_deref() {
+        None => EpochsResult::default(),
+        Some(_) if opts.skip_epochs => EpochsResult {
+            epochs_dir: opts.epochs_db_path.clone(),
+            skipped_reason: Some(
+                "skipped via skip_epochs flag; pending/debug/state were still migrated",
+            ),
+            ..EpochsResult::default()
+        },
+        Some(dir) => migrate_epochs(dir, opts.latest_epochs),
+    };
+
+    MigrateOutcome {
+        started_at: started_clock,
+        overall_duration: started.elapsed(),
+        env_label: opts.env_label,
+        state,
+        pending,
+        debug,
+        epochs,
+    }
+}
+
+fn migrate_state(path: &Path) -> StoreResult {
+    let started = Instant::now();
+    let error = match StateStore::init_db(path) {
+        Ok(_) => None,
+        Err(e) => Some(format_chain(&e)),
+    };
+    // State DB does not have a legacy certificate CF subject to the
+    // proto migration, so there is nothing to scan here.
+    StoreResult {
+        label: "state".into(),
+        path: path.to_path_buf(),
+        duration: started.elapsed(),
+        error,
+        unparsable_rows: Vec::new(),
+        diagnostics_error: None,
+    }
+}
+
+fn migrate_pending(path: &Path) -> StoreResult {
+    let started = Instant::now();
+    let error = match PendingStore::init_db(path) {
+        Ok(_) => None,
+        Err(e) => Some(format_chain(&e)),
+    };
+    let (unparsable_rows, diagnostics_error) = if error.is_none() {
+        scan_or_warn(diagnostics::scan_unparsable_pending_rows(path), "pending")
+    } else {
+        (Vec::new(), None)
+    };
+    StoreResult {
+        label: "pending".into(),
+        path: path.to_path_buf(),
+        duration: started.elapsed(),
+        error,
+        unparsable_rows,
+        diagnostics_error,
+    }
+}
+
+fn migrate_debug(path: &Path) -> StoreResult {
+    let started = Instant::now();
+    let error = match DebugStore::init_db(path) {
+        Ok(_) => None,
+        Err(e) => Some(format_chain(&e)),
+    };
+    let (unparsable_rows, diagnostics_error) = if error.is_none() {
+        scan_or_warn(diagnostics::scan_unparsable_debug_rows(path), "debug")
+    } else {
+        (Vec::new(), None)
+    };
+    StoreResult {
+        label: "debug".into(),
+        path: path.to_path_buf(),
+        duration: started.elapsed(),
+        error,
+        unparsable_rows,
+        diagnostics_error,
+    }
+}
+
+/// Run a diagnostics scan and carry any non-fatal scan failure into the
+/// migration report.
+fn scan_or_warn(
+    result: Result<Vec<UnparsableRow>, diagnostics::ScanError>,
+    store: &'static str,
+) -> (Vec<UnparsableRow>, Option<String>) {
+    match result {
+        Ok(rows) => (rows, None),
+        Err(error) => {
+            let error = error.to_string();
+            tracing::warn!(
+                store,
+                %error,
+                "diagnostics scan for unparsable legacy rows failed; report will not include them",
+            );
+            (Vec::new(), Some(error))
+        }
+    }
+}
+
+fn migrate_epochs(epochs_dir: &Path, latest_epochs: Option<NonZeroU64>) -> EpochsResult {
+    let started = Instant::now();
+    let mut result = EpochsResult {
+        epochs_dir: Some(epochs_dir.to_path_buf()),
+        ..EpochsResult::default()
+    };
+
+    let entries = match fs::read_dir(epochs_dir) {
+        Ok(it) => it,
+        Err(error) => {
+            result.discovery_error = Some(format!(
+                "failed to read epoch directory at {}: {error}",
+                epochs_dir.display()
+            ));
+            result.duration = started.elapsed();
+            return result;
+        }
+    };
+
+    // Discover every numeric epoch directory.
+    let mut numeric_dirs = match collect_numeric_epoch_dirs(entries.map(|entry| {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to read epoch directory entry under {}: {error}",
+                epochs_dir.display()
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|error| {
+            format!(
+                "failed to read file type for epoch directory entry {}: {error}",
+                path.display()
+            )
+        })?;
+
+        Ok(EpochDirEntry {
+            file_name: entry.file_name(),
+            path,
+            is_dir: file_type.is_dir(),
+        })
+    })) {
+        Ok(dirs) => dirs,
+        Err(error) => {
+            result.discovery_error = Some(error);
+            result.duration = started.elapsed();
+            return result;
+        }
+    };
+    result.discovered = numeric_dirs.len();
+
+    // For `latest_epochs`, pick the N highest-numbered epochs (operator
+    // spot-checks usually want the active recent epochs, not the
+    // typically-empty lowest-numbered ones). Then re-sort ascending so
+    // the actual migration runs in chronological order, which keeps
+    // progress logs monotonic and matches what an operator would expect
+    // from a sequential walk.
+    let to_process: Vec<_> = match latest_epochs {
+        Some(cap) => {
+            numeric_dirs.sort_by_key(|(n, _)| std::cmp::Reverse(*n));
+            let cap = usize::try_from(cap.get()).unwrap_or(usize::MAX);
+            let mut taken: Vec<_> = numeric_dirs.into_iter().take(cap).collect();
+            taken.sort_by_key(|(n, _)| *n);
+            taken
+        }
+        None => {
+            numeric_dirs.sort_by_key(|(n, _)| *n);
+            numeric_dirs
+        }
+    };
+
+    let mut successful_epoch_dirs = Vec::new();
+    for (n, path) in &to_process {
+        result.processed += 1;
+        match PerEpochStore::<(), ()>::init_db(path) {
+            Ok(_) => {
+                result.successful += 1;
+                successful_epoch_dirs.push((*n, path.clone()));
+            }
+            Err(e) => result.failed.push(EpochFailure {
+                epoch: *n,
+                error: format_chain(&e),
+            }),
+        }
+        if result.processed.is_multiple_of(200) {
+            eprintln!(
+                "[migrate] epochs: {} / {} processed ({:.2?} elapsed)",
+                result.processed,
+                result.discovered,
+                started.elapsed(),
+            );
+        }
+    }
+
+    // Keep diagnostics bounded to the same selected epochs as migration.
+    let (unparsable_rows, diagnostics_failures) = collect_epoch_diagnostics(
+        &successful_epoch_dirs,
+        diagnostics::scan_unparsable_epoch_dir,
+    );
+    result.unparsable_rows = unparsable_rows;
+    result.diagnostics_failures = diagnostics_failures;
+
+    result.duration = started.elapsed();
+    result
+}
+
+fn collect_epoch_diagnostics<F>(
+    epoch_dirs: &[(u64, PathBuf)],
+    mut scan_epoch: F,
+) -> (Vec<UnparsableRow>, Vec<EpochFailure>)
+where
+    F: FnMut(u64, &Path) -> Result<Vec<UnparsableRow>, diagnostics::ScanError>,
+{
+    let mut rows = Vec::new();
+    let mut failures = Vec::new();
+    for (epoch, path) in epoch_dirs {
+        match scan_epoch(*epoch, path) {
+            Ok(mut epoch_rows) => rows.append(&mut epoch_rows),
+            Err(error) => {
+                let error = format_chain(&error);
+                tracing::warn!(
+                    epoch,
+                    %error,
+                    "diagnostics scan for unparsable legacy epoch rows failed",
+                );
+                failures.push(EpochFailure {
+                    epoch: *epoch,
+                    error,
+                });
+            }
+        }
+    }
+    (rows, failures)
+}
+
+fn collect_numeric_epoch_dirs<I>(entries: I) -> Result<Vec<(u64, PathBuf)>, String>
+where
+    I: IntoIterator<Item = Result<EpochDirEntry, String>>,
+{
+    let mut numeric_dirs = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        if !entry.is_dir {
+            continue;
+        }
+        let Some(n) = entry.file_name.to_str().and_then(|s| s.parse::<u64>().ok()) else {
+            continue;
+        };
+        numeric_dirs.push((n, entry.path));
+    }
+    Ok(numeric_dirs)
+}
+
+fn format_chain(error: &dyn std::error::Error) -> String {
+    let mut out = error.to_string();
+    let mut next = error.source();
+    while let Some(cur) = next {
+        out.push_str(" -> ");
+        out.push_str(&cur.to_string());
+        next = cur.source();
+    }
+    // Squash whitespace runs so multi-line errors fit one log line.
+    let mut single_line = String::with_capacity(out.len());
+    let mut prev_space = false;
+    for c in out.chars() {
+        if c.is_whitespace() {
+            if !prev_space {
+                single_line.push(' ');
+                prev_space = true;
+            }
+        } else {
+            single_line.push(c);
+            prev_space = false;
+        }
+    }
+    single_line.trim().to_string()
+}
+
+#[cfg(test)]
+#[cfg(feature = "testutils")]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use agglayer_types::{CertificateIndex, Height, NetworkId};
+
+    use super::*;
+    use crate::{
+        columns::{
+            epochs::certificates::CertificatePerIndexColumn,
+            pending_queue::{PendingQueueColumn, PendingQueueKey},
+        },
+        schema::{Codec as _, ColumnSchema as _},
+        stores::{pending::cf_definitions::PENDING_DB_V0, per_epoch::cf_definitions::EPOCHS_DB_V0},
+        tests::TempDBDir,
+    };
+
+    fn seed_corrupt_pending_row(path: &Path, key: PendingQueueKey, value: Vec<u8>) {
+        let db = crate::storage::DB::open_cf(path, PENDING_DB_V0).unwrap();
+        let cf = db
+            .raw_rocksdb()
+            .cf_handle(PendingQueueColumn::COLUMN_FAMILY_NAME)
+            .unwrap();
+        db.raw_rocksdb()
+            .put_cf(&cf, key.encode().unwrap(), value)
+            .unwrap();
+    }
+
+    fn seed_corrupt_epoch_row(path: &Path, key: CertificateIndex, value: Vec<u8>) {
+        let db = crate::storage::DB::open_cf(path, EPOCHS_DB_V0).unwrap();
+        let cf = db
+            .raw_rocksdb()
+            .cf_handle(CertificatePerIndexColumn::COLUMN_FAMILY_NAME)
+            .unwrap();
+        db.raw_rocksdb()
+            .put_cf(&cf, key.encode().unwrap(), value)
+            .unwrap();
+    }
+
+    #[test]
+    fn missing_epochs_directory_is_a_fatal_outcome() {
+        let tmp = TempDBDir::new();
+        let epochs_path = tmp.path.join("missing-epochs");
+
+        let outcome = run(MigrateOptions {
+            state_db_path: None,
+            pending_db_path: None,
+            debug_db_path: None,
+            epochs_db_path: Some(epochs_path),
+            env_label: "test".into(),
+            skip_epochs: false,
+            latest_epochs: None,
+        });
+
+        assert_eq!(outcome.fatal_count(), 1);
+        assert!(!outcome.is_success());
+    }
+
+    #[test]
+    fn epoch_discovery_propagates_entry_errors() {
+        let entries: [Result<EpochDirEntry, String>; 1] = [Err("entry read failed".into())];
+
+        let error = collect_numeric_epoch_dirs(entries).unwrap_err();
+
+        assert_eq!(error, "entry read failed");
+    }
+
+    #[test]
+    fn latest_epochs_limits_epoch_diagnostics_to_processed_subset() {
+        let tmp = TempDBDir::new();
+        let epochs_dir = tmp.path.join("epochs");
+        std::fs::create_dir_all(&epochs_dir).unwrap();
+
+        seed_corrupt_epoch_row(
+            &epochs_dir.join("42"),
+            CertificateIndex::new(7),
+            vec![0xff_u8; 16],
+        );
+        std::fs::create_dir_all(epochs_dir.join("99")).unwrap();
+
+        let outcome = run(MigrateOptions {
+            state_db_path: None,
+            pending_db_path: None,
+            debug_db_path: None,
+            epochs_db_path: Some(epochs_dir),
+            env_label: "test".into(),
+            skip_epochs: false,
+            latest_epochs: Some(NonZeroU64::new(1).unwrap()),
+        });
+
+        assert_eq!(outcome.epochs.discovered, 2);
+        assert_eq!(outcome.epochs.processed, 1);
+        assert!(
+            outcome.epochs.unparsable_rows.is_empty(),
+            "diagnostics should not scan epochs outside the selected latest subset"
+        );
+    }
+
+    #[test]
+    fn epoch_diagnostics_preserve_rows_when_one_epoch_scan_fails() {
+        let good_path = PathBuf::from("42");
+        let bad_path = PathBuf::from("99");
+        let expected_rows = vec![UnparsableRow {
+            source: "epoch 42".into(),
+            cf: CertificatePerIndexColumn::COLUMN_FAMILY_NAME,
+            key_hex: "0000000000000007".into(),
+            error: "decode error".into(),
+        }];
+
+        let (rows, failures) =
+            collect_epoch_diagnostics(&[(42, good_path), (99, bad_path.clone())], |epoch, path| {
+                if epoch == 42 {
+                    Ok(expected_rows.clone())
+                } else {
+                    Err(diagnostics::ScanError::EpochDir {
+                        path: path.to_path_buf(),
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::PermissionDenied,
+                            "scan failed",
+                        ),
+                    })
+                }
+            });
+
+        assert_eq!(rows, expected_rows);
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].epoch, 99);
+        assert!(failures[0].error.contains("failed to read epoch directory"));
+        assert!(failures[0].error.contains(&bad_path.display().to_string()));
+    }
+
+    #[test]
+    fn outcome_surfaces_unparsable_rows_per_store() {
+        let tmp = TempDBDir::new();
+        let pending_path = tmp.path.join("pending");
+
+        // Two rows in the legacy CF: one valid, one corrupt.
+        let valid_v0_bytes = {
+            let p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("src/types/certificate/tests/encoded/v0-n15-cert_h0.hex");
+            hex::decode(std::fs::read_to_string(p).unwrap().trim()).unwrap()
+        };
+        seed_corrupt_pending_row(
+            &pending_path,
+            PendingQueueKey(NetworkId::new(15), Height::ZERO),
+            valid_v0_bytes,
+        );
+        seed_corrupt_pending_row(
+            &pending_path,
+            PendingQueueKey(NetworkId::new(15), Height::new(1)),
+            vec![0xff_u8; 16],
+        );
+
+        let outcome = run(MigrateOptions {
+            state_db_path: None,
+            pending_db_path: Some(pending_path),
+            debug_db_path: None,
+            epochs_db_path: None,
+            env_label: "test".into(),
+            skip_epochs: true,
+            latest_epochs: None,
+        });
+
+        let pending = outcome.pending.expect("pending store ran");
+        assert!(
+            pending.error.is_none(),
+            "init_db should succeed despite the corrupt row, got {:?}",
+            pending.error
+        );
+        assert_eq!(
+            pending.unparsable_rows.len(),
+            1,
+            "exactly the corrupt row should be reported, got {:?}",
+            pending.unparsable_rows
+        );
+        let row = &pending.unparsable_rows[0];
+        assert_eq!(row.source, "pending");
+        assert_eq!(row.cf, PendingQueueColumn::COLUMN_FAMILY_NAME);
+        let expected_key = PendingQueueKey(NetworkId::new(15), Height::new(1))
+            .encode()
+            .unwrap();
+        assert_eq!(row.key_hex, hex::encode(expected_key));
+    }
+
+    #[test]
+    fn outcome_unparsable_rows_empty_when_legacy_cf_is_clean() {
+        let tmp = TempDBDir::new();
+        let pending_path = tmp.path.join("pending");
+
+        // Initialise the pending DB with V0 schema; no rows seeded.
+        let _ = crate::storage::DB::open_cf(&pending_path, PENDING_DB_V0).unwrap();
+
+        let outcome = run(MigrateOptions {
+            state_db_path: None,
+            pending_db_path: Some(pending_path),
+            debug_db_path: None,
+            epochs_db_path: None,
+            env_label: "test".into(),
+            skip_epochs: true,
+            latest_epochs: None,
+        });
+
+        let pending = outcome.pending.expect("pending store ran");
+        assert!(pending.error.is_none());
+        assert!(
+            pending.unparsable_rows.is_empty(),
+            "no unparsable rows expected, got {:?}",
+            pending.unparsable_rows
+        );
+    }
+}

--- a/crates/agglayer-storage/src/storage/migration/error.rs
+++ b/crates/agglayer-storage/src/storage/migration/error.rs
@@ -34,6 +34,24 @@ pub enum DBOpenError {
         path.display()
     )]
     StorageNeedsMigration { path: PathBuf, status: SchemaStatus },
+
+    #[error(
+        "Storage at {} could not be inspected ({reason}); resolve the underlying I/O or \
+         permission error before starting agglayer-node",
+        path.display()
+    )]
+    StorageInspectionFailed { path: PathBuf, reason: String },
+
+    #[error(
+        "Storage at {} was written by a newer agglayer-node (recorded {recorded} migration \
+         steps, this binary declares {declared}); upgrade agglayer-node before starting it",
+        path.display()
+    )]
+    StorageFromNewerVersion {
+        path: PathBuf,
+        declared: u32,
+        recorded: u32,
+    },
 }
 
 #[derive(Debug, Error)]

--- a/crates/agglayer-storage/src/storage/migration/inspection.rs
+++ b/crates/agglayer-storage/src/storage/migration/inspection.rs
@@ -359,4 +359,89 @@ mod tests {
             SchemaStatus::MigrationRecordGap(0)
         );
     }
+
+    #[test]
+    fn open_migrated_or_create_reports_inspection_failure_for_unreadable_storage() {
+        let tmp = TempDBDir::new();
+        let path = tmp.path.join("not-rocksdb");
+        std::fs::write(&path, b"not a rocksdb directory").unwrap();
+
+        let error = match open_migrated_or_create(&path, LEGACY, CURRENT, 2, open_current) {
+            Ok(_) => panic!("unreadable storage must not be opened"),
+            Err(error) => error,
+        };
+
+        // An I/O/permission failure while inspecting must not be reported as a
+        // migration requirement: migration cannot fix it and it may be transient.
+        let message = error.to_string();
+        assert!(
+            !message.contains("needs migration"),
+            "inspection failure should not be reported as needing migration: {message}"
+        );
+        assert!(
+            matches!(error, DBOpenError::StorageInspectionFailed { .. }),
+            "expected StorageInspectionFailed, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn open_migrated_or_create_reports_newer_version_for_future_records() {
+        let tmp = TempDBDir::new();
+        // Current data CFs plus the migration-record CF, but with more records
+        // than this binary declares: the DB was written by a newer binary.
+        create_raw_db(
+            &tmp.path,
+            [
+                MetadataColumn::COLUMN_FAMILY_NAME,
+                NetworkInfoColumn::COLUMN_FAMILY_NAME,
+                MigrationRecordColumn::COLUMN_FAMILY_NAME,
+            ],
+        );
+        let db = rocksdb::DB::open_cf(
+            &rocksdb::Options::default(),
+            &tmp.path,
+            [
+                MetadataColumn::COLUMN_FAMILY_NAME,
+                NetworkInfoColumn::COLUMN_FAMILY_NAME,
+                MigrationRecordColumn::COLUMN_FAMILY_NAME,
+            ],
+        )
+        .unwrap();
+        let cf = db
+            .cf_handle(MigrationRecordColumn::COLUMN_FAMILY_NAME)
+            .unwrap();
+        for step in 0..3_u32 {
+            db.put_cf(
+                cf,
+                step.encode().unwrap(),
+                MigrationRecord::default().encode().unwrap(),
+            )
+            .unwrap();
+        }
+        drop(db);
+
+        let error = match open_migrated_or_create(&tmp.path, LEGACY, CURRENT, 2, open_current) {
+            Ok(_) => panic!("storage written by a newer binary must not be opened"),
+            Err(error) => error,
+        };
+
+        // Telling the operator to "run explicit storage migration" is wrong
+        // remediation here; the correct action is to upgrade the binary.
+        let message = error.to_string();
+        assert!(
+            !message.contains("needs migration"),
+            "future-version storage should not be reported as needing migration: {message}"
+        );
+        assert!(
+            matches!(
+                error,
+                DBOpenError::StorageFromNewerVersion {
+                    declared: 2,
+                    recorded: 3,
+                    ..
+                }
+            ),
+            "expected StorageFromNewerVersion {{ declared: 2, recorded: 3 }}, got {error:?}"
+        );
+    }
 }

--- a/crates/agglayer-storage/src/storage/migration/inspection.rs
+++ b/crates/agglayer-storage/src/storage/migration/inspection.rs
@@ -110,11 +110,6 @@ pub fn inspect_schema(
         return out;
     }
 
-    if data_cfs != legacy && data_cfs != current {
-        out.status = SchemaStatus::UnsupportedSchema;
-        return out;
-    }
-
     let recorded_steps = match recorded_steps(path) {
         Ok(steps) => steps,
         Err(error) => {
@@ -132,11 +127,24 @@ pub fn inspect_schema(
     }
 
     let recorded = u32::try_from(recorded_steps.len()).unwrap_or(u32::MAX);
+
+    // Check for newer-version storage before rejecting unknown CF sets: a
+    // database with more recorded steps than this binary declares was written
+    // by a newer agglayer-node, which may have added column families this
+    // binary does not recognize. Report it as a version mismatch (upgrade the
+    // binary) rather than an unsupported schema or a migration requirement.
     if recorded > declared_steps {
         out.status = SchemaStatus::FutureMigrationRecords {
             declared: declared_steps,
             recorded,
         };
+        return out;
+    }
+
+    // Records are valid and within the declared range, so the CF set must match
+    // a schema this binary recognizes.
+    if data_cfs != legacy && data_cfs != current {
+        out.status = SchemaStatus::UnsupportedSchema;
         return out;
     }
 
@@ -314,7 +322,11 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_schema_with_future_records_is_unsupported() {
+    fn future_records_with_unknown_cfs_report_newer_version() {
+        // An unknown CF set combined with more recorded steps than declared
+        // means a newer binary added that CF in a later migration. The operator
+        // should upgrade, not migrate, so this must be FutureMigrationRecords
+        // (not UnsupportedSchema).
         let tmp = TempDBDir::new();
         create_raw_db(
             &tmp.path,
@@ -339,7 +351,13 @@ mod tests {
         }
         drop(db);
 
-        assert_eq!(inspect(&tmp.path).status, SchemaStatus::UnsupportedSchema);
+        assert_eq!(
+            inspect(&tmp.path).status,
+            SchemaStatus::FutureMigrationRecords {
+                declared: 2,
+                recorded: 3,
+            }
+        );
     }
 
     #[test]

--- a/crates/agglayer-storage/src/storage/migration/mod.rs
+++ b/crates/agglayer-storage/src/storage/migration/mod.rs
@@ -30,6 +30,23 @@ pub(crate) fn open_migrated_or_create(
     let inspection = inspect_schema(path, cfs_v0, current_cfs, declared_steps);
     match inspection.status {
         SchemaStatus::Missing | SchemaStatus::Empty | SchemaStatus::Current => open(path),
+        // A failed inspection is an I/O/permission problem, not a migration
+        // requirement: surface it as such so operators don't run a migration
+        // that cannot fix it.
+        SchemaStatus::Unreadable(reason) => Err(DBOpenError::StorageInspectionFailed {
+            path: path.to_path_buf(),
+            reason,
+        }),
+        // More recorded steps than this binary declares means the storage was
+        // written by a newer agglayer-node; the fix is to upgrade the binary,
+        // not to migrate forward.
+        SchemaStatus::FutureMigrationRecords { declared, recorded } => {
+            Err(DBOpenError::StorageFromNewerVersion {
+                path: path.to_path_buf(),
+                declared,
+                recorded,
+            })
+        }
         status => Err(DBOpenError::StorageNeedsMigration {
             path: path.to_path_buf(),
             status,

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -47,6 +47,18 @@ mod settlement;
 #[cfg(test)]
 mod tests;
 
+/// Number of migration steps `init_db` performs and records in
+/// `migration_record_v0_cf`. It must equal that recorded step count: the open
+/// gate (`open_migrated_or_create_db`) classifies freshly created storage as
+/// `Current` only when `recorded == DECLARED_MIGRATION_STEPS`.
+///
+/// Update this whenever a migration step is added to or removed from `init_db`
+/// (today: `Builder::open` records step 0 and `ensure_cfs` records step 1). A
+/// stale value cannot cause data loss, but it is not silent: the
+/// `migrated_or_create_state_roundtrips_as_current` test (via
+/// `crate::tests::assert_storage_gate_roundtrips`) creates storage through the
+/// gate and re-opens it, so a wrong value fails in CI rather than rejecting
+/// freshly created storage at node startup.
 const DECLARED_MIGRATION_STEPS: u32 = 2;
 
 /// A logical store for the state.

--- a/crates/agglayer-storage/src/stores/state/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/tests.rs
@@ -188,6 +188,16 @@ fn migrated_or_create_state_rejects_legacy_storage_without_mutating_it() {
     ));
 }
 
+#[test]
+fn migrated_or_create_state_roundtrips_as_current() {
+    // Guards DECLARED_MIGRATION_STEPS against init_db's actual recorded-step
+    // count: storage created through the gate must re-open through the gate as
+    // Current. If a future change adds or removes a migration step in init_db
+    // without updating DECLARED_MIGRATION_STEPS, this fails in CI instead of
+    // the node rejecting freshly created storage on restart.
+    crate::tests::assert_storage_gate_roundtrips(StateStore::open_migrated_or_create_db);
+}
+
 fn equal_state(lhs: &LocalNetworkStateData, rhs: &LocalNetworkStateData) -> bool {
     // local exit tree
     assert_eq!(lhs.exit_tree.leaf_count(), rhs.exit_tree.leaf_count());

--- a/crates/agglayer-storage/src/tests.rs
+++ b/crates/agglayer-storage/src/tests.rs
@@ -48,3 +48,33 @@ impl Drop for TempDBDir {
         _ = std::fs::remove_dir_all(&self.path);
     }
 }
+
+/// Asserts that a store's migration gate round-trips: storage created through
+/// `open_gate` must re-open through the same gate as `SchemaStatus::Current`.
+///
+/// This guards the coupling between a store's `DECLARED_MIGRATION_STEPS`
+/// constant and the number of migration steps its `init_db` actually records.
+/// If they drift, the second open returns `DBOpenError::StorageNeedsMigration`
+/// and this assertion fails in CI, instead of the node rejecting storage it
+/// just created on its next restart.
+///
+/// Pass each store's `open_migrated_or_create_db` (e.g.
+/// `StateStore::open_migrated_or_create_db`).
+pub fn assert_storage_gate_roundtrips<F>(open_gate: F)
+where
+    F: Fn(&std::path::Path) -> Result<crate::storage::DB, crate::storage::DBOpenError>,
+{
+    let tmp = TempDBDir::new();
+    let path = tmp.path.join("gate-roundtrip");
+
+    // First open creates and migrates fresh storage.
+    open_gate(&path).expect("migration gate should create fresh storage on first open");
+
+    // Storage created through the gate must re-open through the same gate.
+    // A failure here means DECLARED_MIGRATION_STEPS is out of sync with the
+    // number of steps init_db records.
+    open_gate(&path).expect(
+        "storage created through the migration gate must re-open as Current; \
+         DECLARED_MIGRATION_STEPS is out of sync with init_db's recorded step count",
+    );
+}


### PR DESCRIPTION
Add the storage migration runner and diagnostics outcome model.

This migrates legacy storage column families to the current schema and records per-store diagnostics so migration results can be inspected before node startup.