### PR TITLE
feat(cli): add storage migration command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,9 @@ dependencies = [
  "agglayer-config",
  "agglayer-node",
  "agglayer-storage",
+ "askama",
  "assert_cmd",
+ "chrono",
  "clap",
  "color-eyre",
  "dirs 6.0.0",
@@ -2010,6 +2012,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,6 +2747,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bech32"

--- a/crates/agglayer/Cargo.toml
+++ b/crates/agglayer/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+askama = "0.14"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { workspace = true, features = ["derive", "env", "string"] }
 dirs.workspace = true
 dotenvy.workspace = true

--- a/crates/agglayer/askama.toml
+++ b/crates/agglayer/askama.toml
@@ -1,0 +1,2 @@
+[general]
+dirs = ["src/templates"]

--- a/crates/agglayer/src/cli.rs
+++ b/crates/agglayer/src/cli.rs
@@ -1,5 +1,8 @@
 //! Agglayer command line interface.
-use std::path::{Path, PathBuf};
+use std::{
+    num::NonZeroU64,
+    path::{Path, PathBuf},
+};
 
 use clap::{Parser, Subcommand, ValueHint};
 
@@ -48,6 +51,63 @@ pub(crate) enum Commands {
 
     #[clap(subcommand)]
     Backup(Backup),
+
+    /// Run the storage migration in place against the configured or selected
+    /// data directory. Brings every store (state, pending, debug, every epoch)
+    /// up to the current schema. Running this command may modify selected
+    /// stores.
+    MigrateStorage {
+        /// Path to the agglayer configuration file. Migration paths are
+        /// derived from `[storage]`.
+        #[arg(long, short, value_hint = ValueHint::FilePath, default_value = "agglayer.toml", env = "AGGLAYER_CONFIG_PATH")]
+        cfg: PathBuf,
+
+        /// Override the configured storage directory. The command derives
+        /// `state`, `pending`, `debug`, and `epochs` paths directly under
+        /// this root. Running `migrate-storage` may modify those stores.
+        #[arg(long, value_hint = ValueHint::DirPath, env = "AGGLAYER_MIGRATION_STORAGE_PATH")]
+        storage_path: Option<PathBuf>,
+
+        /// Operator-supplied environment label (`mainnet`, `testnet`, …)
+        /// used in the markdown report's heading and filename. Defaults
+        /// to the configured data directory's basename, or `local` when
+        /// the basename cannot be derived.
+        #[arg(long, env = "AGGLAYER_MIGRATION_ENV_LABEL")]
+        env_label: Option<String>,
+
+        /// Skip the epoch sweep entirely; only state, pending, and debug
+        /// run. Useful when iterating on the upgrade procedure or when
+        /// epoch migration was already done in a previous run.
+        #[arg(long)]
+        skip_epochs: bool,
+
+        /// Cap the epoch sweep to the N most-recent epochs (highest
+        /// numeric names first). Useful for spot checks: the active
+        /// data lives at the latest epochs while the lowest-numbered
+        /// ones are typically empty.
+        #[arg(long)]
+        latest_epochs: Option<NonZeroU64>,
+
+        /// Write the markdown report to this file path. By default the
+        /// markdown is printed to stdout; pass this flag to redirect it
+        /// to a file instead. The flag is independent of `--html-file`,
+        /// so you can request both, neither, or either.
+        #[arg(long, value_hint = ValueHint::FilePath)]
+        markdown_file: Option<PathBuf>,
+
+        /// Write the HTML report to this file path. When unset, no HTML
+        /// is produced. The HTML is self-contained (no external
+        /// resources) and openable in any browser.
+        #[arg(long, value_hint = ValueHint::FilePath)]
+        html_file: Option<PathBuf>,
+
+        /// Suppress the non-zero exit on fatal store outcomes. By
+        /// default the command exits non-zero when any store fails so
+        /// CI/orchestration sees the failure; pass this flag to keep
+        /// the run "advisory" (markdown report still flags failures).
+        #[arg(long)]
+        no_fail_on_error: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -132,8 +192,64 @@ fn parse_db_kind_version(s: &str) -> Result<(DbKind, u32), String> {
 #[cfg(test)]
 mod tests {
     use agglayer_config::Config;
+    use clap::Parser;
 
     use super::*;
+
+    #[test]
+    fn migrate_storage_rejects_zero_latest_epochs() {
+        let err = match Cli::try_parse_from(["agglayer", "migrate-storage", "--latest-epochs", "0"])
+        {
+            Ok(_) => panic!("zero latest-epochs should be rejected at the CLI boundary"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("latest-epochs"),
+            "error should mention the rejected flag, got {err}"
+        );
+    }
+
+    #[test]
+    fn migrate_storage_accepts_explicit_storage_path() {
+        let cli = Cli::try_parse_from([
+            "agglayer",
+            "migrate-storage",
+            "--storage-path",
+            "/var/lib/agglayer/storage",
+        ])
+        .unwrap();
+
+        match cli.cmd {
+            Commands::MigrateStorage { storage_path, .. } => {
+                assert_eq!(
+                    storage_path.unwrap(),
+                    PathBuf::from("/var/lib/agglayer/storage")
+                );
+            }
+            _ => panic!("expected migrate-storage command"),
+        }
+    }
+
+    #[test]
+    fn migrate_storage_rejects_dry_run_flag() {
+        let err = match Cli::try_parse_from(["agglayer", "migrate-storage", "--dry-run"]) {
+            Ok(_) => panic!("dry-run should be rejected at the CLI boundary"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn rejects_storage_doctor_subcommand() {
+        let err = match Cli::try_parse_from(["agglayer", "storage-doctor", "list"]) {
+            Ok(_) => panic!("storage-doctor should not be exposed in this CLI"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+    }
 
     #[test]
     fn testing_path_state() {

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -1,4 +1,4 @@
-use std::process::exit;
+use std::{path::Path, process::exit};
 
 use agglayer_config::storage::backup::BackupConfig;
 use clap::Parser;
@@ -8,6 +8,7 @@ use pessimistic_proof::ELF;
 use sp1_sdk::HashableKey as _;
 
 mod cli;
+mod migrate_report;
 
 fn main() -> eyre::Result<()> {
     install_default_crypto_provider();
@@ -86,6 +87,70 @@ fn main() -> eyre::Result<()> {
                 exit(1);
             }
         }
+
+        cli::Commands::MigrateStorage {
+            cfg,
+            storage_path,
+            env_label,
+            skip_epochs,
+            latest_epochs,
+            markdown_file,
+            html_file,
+            no_fail_on_error,
+        } => {
+            let storage = match storage_path.as_deref() {
+                Some(root) => agglayer_config::storage::StorageConfig {
+                    metadata_db_path: root.join("metadata"),
+                    pending_db_path: root.join("pending"),
+                    state_db_path: root.join("state"),
+                    epochs_db_path: root.join("epochs"),
+                    debug_db_path: root.join("debug"),
+                    backup: Default::default(),
+                },
+                None => agglayer_config::Config::try_load(&cfg)?.storage,
+            };
+
+            let env_label = env_label.unwrap_or_else(|| default_env_label(&storage.state_db_path));
+
+            let opts = agglayer_storage::migrate::MigrateOptions {
+                state_db_path: Some(storage.state_db_path),
+                pending_db_path: Some(storage.pending_db_path),
+                debug_db_path: Some(storage.debug_db_path),
+                epochs_db_path: Some(storage.epochs_db_path),
+                env_label,
+                skip_epochs,
+                latest_epochs,
+            };
+
+            let outcome = agglayer_storage::migrate::run(opts);
+
+            // Default behaviour: print the markdown report to stdout so
+            // the operator immediately sees the outcome. If the operator
+            // explicitly redirected markdown to a file, we surface the
+            // file path on stderr instead (and skip stdout to avoid
+            // duplicating the report).
+            match markdown_file.as_deref() {
+                None => println!("{}", migrate_report::render_markdown(&outcome)),
+                Some(path) => {
+                    migrate_report::write_to_file(path, &migrate_report::render_markdown(&outcome))
+                        .with_context(|| {
+                            format!("failed to write markdown report to {}", path.display())
+                        })?;
+                    eprintln!("Markdown report: {}", path.display());
+                }
+            }
+            if let Some(path) = html_file.as_deref() {
+                migrate_report::write_to_file(path, &migrate_report::render_html(&outcome))
+                    .with_context(|| {
+                        format!("failed to write HTML report to {}", path.display())
+                    })?;
+                eprintln!("HTML report:     {}", path.display());
+            }
+
+            if !no_fail_on_error && !outcome.is_success() {
+                exit(1);
+            }
+        }
     }
 
     Ok(())
@@ -95,6 +160,28 @@ fn install_default_crypto_provider() {
     // rustls cannot infer a provider when transitive dependencies enable both
     // built-in crypto backends. Install one before any TLS client is built.
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
+fn default_env_label(state_db_path: &Path) -> String {
+    let Some(storage_dir) = state_db_path.parent() else {
+        return "local".to_string();
+    };
+
+    let label_path = if storage_dir
+        .file_name()
+        .is_some_and(|name| name == "storage")
+    {
+        storage_dir.parent().unwrap_or(storage_dir)
+    } else {
+        storage_dir
+    };
+
+    label_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("local")
+        .to_string()
 }
 
 /// Common version information about the executed agglayer binary.
@@ -114,10 +201,33 @@ pub async fn compute_program_vkey(program: &'static [u8]) -> eyre::Result<String
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn installs_a_default_rustls_crypto_provider() {
-        super::install_default_crypto_provider();
+        install_default_crypto_provider();
 
         assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
+
+    #[test]
+    fn default_env_label_uses_data_directory_basename() {
+        assert_eq!(
+            default_env_label(Path::new("/var/lib/agglayer-mainnet/storage/state")),
+            "agglayer-mainnet"
+        );
+    }
+
+    #[test]
+    fn default_env_label_falls_back_to_parent_for_custom_store_layout() {
+        assert_eq!(
+            default_env_label(Path::new("/var/lib/agglayer-mainnet/state")),
+            "agglayer-mainnet"
+        );
+    }
+
+    #[test]
+    fn default_env_label_is_local() {
+        assert_eq!(default_env_label(Path::new("state")), "local");
     }
 }

--- a/crates/agglayer/src/migrate_report.rs
+++ b/crates/agglayer/src/migrate_report.rs
@@ -1,0 +1,903 @@
+//! Report rendering for the `migrate-storage` CLI subcommand.
+//!
+//! This module is the operator-output side of the migration. The
+//! migration runner in [`agglayer_storage::migrate`] returns a
+//! [`MigrateOutcome`] of pure data; we turn that data into a markdown
+//! report (printed to stdout by default) and an optional self-contained
+//! HTML report (when the operator passes `--html-file`).
+//!
+//! Templates live under `crates/agglayer/src/templates/` and are compiled
+//! into the binary by `askama`. Anything format-related (durations,
+//! timestamps, status badges, paths) is pre-flattened into the small
+//! view-model structs below so the templates stay declarative.
+
+use std::{
+    fs,
+    path::Path,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use agglayer_storage::migrate::{EpochsResult, MigrateOutcome, StoreResult};
+use askama::Template;
+use chrono::{DateTime, Utc};
+
+/// Render the markdown report for a migration outcome.
+pub fn render_markdown(outcome: &MigrateOutcome) -> String {
+    MarkdownReport::from_outcome(outcome)
+        .render()
+        .expect("markdown template renders")
+}
+
+/// Render the self-contained HTML report for a migration outcome.
+pub fn render_html(outcome: &MigrateOutcome) -> String {
+    HtmlReport::from_outcome(outcome)
+        .render()
+        .expect("HTML template renders")
+}
+
+/// Write `contents` to `path`, creating the parent directory if needed.
+pub fn write_to_file(path: &Path, contents: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    fs::write(path, contents)
+}
+
+// ---------------------------------------------------------------------------
+// Markdown
+// ---------------------------------------------------------------------------
+
+#[derive(Template)]
+#[template(path = "migration-report.md", escape = "none")]
+struct MarkdownReport<'a> {
+    env_label: &'a str,
+    started_at: String,
+    overall_duration: String,
+    is_success: bool,
+    status_label: &'static str,
+    rows: Vec<RowVm>,
+    fatals: Vec<FatalVm>,
+    diagnostics_warnings: Vec<DiagnosticWarningVm>,
+    unparsable: Vec<UnparsableRowVm>,
+    unparsable_count: usize,
+    has_unparsable: bool,
+}
+
+struct RowVm {
+    label: String,
+    status: String,
+    duration: String,
+    notes: String,
+}
+
+struct FatalVm {
+    label: String,
+    error: String,
+}
+
+struct DiagnosticWarningVm {
+    label: String,
+    error: String,
+}
+
+#[derive(Clone)]
+struct UnparsableRowVm {
+    source: String,
+    cf: String,
+    key_hex: String,
+    error: String,
+}
+
+impl<'a> MarkdownReport<'a> {
+    fn from_outcome(o: &'a MigrateOutcome) -> Self {
+        let is_success = o.is_success();
+        let status_label = if is_success { "OK" } else { "FAILED" };
+
+        let rows = vec![
+            store_row(o.state.as_ref(), "state"),
+            store_row(o.pending.as_ref(), "pending"),
+            store_row(o.debug.as_ref(), "debug"),
+            epochs_row(&o.epochs),
+        ];
+
+        let mut fatals = Vec::new();
+        for r in [o.state.as_ref(), o.pending.as_ref(), o.debug.as_ref()]
+            .into_iter()
+            .flatten()
+        {
+            if let Some(err) = &r.error {
+                fatals.push(FatalVm {
+                    label: r.label.clone(),
+                    error: err.clone(),
+                });
+            }
+        }
+        if let Some(err) = &o.epochs.discovery_error {
+            fatals.push(FatalVm {
+                label: "epochs".into(),
+                error: err.clone(),
+            });
+        }
+        for f in &o.epochs.failed {
+            fatals.push(FatalVm {
+                label: format!("epoch {}", f.epoch),
+                error: f.error.clone(),
+            });
+        }
+        let mut diagnostics_warnings = [&o.state, &o.pending, &o.debug]
+            .iter()
+            .filter_map(|s| s.as_ref())
+            .filter_map(|s| {
+                s.diagnostics_error
+                    .as_ref()
+                    .map(|error| DiagnosticWarningVm {
+                        label: s.label.clone(),
+                        error: error.clone(),
+                    })
+            })
+            .collect::<Vec<_>>();
+        diagnostics_warnings.extend(o.epochs.diagnostics_failures.iter().map(|f| {
+            DiagnosticWarningVm {
+                label: format!("epoch {}", f.epoch),
+                error: f.error.clone(),
+            }
+        }));
+
+        let unparsable = collect_unparsable(o);
+        let unparsable_count = unparsable.len();
+
+        Self {
+            env_label: &o.env_label,
+            started_at: format_time(o.started_at),
+            overall_duration: format_duration(o.overall_duration),
+            is_success,
+            status_label,
+            rows,
+            fatals,
+            diagnostics_warnings,
+            has_unparsable: !unparsable.is_empty(),
+            unparsable_count,
+            unparsable,
+        }
+    }
+}
+
+/// Flatten every store's unparsable rows into a single, deterministically-
+/// ordered list (state, pending, debug, epochs) for the markdown summary
+/// section. The HTML report keeps the per-store buckets separate.
+fn collect_unparsable(o: &MigrateOutcome) -> Vec<UnparsableRowVm> {
+    let mut out = Vec::new();
+    for store in [&o.state, &o.pending, &o.debug]
+        .iter()
+        .filter_map(|s| s.as_ref())
+    {
+        for u in &store.unparsable_rows {
+            out.push(UnparsableRowVm {
+                source: u.source.clone(),
+                cf: u.cf.to_string(),
+                key_hex: u.key_hex.clone(),
+                error: u.error.clone(),
+            });
+        }
+    }
+    for u in &o.epochs.unparsable_rows {
+        out.push(UnparsableRowVm {
+            source: u.source.clone(),
+            cf: u.cf.to_string(),
+            key_hex: u.key_hex.clone(),
+            error: u.error.clone(),
+        });
+    }
+    out
+}
+
+fn store_row(store: Option<&StoreResult>, fallback_label: &str) -> RowVm {
+    let Some(r) = store else {
+        return RowVm {
+            label: fallback_label.into(),
+            status: "—".into(),
+            duration: "—".into(),
+            notes: "not configured for this deployment".into(),
+        };
+    };
+    let unparsable_count = r.unparsable_rows.len();
+    let (status, notes) = match &r.error {
+        None => {
+            let notes = match (&r.diagnostics_error, unparsable_count) {
+                (Some(error), 0) => format!("diagnostics failed: {error}"),
+                (Some(error), _) => {
+                    format!("{unparsable_count} unparsable rows; diagnostics failed: {error}")
+                }
+                (None, count) if count > 0 => format!("{count} unparsable rows"),
+                (None, _) => "—".to_string(),
+            };
+            let status = if r.diagnostics_error.is_some() {
+                "⚠️ INCOMPLETE"
+            } else {
+                "✅ OK"
+            };
+            (status.to_string(), notes)
+        }
+        Some(e) => ("❌ FAILED".to_string(), e.clone()),
+    };
+    RowVm {
+        label: r.label.clone(),
+        status,
+        duration: format_duration(r.duration),
+        notes,
+    }
+}
+
+fn epochs_row(epochs: &EpochsResult) -> RowVm {
+    if epochs.epochs_dir.is_none() {
+        return RowVm {
+            label: "epochs".into(),
+            status: "—".into(),
+            duration: "—".into(),
+            notes: "not configured for this deployment".into(),
+        };
+    }
+    if let Some(reason) = epochs.skipped_reason {
+        return RowVm {
+            label: "epochs".into(),
+            status: "—".into(),
+            duration: "—".into(),
+            notes: reason.to_string(),
+        };
+    }
+    if let Some(error) = &epochs.discovery_error {
+        return RowVm {
+            label: "epochs".into(),
+            status: "❌ FAILED".into(),
+            duration: format_duration(epochs.duration),
+            notes: error.clone(),
+        };
+    }
+    let status = if epochs.failed.is_empty() {
+        "✅ OK"
+    } else {
+        "❌ FAILED"
+    };
+    let mut notes = format!(
+        "{} processed; {} OK; {} failed",
+        epochs.processed,
+        epochs.successful,
+        epochs.failed.len(),
+    );
+    let unparsable_count = epochs.unparsable_rows.len();
+    if unparsable_count > 0 {
+        notes.push_str(&format!("; {unparsable_count} unparsable"));
+    }
+    let diagnostics_failure_count = epochs.diagnostics_failures.len();
+    if diagnostics_failure_count > 0 {
+        notes.push_str(&format!("; {diagnostics_failure_count} diagnostics failed"));
+    }
+    RowVm {
+        label: "epochs".into(),
+        status: status.into(),
+        duration: format_duration(epochs.duration),
+        notes,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HTML
+// ---------------------------------------------------------------------------
+
+const STYLE: &str = include_str!("templates/migration-report.css");
+
+#[derive(Template)]
+#[template(path = "migration-report.html")]
+struct HtmlReport<'a> {
+    env_label: &'a str,
+    started_at: String,
+    overall_duration: String,
+    status_label: &'static str,
+    status_class: &'static str,
+    store_count: usize,
+    fatal_count: usize,
+    unparsable_total: usize,
+    unparsable_class: &'static str,
+    store_cards: Vec<StoreCardVm>,
+    epochs: EpochsCardVm,
+    path_rows: Vec<PathRowVm>,
+    style: &'static str,
+}
+
+struct StoreCardVm {
+    heading: &'static str,
+    skipped: bool,
+    label: String,
+    badge_class: &'static str,
+    badge_label: &'static str,
+    path: String,
+    duration: String,
+    has_error: bool,
+    error: String,
+    has_diagnostics_error: bool,
+    diagnostics_error: String,
+    has_unparsable: bool,
+    unparsable_count: usize,
+    unparsable: Vec<UnparsableRowVm>,
+}
+
+struct EpochsCardVm {
+    kind_not_configured: bool,
+    kind_skipped: bool,
+    skip_reason: String,
+    path: String,
+    badge_class: &'static str,
+    badge_label: &'static str,
+    discovered: usize,
+    processed: usize,
+    successful: usize,
+    failed_count: usize,
+    failed_class: &'static str,
+    duration: String,
+    has_discovery_error: bool,
+    discovery_error: String,
+    has_failures: bool,
+    failures: Vec<EpochFailureVm>,
+    has_diagnostics_failures: bool,
+    diagnostics_failure_count: usize,
+    diagnostics_failures: Vec<EpochFailureVm>,
+    has_unparsable: bool,
+    unparsable_count: usize,
+    unparsable: Vec<UnparsableRowVm>,
+}
+
+struct EpochFailureVm {
+    epoch: u64,
+    error: String,
+}
+
+struct PathRowVm {
+    label: &'static str,
+    path: String,
+}
+
+impl<'a> HtmlReport<'a> {
+    fn from_outcome(o: &'a MigrateOutcome) -> Self {
+        let is_success = o.is_success();
+        let (status_class, status_label) = if is_success {
+            ("success", "OK")
+        } else {
+            ("destructive", "FAILED")
+        };
+
+        let store_cards = vec![
+            store_card("State DB", o.state.as_ref()),
+            store_card("Pending DB", o.pending.as_ref()),
+            store_card("Debug DB", o.debug.as_ref()),
+        ];
+
+        let configured_store_count = [&o.state, &o.pending, &o.debug]
+            .iter()
+            .filter(|s| s.is_some())
+            .count();
+        let store_count = configured_store_count
+            + if o.epochs.epochs_dir.is_some() {
+                o.epochs.processed
+            } else {
+                0
+            };
+
+        let mut path_rows = Vec::new();
+        if let Some(s) = o.state.as_ref() {
+            path_rows.push(PathRowVm {
+                label: "state path",
+                path: s.path.display().to_string(),
+            });
+        }
+        if let Some(s) = o.pending.as_ref() {
+            path_rows.push(PathRowVm {
+                label: "pending path",
+                path: s.path.display().to_string(),
+            });
+        }
+        if let Some(s) = o.debug.as_ref() {
+            path_rows.push(PathRowVm {
+                label: "debug path",
+                path: s.path.display().to_string(),
+            });
+        }
+        if let Some(d) = o.epochs.epochs_dir.as_ref() {
+            path_rows.push(PathRowVm {
+                label: "epochs path",
+                path: d.display().to_string(),
+            });
+        }
+
+        let unparsable_total: usize = [&o.state, &o.pending, &o.debug]
+            .iter()
+            .filter_map(|s| s.as_ref())
+            .map(|s| s.unparsable_rows.len())
+            .sum::<usize>()
+            + o.epochs.unparsable_rows.len();
+
+        Self {
+            env_label: &o.env_label,
+            started_at: format_time(o.started_at),
+            overall_duration: format_duration(o.overall_duration),
+            status_label,
+            status_class,
+            store_count,
+            fatal_count: o.fatal_count(),
+            unparsable_total,
+            unparsable_class: if unparsable_total == 0 {
+                "success"
+            } else {
+                "warning"
+            },
+            store_cards,
+            epochs: epochs_card(&o.epochs),
+            path_rows,
+            style: STYLE,
+        }
+    }
+}
+
+fn store_card(heading: &'static str, store: Option<&StoreResult>) -> StoreCardVm {
+    let Some(s) = store else {
+        return StoreCardVm {
+            heading,
+            skipped: true,
+            label: String::new(),
+            badge_class: "muted",
+            badge_label: "SKIPPED",
+            path: String::new(),
+            duration: String::new(),
+            has_error: false,
+            error: String::new(),
+            has_diagnostics_error: false,
+            diagnostics_error: String::new(),
+            has_unparsable: false,
+            unparsable_count: 0,
+            unparsable: Vec::new(),
+        };
+    };
+    let (badge_class, badge_label) = match (&s.error, &s.diagnostics_error) {
+        (None, None) => ("success", "OK"),
+        (None, Some(_)) => ("warning", "INCOMPLETE"),
+        (Some(_), _) => ("destructive", "FAILED"),
+    };
+    let unparsable: Vec<UnparsableRowVm> = s
+        .unparsable_rows
+        .iter()
+        .map(|u| UnparsableRowVm {
+            source: u.source.clone(),
+            cf: u.cf.to_string(),
+            key_hex: u.key_hex.clone(),
+            error: u.error.clone(),
+        })
+        .collect();
+    StoreCardVm {
+        heading,
+        skipped: false,
+        label: s.label.clone(),
+        badge_class,
+        badge_label,
+        path: s.path.display().to_string(),
+        duration: format_duration(s.duration),
+        has_error: s.error.is_some(),
+        error: s.error.clone().unwrap_or_default(),
+        has_diagnostics_error: s.diagnostics_error.is_some(),
+        diagnostics_error: s.diagnostics_error.clone().unwrap_or_default(),
+        has_unparsable: !unparsable.is_empty(),
+        unparsable_count: unparsable.len(),
+        unparsable,
+    }
+}
+
+fn epochs_card(epochs: &EpochsResult) -> EpochsCardVm {
+    let unparsable: Vec<UnparsableRowVm> = epochs
+        .unparsable_rows
+        .iter()
+        .map(|u| UnparsableRowVm {
+            source: u.source.clone(),
+            cf: u.cf.to_string(),
+            key_hex: u.key_hex.clone(),
+            error: u.error.clone(),
+        })
+        .collect();
+    if epochs.epochs_dir.is_none() {
+        return EpochsCardVm {
+            kind_not_configured: true,
+            kind_skipped: false,
+            skip_reason: String::new(),
+            path: String::new(),
+            badge_class: "muted",
+            badge_label: "SKIPPED",
+            discovered: 0,
+            processed: 0,
+            successful: 0,
+            failed_count: 0,
+            failed_class: "success",
+            duration: String::new(),
+            has_discovery_error: false,
+            discovery_error: String::new(),
+            has_failures: false,
+            failures: Vec::new(),
+            has_diagnostics_failures: false,
+            diagnostics_failure_count: 0,
+            diagnostics_failures: Vec::new(),
+            has_unparsable: false,
+            unparsable_count: 0,
+            unparsable: Vec::new(),
+        };
+    }
+    if let Some(reason) = epochs.skipped_reason {
+        return EpochsCardVm {
+            kind_not_configured: false,
+            kind_skipped: true,
+            skip_reason: reason.to_string(),
+            path: epochs
+                .epochs_dir
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
+            badge_class: "muted",
+            badge_label: "SKIPPED",
+            discovered: 0,
+            processed: 0,
+            successful: 0,
+            failed_count: 0,
+            failed_class: "success",
+            duration: String::new(),
+            has_discovery_error: false,
+            discovery_error: String::new(),
+            has_failures: false,
+            failures: Vec::new(),
+            has_diagnostics_failures: false,
+            diagnostics_failure_count: 0,
+            diagnostics_failures: Vec::new(),
+            has_unparsable: !unparsable.is_empty(),
+            unparsable_count: unparsable.len(),
+            unparsable,
+        };
+    }
+    let has_discovery_error = epochs.discovery_error.is_some();
+    let (badge_class, badge_label) = if !has_discovery_error && epochs.failed.is_empty() {
+        ("success", "OK")
+    } else {
+        ("destructive", "FAILED")
+    };
+    let failed_count = epochs.failed.len() + usize::from(has_discovery_error);
+    let failed_class = if failed_count == 0 {
+        "success"
+    } else {
+        "destructive"
+    };
+    let failures = epochs
+        .failed
+        .iter()
+        .map(|f| EpochFailureVm {
+            epoch: f.epoch,
+            error: f.error.clone(),
+        })
+        .collect::<Vec<_>>();
+    let diagnostics_failures = epochs
+        .diagnostics_failures
+        .iter()
+        .map(|f| EpochFailureVm {
+            epoch: f.epoch,
+            error: f.error.clone(),
+        })
+        .collect::<Vec<_>>();
+    EpochsCardVm {
+        kind_not_configured: false,
+        kind_skipped: false,
+        skip_reason: String::new(),
+        path: epochs
+            .epochs_dir
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default(),
+        badge_class,
+        badge_label,
+        discovered: epochs.discovered,
+        processed: epochs.processed,
+        successful: epochs.successful,
+        failed_count,
+        failed_class,
+        duration: format_duration(epochs.duration),
+        has_discovery_error,
+        discovery_error: epochs.discovery_error.clone().unwrap_or_default(),
+        has_failures: !epochs.failed.is_empty(),
+        failures,
+        has_diagnostics_failures: !diagnostics_failures.is_empty(),
+        diagnostics_failure_count: diagnostics_failures.len(),
+        diagnostics_failures,
+        has_unparsable: !unparsable.is_empty(),
+        unparsable_count: unparsable.len(),
+        unparsable,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+/// `Duration` formatted the way the original report used it
+/// (`format!("{:.2?}", d)` -- e.g. `1.23s`, `345.67ms`).
+fn format_duration(d: Duration) -> String {
+    format!("{d:.2?}")
+}
+
+/// Format a `SystemTime` as `YYYY-MM-DD HH:MM:SS` UTC.
+fn format_time(t: SystemTime) -> String {
+    let secs = t.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() as i64;
+    DateTime::<Utc>::from_timestamp(secs, 0)
+        .unwrap_or(DateTime::<Utc>::UNIX_EPOCH)
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::PathBuf,
+        time::{Duration, UNIX_EPOCH},
+    };
+
+    use agglayer_storage::migrate::{
+        EpochFailure, EpochsResult, MigrateOutcome, StoreResult, UnparsableRow,
+    };
+
+    use super::*;
+
+    /// Fixed instant so duration / timestamp formatting is deterministic
+    /// across runs. Picked to land at `2024-01-15 12:34:56 UTC`.
+    fn fixed_started_at() -> std::time::SystemTime {
+        UNIX_EPOCH + Duration::from_secs(1_705_321_896)
+    }
+
+    fn outcome_all_ok() -> MigrateOutcome {
+        MigrateOutcome {
+            started_at: fixed_started_at(),
+            overall_duration: Duration::from_millis(1_234),
+            env_label: "mainnet".into(),
+            state: Some(StoreResult {
+                label: "state".into(),
+                path: PathBuf::from("/var/agglayer/state"),
+                duration: Duration::from_millis(120),
+                error: None,
+                unparsable_rows: Vec::new(),
+                diagnostics_error: None,
+            }),
+            pending: Some(StoreResult {
+                label: "pending".into(),
+                path: PathBuf::from("/var/agglayer/pending"),
+                duration: Duration::from_millis(45),
+                error: None,
+                unparsable_rows: Vec::new(),
+                diagnostics_error: None,
+            }),
+            debug: Some(StoreResult {
+                label: "debug".into(),
+                path: PathBuf::from("/var/agglayer/debug"),
+                duration: Duration::from_millis(30),
+                error: None,
+                unparsable_rows: Vec::new(),
+                diagnostics_error: None,
+            }),
+            epochs: EpochsResult {
+                epochs_dir: Some(PathBuf::from("/var/agglayer/epochs")),
+                discovered: 5,
+                processed: 5,
+                successful: 5,
+                discovery_error: None,
+                failed: Vec::new(),
+                duration: Duration::from_millis(800),
+                skipped_reason: None,
+                unparsable_rows: Vec::new(),
+                diagnostics_failures: Vec::new(),
+            },
+        }
+    }
+
+    fn outcome_with_failures() -> MigrateOutcome {
+        MigrateOutcome {
+            state: Some(StoreResult {
+                label: "state".into(),
+                path: PathBuf::from("/var/agglayer/state"),
+                duration: Duration::from_millis(120),
+                error: Some("schema mismatch".into()),
+                unparsable_rows: Vec::new(),
+                diagnostics_error: None,
+            }),
+            epochs: EpochsResult {
+                epochs_dir: Some(PathBuf::from("/var/agglayer/epochs")),
+                discovered: 3,
+                processed: 3,
+                successful: 1,
+                discovery_error: None,
+                failed: vec![
+                    EpochFailure {
+                        epoch: 17,
+                        error: "missing CF debug_certificates".into(),
+                    },
+                    EpochFailure {
+                        epoch: 42,
+                        error: "decode error".into(),
+                    },
+                ],
+                duration: Duration::from_millis(500),
+                skipped_reason: None,
+                unparsable_rows: Vec::new(),
+                diagnostics_failures: Vec::new(),
+            },
+            ..outcome_all_ok()
+        }
+    }
+
+    #[test]
+    fn markdown_all_ok_renders_expected_shape() {
+        insta::assert_snapshot!(
+            "migration_report_markdown_all_ok",
+            render_markdown(&outcome_all_ok())
+        );
+    }
+
+    #[test]
+    fn markdown_with_failures_lists_each_fatal() {
+        insta::assert_snapshot!(
+            "migration_report_markdown_with_failures",
+            render_markdown(&outcome_with_failures())
+        );
+    }
+
+    #[test]
+    fn epoch_discovery_errors_render_as_fatal() {
+        let mut o = outcome_all_ok();
+        o.epochs = EpochsResult {
+            epochs_dir: Some(PathBuf::from("/var/agglayer/epochs")),
+            discovery_error: Some("failed to read epoch directory".into()),
+            duration: Duration::from_millis(10),
+            ..EpochsResult::default()
+        };
+
+        insta::assert_snapshot!(
+            "migration_report_markdown_epoch_discovery_error",
+            render_markdown(&o)
+        );
+
+        insta::assert_snapshot!(
+            "migration_report_html_epoch_discovery_error",
+            render_html(&o)
+        );
+    }
+
+    #[test]
+    fn html_renders_self_contained_document() {
+        insta::assert_snapshot!(
+            "migration_report_html_self_contained_document",
+            render_html(&outcome_all_ok())
+        );
+    }
+
+    #[test]
+    fn html_escapes_user_supplied_strings() {
+        let mut o = outcome_all_ok();
+        o.env_label = "weird <env> & label".into();
+        if let Some(s) = o.state.as_mut() {
+            s.error = Some("oops <script>".into());
+        }
+        let html = render_html(&o);
+        insta::assert_snapshot!("migration_report_html_escapes_user_strings", html);
+        assert_eq!(html.find("<script>"), None);
+    }
+
+    #[test]
+    fn html_with_failures_has_destructive_styling() {
+        insta::assert_snapshot!(
+            "migration_report_html_with_failures",
+            render_html(&outcome_with_failures())
+        );
+    }
+
+    #[test]
+    fn diagnostics_failures_render_as_warnings_without_failing_run() {
+        let mut o = outcome_all_ok();
+        o.epochs.diagnostics_failures = vec![EpochFailure {
+            epoch: 99,
+            error: "read-only diagnostics open failed".into(),
+        }];
+
+        assert!(o.is_success());
+
+        insta::assert_snapshot!(
+            "migration_report_markdown_epoch_diagnostics_warnings",
+            render_markdown(&o)
+        );
+
+        insta::assert_snapshot!(
+            "migration_report_html_epoch_diagnostics_warnings",
+            render_html(&o)
+        );
+    }
+
+    #[test]
+    fn per_store_diagnostics_failures_render_as_incomplete_warnings() {
+        let mut o = outcome_all_ok();
+        if let Some(pending) = o.pending.as_mut() {
+            pending.diagnostics_error = Some("pending scan failed".into());
+        }
+
+        assert!(o.is_success());
+
+        insta::assert_snapshot!(
+            "migration_report_markdown_per_store_diagnostics_warning",
+            render_markdown(&o)
+        );
+
+        insta::assert_snapshot!(
+            "migration_report_html_per_store_diagnostics_warning",
+            render_html(&o)
+        );
+    }
+
+    #[test]
+    fn skipped_epochs_renders_skip_reason() {
+        let mut o = outcome_all_ok();
+        o.epochs = EpochsResult {
+            epochs_dir: Some(PathBuf::from("/var/agglayer/epochs")),
+            skipped_reason: Some("skipped via --skip-epochs"),
+            ..EpochsResult::default()
+        };
+        insta::assert_snapshot!(
+            "migration_report_markdown_skipped_epochs",
+            render_markdown(&o)
+        );
+        insta::assert_snapshot!("migration_report_html_skipped_epochs", render_html(&o));
+    }
+
+    fn outcome_with_unparsable_rows() -> MigrateOutcome {
+        let mut o = outcome_all_ok();
+        if let Some(p) = o.pending.as_mut() {
+            p.unparsable_rows = vec![
+                UnparsableRow {
+                    source: "pending".into(),
+                    cf: "pending_queue",
+                    key_hex: "00000000000000010000000000000005".into(),
+                    error: "invalid varint".into(),
+                },
+                UnparsableRow {
+                    source: "pending".into(),
+                    cf: "pending_queue",
+                    key_hex: "0000000000000002000000000000000a".into(),
+                    error: "BadCertificateVersion { version: 7 }".into(),
+                },
+            ];
+        }
+        o.epochs.unparsable_rows = vec![UnparsableRow {
+            source: "epoch 17".into(),
+            cf: "epoch_certificate_per_index",
+            key_hex: "0000000000000003".into(),
+            error: "decode error".into(),
+        }];
+        o
+    }
+
+    #[test]
+    fn markdown_lists_unparsable_rows_per_store() {
+        insta::assert_snapshot!(
+            "migration_report_markdown_with_unparsable_rows",
+            render_markdown(&outcome_with_unparsable_rows())
+        );
+    }
+
+    #[test]
+    fn html_with_unparsable_rows_renders_section_per_store() {
+        insta::assert_snapshot!(
+            "migration_report_html_with_unparsable_rows",
+            render_html(&outcome_with_unparsable_rows())
+        );
+    }
+}

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_epoch_diagnostics_warnings.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_epoch_diagnostics_warnings.snap
@@ -1,0 +1,225 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_html(&o)
+snapshot_kind: text
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storage migration report — mainnet</title>
+<style>:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --success: 142 71% 35%;
+  --warning: 38 92% 45%;
+  --destructive: 0 72% 50%;
+  --radius: 0.625rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --border: 240 3.7% 15.9%;
+    --success: 142 60% 45%;
+    --warning: 38 90% 55%;
+    --destructive: 0 70% 60%;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  margin: 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+header.page-header { margin-bottom: 2rem; }
+header.page-header h1 { font-size: 1.875rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.4rem; }
+header.page-header .meta { color: hsl(var(--muted-foreground)); font-size: 0.875rem; display: flex; flex-wrap: wrap; gap: 0.4rem 1.25rem; }
+h2 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; margin: 2.5rem 0 1rem; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: hsl(var(--muted)); padding: 0.1em 0.35em; border-radius: 4px; font-size: 0.875em; }
+.mono.break { word-break: break-all; }
+.kpi-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 1rem; }
+.kpi { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.kpi .kpi-label { color: hsl(var(--muted-foreground)); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; }
+.kpi .kpi-value { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-top: 0.4rem; }
+.kpi .kpi-value.success { color: hsl(var(--success)); }
+.kpi .kpi-value.warning { color: hsl(var(--warning)); }
+.kpi .kpi-value.destructive { color: hsl(var(--destructive)); }
+.kpi .kpi-hint { color: hsl(var(--muted-foreground)); margin-top: 0.25rem; font-size: 0.8125rem; }
+.card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1.25rem 1.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.card + .card { margin-top: 1rem; }
+.card .card-title { font-size: 0.95rem; font-weight: 600; display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0 0 0.5rem; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; }
+.badge.success { background: hsl(var(--success) / 0.12); color: hsl(var(--success)); border: 1px solid hsl(var(--success) / 0.3); }
+.badge.warning { background: hsl(var(--warning) / 0.12); color: hsl(var(--warning)); border: 1px solid hsl(var(--warning) / 0.3); }
+.badge.destructive { background: hsl(var(--destructive) / 0.12); color: hsl(var(--destructive)); border: 1px solid hsl(var(--destructive) / 0.3); }
+.badge.muted { background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); border: 1px solid hsl(var(--border)); }
+table { width: 100%; border-collapse: collapse; border: 1px solid hsl(var(--border)); border-radius: var(--radius); overflow: hidden; font-size: 0.875rem; margin: 0.85rem 0; }
+thead { background: hsl(var(--muted)); }
+th, td { padding: 0.55rem 0.85rem; text-align: left; vertical-align: top; }
+th { font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+tbody tr { border-top: 1px solid hsl(var(--border)); }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.muted { color: hsl(var(--muted-foreground)); font-size: 0.875rem; }
+.warning { border-left: 3px solid hsl(var(--warning)); background: hsl(var(--warning) / 0.08); color: hsl(var(--warning)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.fatal { border-left: 3px solid hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); color: hsl(var(--destructive)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.path-key { text-align: right; width: 200px; }
+.store-key { text-align: right; width: 160px; }
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page-header">
+  <h1>Storage migration report</h1>
+  <div class="meta">
+    <span><span class="badge success">OK</span></span>
+    <span>env <strong>mainnet</strong></span>
+    <span>generated <strong>2024-01-15 12:31:36</strong> UTC</span>
+    <span>duration <strong>1.23s</strong></span>
+  </div>
+</header>
+
+<section><h2>Summary</h2>
+<div class="kpi-grid">
+  <div class="kpi">
+    <div class="kpi-label">Status</div>
+    <div class="kpi-value success">OK</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Stores migrated</div>
+    <div class="kpi-value success">8</div>
+    <div class="kpi-hint">state + pending + debug + epochs</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Failures</div>
+    <div class="kpi-value success">0</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Total time</div>
+    <div class="kpi-value success">1.23s</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Unparsable rows</div>
+    <div class="kpi-value success">0</div>
+  </div>
+</div>
+</section>
+
+
+<section><h2>State DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>state</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>120.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Pending DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>pending</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>45.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Debug DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>debug</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>30.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+
+<section><h2>Epoch DBs</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>aggregate (/var/agglayer/epochs)</span>
+    <span class="badge success">OK</span>
+  </div>
+  <div class="kpi-grid">
+    <div class="kpi"><div class="kpi-label">Discovered</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Processed</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Successful</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Failed</div><div class="kpi-value success">0</div></div>
+    <div class="kpi"><div class="kpi-label">Diagnostics failed</div><div class="kpi-value warning">1</div></div>
+    <div class="kpi"><div class="kpi-label">Duration</div><div class="kpi-value success">800.00ms</div></div>
+  </div>
+
+
+
+  <h3>Diagnostics warnings (1)</h3>
+  <table><thead><tr><th>Epoch</th><th>Error</th></tr></thead><tbody>
+
+    <tr><td class="num"><strong>99</strong></td><td>read-only diagnostics open failed</td></tr>
+
+  </tbody></table>
+
+
+</div>
+
+</section>
+
+<h2>Run configuration</h2>
+<table><tbody>
+  <tr><th class="path-key">Environment label</th><td>mainnet</td></tr>
+
+  <tr><th class="path-key">state path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+
+  <tr><th class="path-key">pending path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+
+  <tr><th class="path-key">debug path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+
+  <tr><th class="path-key">epochs path</th><td><code class="mono break">/var/agglayer/epochs</code></td></tr>
+
+</tbody></table>
+
+</div>
+</body>
+</html>

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_epoch_discovery_error.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_epoch_discovery_error.snap
@@ -1,0 +1,218 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_html(&o)
+snapshot_kind: text
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storage migration report — mainnet</title>
+<style>:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --success: 142 71% 35%;
+  --warning: 38 92% 45%;
+  --destructive: 0 72% 50%;
+  --radius: 0.625rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --border: 240 3.7% 15.9%;
+    --success: 142 60% 45%;
+    --warning: 38 90% 55%;
+    --destructive: 0 70% 60%;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  margin: 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+header.page-header { margin-bottom: 2rem; }
+header.page-header h1 { font-size: 1.875rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.4rem; }
+header.page-header .meta { color: hsl(var(--muted-foreground)); font-size: 0.875rem; display: flex; flex-wrap: wrap; gap: 0.4rem 1.25rem; }
+h2 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; margin: 2.5rem 0 1rem; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: hsl(var(--muted)); padding: 0.1em 0.35em; border-radius: 4px; font-size: 0.875em; }
+.mono.break { word-break: break-all; }
+.kpi-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 1rem; }
+.kpi { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.kpi .kpi-label { color: hsl(var(--muted-foreground)); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; }
+.kpi .kpi-value { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-top: 0.4rem; }
+.kpi .kpi-value.success { color: hsl(var(--success)); }
+.kpi .kpi-value.warning { color: hsl(var(--warning)); }
+.kpi .kpi-value.destructive { color: hsl(var(--destructive)); }
+.kpi .kpi-hint { color: hsl(var(--muted-foreground)); margin-top: 0.25rem; font-size: 0.8125rem; }
+.card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1.25rem 1.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.card + .card { margin-top: 1rem; }
+.card .card-title { font-size: 0.95rem; font-weight: 600; display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0 0 0.5rem; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; }
+.badge.success { background: hsl(var(--success) / 0.12); color: hsl(var(--success)); border: 1px solid hsl(var(--success) / 0.3); }
+.badge.warning { background: hsl(var(--warning) / 0.12); color: hsl(var(--warning)); border: 1px solid hsl(var(--warning) / 0.3); }
+.badge.destructive { background: hsl(var(--destructive) / 0.12); color: hsl(var(--destructive)); border: 1px solid hsl(var(--destructive) / 0.3); }
+.badge.muted { background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); border: 1px solid hsl(var(--border)); }
+table { width: 100%; border-collapse: collapse; border: 1px solid hsl(var(--border)); border-radius: var(--radius); overflow: hidden; font-size: 0.875rem; margin: 0.85rem 0; }
+thead { background: hsl(var(--muted)); }
+th, td { padding: 0.55rem 0.85rem; text-align: left; vertical-align: top; }
+th { font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+tbody tr { border-top: 1px solid hsl(var(--border)); }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.muted { color: hsl(var(--muted-foreground)); font-size: 0.875rem; }
+.warning { border-left: 3px solid hsl(var(--warning)); background: hsl(var(--warning) / 0.08); color: hsl(var(--warning)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.fatal { border-left: 3px solid hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); color: hsl(var(--destructive)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.path-key { text-align: right; width: 200px; }
+.store-key { text-align: right; width: 160px; }
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page-header">
+  <h1>Storage migration report</h1>
+  <div class="meta">
+    <span><span class="badge destructive">FAILED</span></span>
+    <span>env <strong>mainnet</strong></span>
+    <span>generated <strong>2024-01-15 12:31:36</strong> UTC</span>
+    <span>duration <strong>1.23s</strong></span>
+  </div>
+</header>
+
+<section><h2>Summary</h2>
+<div class="kpi-grid">
+  <div class="kpi">
+    <div class="kpi-label">Status</div>
+    <div class="kpi-value destructive">FAILED</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Stores migrated</div>
+    <div class="kpi-value success">3</div>
+    <div class="kpi-hint">state + pending + debug + epochs</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Failures</div>
+    <div class="kpi-value destructive">1</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Total time</div>
+    <div class="kpi-value success">1.23s</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Unparsable rows</div>
+    <div class="kpi-value success">0</div>
+  </div>
+</div>
+</section>
+
+
+<section><h2>State DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>state</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>120.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Pending DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>pending</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>45.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Debug DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>debug</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>30.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+
+<section><h2>Epoch DBs</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>aggregate (/var/agglayer/epochs)</span>
+    <span class="badge destructive">FAILED</span>
+  </div>
+  <div class="kpi-grid">
+    <div class="kpi"><div class="kpi-label">Discovered</div><div class="kpi-value success">0</div></div>
+    <div class="kpi"><div class="kpi-label">Processed</div><div class="kpi-value success">0</div></div>
+    <div class="kpi"><div class="kpi-label">Successful</div><div class="kpi-value success">0</div></div>
+    <div class="kpi"><div class="kpi-label">Failed</div><div class="kpi-value destructive">1</div></div>
+    <div class="kpi"><div class="kpi-label">Diagnostics failed</div><div class="kpi-value warning">0</div></div>
+    <div class="kpi"><div class="kpi-label">Duration</div><div class="kpi-value success">10.00ms</div></div>
+  </div>
+<div class="fatal">failed to read epoch directory</div>
+
+
+
+</div>
+
+</section>
+
+<h2>Run configuration</h2>
+<table><tbody>
+  <tr><th class="path-key">Environment label</th><td>mainnet</td></tr>
+
+  <tr><th class="path-key">state path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+
+  <tr><th class="path-key">pending path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+
+  <tr><th class="path-key">debug path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+
+  <tr><th class="path-key">epochs path</th><td><code class="mono break">/var/agglayer/epochs</code></td></tr>
+
+</tbody></table>
+
+</div>
+</body>
+</html>

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_escapes_user_strings.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_escapes_user_strings.snap
@@ -1,0 +1,218 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: html
+snapshot_kind: text
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storage migration report — weird &#60;env&#62; &#38; label</title>
+<style>:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --success: 142 71% 35%;
+  --warning: 38 92% 45%;
+  --destructive: 0 72% 50%;
+  --radius: 0.625rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --border: 240 3.7% 15.9%;
+    --success: 142 60% 45%;
+    --warning: 38 90% 55%;
+    --destructive: 0 70% 60%;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  margin: 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+header.page-header { margin-bottom: 2rem; }
+header.page-header h1 { font-size: 1.875rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.4rem; }
+header.page-header .meta { color: hsl(var(--muted-foreground)); font-size: 0.875rem; display: flex; flex-wrap: wrap; gap: 0.4rem 1.25rem; }
+h2 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; margin: 2.5rem 0 1rem; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: hsl(var(--muted)); padding: 0.1em 0.35em; border-radius: 4px; font-size: 0.875em; }
+.mono.break { word-break: break-all; }
+.kpi-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 1rem; }
+.kpi { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.kpi .kpi-label { color: hsl(var(--muted-foreground)); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; }
+.kpi .kpi-value { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-top: 0.4rem; }
+.kpi .kpi-value.success { color: hsl(var(--success)); }
+.kpi .kpi-value.warning { color: hsl(var(--warning)); }
+.kpi .kpi-value.destructive { color: hsl(var(--destructive)); }
+.kpi .kpi-hint { color: hsl(var(--muted-foreground)); margin-top: 0.25rem; font-size: 0.8125rem; }
+.card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1.25rem 1.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.card + .card { margin-top: 1rem; }
+.card .card-title { font-size: 0.95rem; font-weight: 600; display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0 0 0.5rem; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; }
+.badge.success { background: hsl(var(--success) / 0.12); color: hsl(var(--success)); border: 1px solid hsl(var(--success) / 0.3); }
+.badge.warning { background: hsl(var(--warning) / 0.12); color: hsl(var(--warning)); border: 1px solid hsl(var(--warning) / 0.3); }
+.badge.destructive { background: hsl(var(--destructive) / 0.12); color: hsl(var(--destructive)); border: 1px solid hsl(var(--destructive) / 0.3); }
+.badge.muted { background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); border: 1px solid hsl(var(--border)); }
+table { width: 100%; border-collapse: collapse; border: 1px solid hsl(var(--border)); border-radius: var(--radius); overflow: hidden; font-size: 0.875rem; margin: 0.85rem 0; }
+thead { background: hsl(var(--muted)); }
+th, td { padding: 0.55rem 0.85rem; text-align: left; vertical-align: top; }
+th { font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+tbody tr { border-top: 1px solid hsl(var(--border)); }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.muted { color: hsl(var(--muted-foreground)); font-size: 0.875rem; }
+.warning { border-left: 3px solid hsl(var(--warning)); background: hsl(var(--warning) / 0.08); color: hsl(var(--warning)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.fatal { border-left: 3px solid hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); color: hsl(var(--destructive)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.path-key { text-align: right; width: 200px; }
+.store-key { text-align: right; width: 160px; }
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page-header">
+  <h1>Storage migration report</h1>
+  <div class="meta">
+    <span><span class="badge destructive">FAILED</span></span>
+    <span>env <strong>weird &#60;env&#62; &#38; label</strong></span>
+    <span>generated <strong>2024-01-15 12:31:36</strong> UTC</span>
+    <span>duration <strong>1.23s</strong></span>
+  </div>
+</header>
+
+<section><h2>Summary</h2>
+<div class="kpi-grid">
+  <div class="kpi">
+    <div class="kpi-label">Status</div>
+    <div class="kpi-value destructive">FAILED</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Stores migrated</div>
+    <div class="kpi-value success">8</div>
+    <div class="kpi-hint">state + pending + debug + epochs</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Failures</div>
+    <div class="kpi-value destructive">1</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Total time</div>
+    <div class="kpi-value success">1.23s</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Unparsable rows</div>
+    <div class="kpi-value success">0</div>
+  </div>
+</div>
+</section>
+
+
+<section><h2>State DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>state</span>
+    <span class="badge destructive">FAILED</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>120.00ms</td></tr>
+  </tbody></table>
+<div class="fatal">oops &#60;script&#62;</div>
+
+
+</div>
+
+</section>
+
+<section><h2>Pending DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>pending</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>45.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Debug DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>debug</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>30.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+
+<section><h2>Epoch DBs</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>aggregate (/var/agglayer/epochs)</span>
+    <span class="badge success">OK</span>
+  </div>
+  <div class="kpi-grid">
+    <div class="kpi"><div class="kpi-label">Discovered</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Processed</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Successful</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Failed</div><div class="kpi-value success">0</div></div>
+    <div class="kpi"><div class="kpi-label">Diagnostics failed</div><div class="kpi-value warning">0</div></div>
+    <div class="kpi"><div class="kpi-label">Duration</div><div class="kpi-value success">800.00ms</div></div>
+  </div>
+
+
+
+
+</div>
+
+</section>
+
+<h2>Run configuration</h2>
+<table><tbody>
+  <tr><th class="path-key">Environment label</th><td>weird &#60;env&#62; &#38; label</td></tr>
+
+  <tr><th class="path-key">state path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+
+  <tr><th class="path-key">pending path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+
+  <tr><th class="path-key">debug path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+
+  <tr><th class="path-key">epochs path</th><td><code class="mono break">/var/agglayer/epochs</code></td></tr>
+
+</tbody></table>
+
+</div>
+</body>
+</html>

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_per_store_diagnostics_warning.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_per_store_diagnostics_warning.snap
@@ -1,0 +1,218 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_html(&o)
+snapshot_kind: text
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storage migration report — mainnet</title>
+<style>:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --success: 142 71% 35%;
+  --warning: 38 92% 45%;
+  --destructive: 0 72% 50%;
+  --radius: 0.625rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --border: 240 3.7% 15.9%;
+    --success: 142 60% 45%;
+    --warning: 38 90% 55%;
+    --destructive: 0 70% 60%;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  margin: 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+header.page-header { margin-bottom: 2rem; }
+header.page-header h1 { font-size: 1.875rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.4rem; }
+header.page-header .meta { color: hsl(var(--muted-foreground)); font-size: 0.875rem; display: flex; flex-wrap: wrap; gap: 0.4rem 1.25rem; }
+h2 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; margin: 2.5rem 0 1rem; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: hsl(var(--muted)); padding: 0.1em 0.35em; border-radius: 4px; font-size: 0.875em; }
+.mono.break { word-break: break-all; }
+.kpi-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 1rem; }
+.kpi { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.kpi .kpi-label { color: hsl(var(--muted-foreground)); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; }
+.kpi .kpi-value { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-top: 0.4rem; }
+.kpi .kpi-value.success { color: hsl(var(--success)); }
+.kpi .kpi-value.warning { color: hsl(var(--warning)); }
+.kpi .kpi-value.destructive { color: hsl(var(--destructive)); }
+.kpi .kpi-hint { color: hsl(var(--muted-foreground)); margin-top: 0.25rem; font-size: 0.8125rem; }
+.card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1.25rem 1.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.card + .card { margin-top: 1rem; }
+.card .card-title { font-size: 0.95rem; font-weight: 600; display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0 0 0.5rem; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; }
+.badge.success { background: hsl(var(--success) / 0.12); color: hsl(var(--success)); border: 1px solid hsl(var(--success) / 0.3); }
+.badge.warning { background: hsl(var(--warning) / 0.12); color: hsl(var(--warning)); border: 1px solid hsl(var(--warning) / 0.3); }
+.badge.destructive { background: hsl(var(--destructive) / 0.12); color: hsl(var(--destructive)); border: 1px solid hsl(var(--destructive) / 0.3); }
+.badge.muted { background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); border: 1px solid hsl(var(--border)); }
+table { width: 100%; border-collapse: collapse; border: 1px solid hsl(var(--border)); border-radius: var(--radius); overflow: hidden; font-size: 0.875rem; margin: 0.85rem 0; }
+thead { background: hsl(var(--muted)); }
+th, td { padding: 0.55rem 0.85rem; text-align: left; vertical-align: top; }
+th { font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+tbody tr { border-top: 1px solid hsl(var(--border)); }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.muted { color: hsl(var(--muted-foreground)); font-size: 0.875rem; }
+.warning { border-left: 3px solid hsl(var(--warning)); background: hsl(var(--warning) / 0.08); color: hsl(var(--warning)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.fatal { border-left: 3px solid hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); color: hsl(var(--destructive)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.path-key { text-align: right; width: 200px; }
+.store-key { text-align: right; width: 160px; }
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page-header">
+  <h1>Storage migration report</h1>
+  <div class="meta">
+    <span><span class="badge success">OK</span></span>
+    <span>env <strong>mainnet</strong></span>
+    <span>generated <strong>2024-01-15 12:31:36</strong> UTC</span>
+    <span>duration <strong>1.23s</strong></span>
+  </div>
+</header>
+
+<section><h2>Summary</h2>
+<div class="kpi-grid">
+  <div class="kpi">
+    <div class="kpi-label">Status</div>
+    <div class="kpi-value success">OK</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Stores migrated</div>
+    <div class="kpi-value success">8</div>
+    <div class="kpi-hint">state + pending + debug + epochs</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Failures</div>
+    <div class="kpi-value success">0</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Total time</div>
+    <div class="kpi-value success">1.23s</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Unparsable rows</div>
+    <div class="kpi-value success">0</div>
+  </div>
+</div>
+</section>
+
+
+<section><h2>State DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>state</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>120.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Pending DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>pending</span>
+    <span class="badge warning">INCOMPLETE</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>45.00ms</td></tr>
+  </tbody></table>
+
+<div class="warning">Diagnostics failed: pending scan failed</div>
+
+</div>
+
+</section>
+
+<section><h2>Debug DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>debug</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>30.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+
+<section><h2>Epoch DBs</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>aggregate (/var/agglayer/epochs)</span>
+    <span class="badge success">OK</span>
+  </div>
+  <div class="kpi-grid">
+    <div class="kpi"><div class="kpi-label">Discovered</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Processed</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Successful</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Failed</div><div class="kpi-value success">0</div></div>
+    <div class="kpi"><div class="kpi-label">Diagnostics failed</div><div class="kpi-value warning">0</div></div>
+    <div class="kpi"><div class="kpi-label">Duration</div><div class="kpi-value success">800.00ms</div></div>
+  </div>
+
+
+
+
+</div>
+
+</section>
+
+<h2>Run configuration</h2>
+<table><tbody>
+  <tr><th class="path-key">Environment label</th><td>mainnet</td></tr>
+
+  <tr><th class="path-key">state path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+
+  <tr><th class="path-key">pending path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+
+  <tr><th class="path-key">debug path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+
+  <tr><th class="path-key">epochs path</th><td><code class="mono break">/var/agglayer/epochs</code></td></tr>
+
+</tbody></table>
+
+</div>
+</body>
+</html>

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_self_contained_document.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_self_contained_document.snap
@@ -1,0 +1,218 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_html(&outcome_all_ok())
+snapshot_kind: text
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storage migration report — mainnet</title>
+<style>:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --success: 142 71% 35%;
+  --warning: 38 92% 45%;
+  --destructive: 0 72% 50%;
+  --radius: 0.625rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --border: 240 3.7% 15.9%;
+    --success: 142 60% 45%;
+    --warning: 38 90% 55%;
+    --destructive: 0 70% 60%;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  margin: 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+header.page-header { margin-bottom: 2rem; }
+header.page-header h1 { font-size: 1.875rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.4rem; }
+header.page-header .meta { color: hsl(var(--muted-foreground)); font-size: 0.875rem; display: flex; flex-wrap: wrap; gap: 0.4rem 1.25rem; }
+h2 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; margin: 2.5rem 0 1rem; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: hsl(var(--muted)); padding: 0.1em 0.35em; border-radius: 4px; font-size: 0.875em; }
+.mono.break { word-break: break-all; }
+.kpi-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 1rem; }
+.kpi { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.kpi .kpi-label { color: hsl(var(--muted-foreground)); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; }
+.kpi .kpi-value { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-top: 0.4rem; }
+.kpi .kpi-value.success { color: hsl(var(--success)); }
+.kpi .kpi-value.warning { color: hsl(var(--warning)); }
+.kpi .kpi-value.destructive { color: hsl(var(--destructive)); }
+.kpi .kpi-hint { color: hsl(var(--muted-foreground)); margin-top: 0.25rem; font-size: 0.8125rem; }
+.card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1.25rem 1.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.card + .card { margin-top: 1rem; }
+.card .card-title { font-size: 0.95rem; font-weight: 600; display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0 0 0.5rem; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; }
+.badge.success { background: hsl(var(--success) / 0.12); color: hsl(var(--success)); border: 1px solid hsl(var(--success) / 0.3); }
+.badge.warning { background: hsl(var(--warning) / 0.12); color: hsl(var(--warning)); border: 1px solid hsl(var(--warning) / 0.3); }
+.badge.destructive { background: hsl(var(--destructive) / 0.12); color: hsl(var(--destructive)); border: 1px solid hsl(var(--destructive) / 0.3); }
+.badge.muted { background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); border: 1px solid hsl(var(--border)); }
+table { width: 100%; border-collapse: collapse; border: 1px solid hsl(var(--border)); border-radius: var(--radius); overflow: hidden; font-size: 0.875rem; margin: 0.85rem 0; }
+thead { background: hsl(var(--muted)); }
+th, td { padding: 0.55rem 0.85rem; text-align: left; vertical-align: top; }
+th { font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+tbody tr { border-top: 1px solid hsl(var(--border)); }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.muted { color: hsl(var(--muted-foreground)); font-size: 0.875rem; }
+.warning { border-left: 3px solid hsl(var(--warning)); background: hsl(var(--warning) / 0.08); color: hsl(var(--warning)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.fatal { border-left: 3px solid hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); color: hsl(var(--destructive)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.path-key { text-align: right; width: 200px; }
+.store-key { text-align: right; width: 160px; }
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page-header">
+  <h1>Storage migration report</h1>
+  <div class="meta">
+    <span><span class="badge success">OK</span></span>
+    <span>env <strong>mainnet</strong></span>
+    <span>generated <strong>2024-01-15 12:31:36</strong> UTC</span>
+    <span>duration <strong>1.23s</strong></span>
+  </div>
+</header>
+
+<section><h2>Summary</h2>
+<div class="kpi-grid">
+  <div class="kpi">
+    <div class="kpi-label">Status</div>
+    <div class="kpi-value success">OK</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Stores migrated</div>
+    <div class="kpi-value success">8</div>
+    <div class="kpi-hint">state + pending + debug + epochs</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Failures</div>
+    <div class="kpi-value success">0</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Total time</div>
+    <div class="kpi-value success">1.23s</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Unparsable rows</div>
+    <div class="kpi-value success">0</div>
+  </div>
+</div>
+</section>
+
+
+<section><h2>State DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>state</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>120.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Pending DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>pending</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>45.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Debug DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>debug</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>30.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+
+<section><h2>Epoch DBs</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>aggregate (/var/agglayer/epochs)</span>
+    <span class="badge success">OK</span>
+  </div>
+  <div class="kpi-grid">
+    <div class="kpi"><div class="kpi-label">Discovered</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Processed</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Successful</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Failed</div><div class="kpi-value success">0</div></div>
+    <div class="kpi"><div class="kpi-label">Diagnostics failed</div><div class="kpi-value warning">0</div></div>
+    <div class="kpi"><div class="kpi-label">Duration</div><div class="kpi-value success">800.00ms</div></div>
+  </div>
+
+
+
+
+</div>
+
+</section>
+
+<h2>Run configuration</h2>
+<table><tbody>
+  <tr><th class="path-key">Environment label</th><td>mainnet</td></tr>
+
+  <tr><th class="path-key">state path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+
+  <tr><th class="path-key">pending path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+
+  <tr><th class="path-key">debug path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+
+  <tr><th class="path-key">epochs path</th><td><code class="mono break">/var/agglayer/epochs</code></td></tr>
+
+</tbody></table>
+
+</div>
+</body>
+</html>

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_skipped_epochs.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_skipped_epochs.snap
@@ -1,0 +1,204 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_html(&o)
+snapshot_kind: text
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storage migration report — mainnet</title>
+<style>:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --success: 142 71% 35%;
+  --warning: 38 92% 45%;
+  --destructive: 0 72% 50%;
+  --radius: 0.625rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --border: 240 3.7% 15.9%;
+    --success: 142 60% 45%;
+    --warning: 38 90% 55%;
+    --destructive: 0 70% 60%;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  margin: 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+header.page-header { margin-bottom: 2rem; }
+header.page-header h1 { font-size: 1.875rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.4rem; }
+header.page-header .meta { color: hsl(var(--muted-foreground)); font-size: 0.875rem; display: flex; flex-wrap: wrap; gap: 0.4rem 1.25rem; }
+h2 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; margin: 2.5rem 0 1rem; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: hsl(var(--muted)); padding: 0.1em 0.35em; border-radius: 4px; font-size: 0.875em; }
+.mono.break { word-break: break-all; }
+.kpi-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 1rem; }
+.kpi { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.kpi .kpi-label { color: hsl(var(--muted-foreground)); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; }
+.kpi .kpi-value { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-top: 0.4rem; }
+.kpi .kpi-value.success { color: hsl(var(--success)); }
+.kpi .kpi-value.warning { color: hsl(var(--warning)); }
+.kpi .kpi-value.destructive { color: hsl(var(--destructive)); }
+.kpi .kpi-hint { color: hsl(var(--muted-foreground)); margin-top: 0.25rem; font-size: 0.8125rem; }
+.card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1.25rem 1.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.card + .card { margin-top: 1rem; }
+.card .card-title { font-size: 0.95rem; font-weight: 600; display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0 0 0.5rem; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; }
+.badge.success { background: hsl(var(--success) / 0.12); color: hsl(var(--success)); border: 1px solid hsl(var(--success) / 0.3); }
+.badge.warning { background: hsl(var(--warning) / 0.12); color: hsl(var(--warning)); border: 1px solid hsl(var(--warning) / 0.3); }
+.badge.destructive { background: hsl(var(--destructive) / 0.12); color: hsl(var(--destructive)); border: 1px solid hsl(var(--destructive) / 0.3); }
+.badge.muted { background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); border: 1px solid hsl(var(--border)); }
+table { width: 100%; border-collapse: collapse; border: 1px solid hsl(var(--border)); border-radius: var(--radius); overflow: hidden; font-size: 0.875rem; margin: 0.85rem 0; }
+thead { background: hsl(var(--muted)); }
+th, td { padding: 0.55rem 0.85rem; text-align: left; vertical-align: top; }
+th { font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+tbody tr { border-top: 1px solid hsl(var(--border)); }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.muted { color: hsl(var(--muted-foreground)); font-size: 0.875rem; }
+.warning { border-left: 3px solid hsl(var(--warning)); background: hsl(var(--warning) / 0.08); color: hsl(var(--warning)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.fatal { border-left: 3px solid hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); color: hsl(var(--destructive)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.path-key { text-align: right; width: 200px; }
+.store-key { text-align: right; width: 160px; }
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page-header">
+  <h1>Storage migration report</h1>
+  <div class="meta">
+    <span><span class="badge success">OK</span></span>
+    <span>env <strong>mainnet</strong></span>
+    <span>generated <strong>2024-01-15 12:31:36</strong> UTC</span>
+    <span>duration <strong>1.23s</strong></span>
+  </div>
+</header>
+
+<section><h2>Summary</h2>
+<div class="kpi-grid">
+  <div class="kpi">
+    <div class="kpi-label">Status</div>
+    <div class="kpi-value success">OK</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Stores migrated</div>
+    <div class="kpi-value success">3</div>
+    <div class="kpi-hint">state + pending + debug + epochs</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Failures</div>
+    <div class="kpi-value success">0</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Total time</div>
+    <div class="kpi-value success">1.23s</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Unparsable rows</div>
+    <div class="kpi-value success">0</div>
+  </div>
+</div>
+</section>
+
+
+<section><h2>State DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>state</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>120.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Pending DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>pending</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>45.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Debug DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>debug</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>30.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+
+<section><h2>Epoch DBs</h2>
+
+<div class="card">
+  <div class="card-title"><span>aggregate</span><span class="badge muted">SKIPPED</span></div>
+  <p class="muted">skipped via --skip-epochs</p>
+</div>
+
+</section>
+
+<h2>Run configuration</h2>
+<table><tbody>
+  <tr><th class="path-key">Environment label</th><td>mainnet</td></tr>
+
+  <tr><th class="path-key">state path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+
+  <tr><th class="path-key">pending path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+
+  <tr><th class="path-key">debug path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+
+  <tr><th class="path-key">epochs path</th><td><code class="mono break">/var/agglayer/epochs</code></td></tr>
+
+</tbody></table>
+
+</div>
+</body>
+</html>

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_with_failures.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_with_failures.snap
@@ -1,0 +1,227 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_html(&outcome_with_failures())
+snapshot_kind: text
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storage migration report — mainnet</title>
+<style>:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --success: 142 71% 35%;
+  --warning: 38 92% 45%;
+  --destructive: 0 72% 50%;
+  --radius: 0.625rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --border: 240 3.7% 15.9%;
+    --success: 142 60% 45%;
+    --warning: 38 90% 55%;
+    --destructive: 0 70% 60%;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  margin: 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+header.page-header { margin-bottom: 2rem; }
+header.page-header h1 { font-size: 1.875rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.4rem; }
+header.page-header .meta { color: hsl(var(--muted-foreground)); font-size: 0.875rem; display: flex; flex-wrap: wrap; gap: 0.4rem 1.25rem; }
+h2 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; margin: 2.5rem 0 1rem; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: hsl(var(--muted)); padding: 0.1em 0.35em; border-radius: 4px; font-size: 0.875em; }
+.mono.break { word-break: break-all; }
+.kpi-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 1rem; }
+.kpi { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.kpi .kpi-label { color: hsl(var(--muted-foreground)); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; }
+.kpi .kpi-value { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-top: 0.4rem; }
+.kpi .kpi-value.success { color: hsl(var(--success)); }
+.kpi .kpi-value.warning { color: hsl(var(--warning)); }
+.kpi .kpi-value.destructive { color: hsl(var(--destructive)); }
+.kpi .kpi-hint { color: hsl(var(--muted-foreground)); margin-top: 0.25rem; font-size: 0.8125rem; }
+.card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1.25rem 1.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.card + .card { margin-top: 1rem; }
+.card .card-title { font-size: 0.95rem; font-weight: 600; display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0 0 0.5rem; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; }
+.badge.success { background: hsl(var(--success) / 0.12); color: hsl(var(--success)); border: 1px solid hsl(var(--success) / 0.3); }
+.badge.warning { background: hsl(var(--warning) / 0.12); color: hsl(var(--warning)); border: 1px solid hsl(var(--warning) / 0.3); }
+.badge.destructive { background: hsl(var(--destructive) / 0.12); color: hsl(var(--destructive)); border: 1px solid hsl(var(--destructive) / 0.3); }
+.badge.muted { background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); border: 1px solid hsl(var(--border)); }
+table { width: 100%; border-collapse: collapse; border: 1px solid hsl(var(--border)); border-radius: var(--radius); overflow: hidden; font-size: 0.875rem; margin: 0.85rem 0; }
+thead { background: hsl(var(--muted)); }
+th, td { padding: 0.55rem 0.85rem; text-align: left; vertical-align: top; }
+th { font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+tbody tr { border-top: 1px solid hsl(var(--border)); }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.muted { color: hsl(var(--muted-foreground)); font-size: 0.875rem; }
+.warning { border-left: 3px solid hsl(var(--warning)); background: hsl(var(--warning) / 0.08); color: hsl(var(--warning)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.fatal { border-left: 3px solid hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); color: hsl(var(--destructive)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.path-key { text-align: right; width: 200px; }
+.store-key { text-align: right; width: 160px; }
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page-header">
+  <h1>Storage migration report</h1>
+  <div class="meta">
+    <span><span class="badge destructive">FAILED</span></span>
+    <span>env <strong>mainnet</strong></span>
+    <span>generated <strong>2024-01-15 12:31:36</strong> UTC</span>
+    <span>duration <strong>1.23s</strong></span>
+  </div>
+</header>
+
+<section><h2>Summary</h2>
+<div class="kpi-grid">
+  <div class="kpi">
+    <div class="kpi-label">Status</div>
+    <div class="kpi-value destructive">FAILED</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Stores migrated</div>
+    <div class="kpi-value success">6</div>
+    <div class="kpi-hint">state + pending + debug + epochs</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Failures</div>
+    <div class="kpi-value destructive">3</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Total time</div>
+    <div class="kpi-value success">1.23s</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Unparsable rows</div>
+    <div class="kpi-value success">0</div>
+  </div>
+</div>
+</section>
+
+
+<section><h2>State DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>state</span>
+    <span class="badge destructive">FAILED</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>120.00ms</td></tr>
+  </tbody></table>
+<div class="fatal">schema mismatch</div>
+
+
+</div>
+
+</section>
+
+<section><h2>Pending DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>pending</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>45.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Debug DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>debug</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>30.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+
+<section><h2>Epoch DBs</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>aggregate (/var/agglayer/epochs)</span>
+    <span class="badge destructive">FAILED</span>
+  </div>
+  <div class="kpi-grid">
+    <div class="kpi"><div class="kpi-label">Discovered</div><div class="kpi-value success">3</div></div>
+    <div class="kpi"><div class="kpi-label">Processed</div><div class="kpi-value success">3</div></div>
+    <div class="kpi"><div class="kpi-label">Successful</div><div class="kpi-value success">1</div></div>
+    <div class="kpi"><div class="kpi-label">Failed</div><div class="kpi-value destructive">2</div></div>
+    <div class="kpi"><div class="kpi-label">Diagnostics failed</div><div class="kpi-value warning">0</div></div>
+    <div class="kpi"><div class="kpi-label">Duration</div><div class="kpi-value success">500.00ms</div></div>
+  </div>
+
+
+  <h3>Failed epochs (2)</h3>
+  <table><thead><tr><th>Epoch</th><th>Error</th></tr></thead><tbody>
+
+    <tr><td class="num"><strong>17</strong></td><td>missing CF debug_certificates</td></tr>
+
+    <tr><td class="num"><strong>42</strong></td><td>decode error</td></tr>
+
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<h2>Run configuration</h2>
+<table><tbody>
+  <tr><th class="path-key">Environment label</th><td>mainnet</td></tr>
+
+  <tr><th class="path-key">state path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+
+  <tr><th class="path-key">pending path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+
+  <tr><th class="path-key">debug path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+
+  <tr><th class="path-key">epochs path</th><td><code class="mono break">/var/agglayer/epochs</code></td></tr>
+
+</tbody></table>
+
+</div>
+</body>
+</html>

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_with_unparsable_rows.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_html_with_unparsable_rows.snap
@@ -1,0 +1,234 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_html(&outcome_with_unparsable_rows())
+snapshot_kind: text
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storage migration report — mainnet</title>
+<style>:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --success: 142 71% 35%;
+  --warning: 38 92% 45%;
+  --destructive: 0 72% 50%;
+  --radius: 0.625rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --border: 240 3.7% 15.9%;
+    --success: 142 60% 45%;
+    --warning: 38 90% 55%;
+    --destructive: 0 70% 60%;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  margin: 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+header.page-header { margin-bottom: 2rem; }
+header.page-header h1 { font-size: 1.875rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.4rem; }
+header.page-header .meta { color: hsl(var(--muted-foreground)); font-size: 0.875rem; display: flex; flex-wrap: wrap; gap: 0.4rem 1.25rem; }
+h2 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; margin: 2.5rem 0 1rem; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: hsl(var(--muted)); padding: 0.1em 0.35em; border-radius: 4px; font-size: 0.875em; }
+.mono.break { word-break: break-all; }
+.kpi-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 1rem; }
+.kpi { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.kpi .kpi-label { color: hsl(var(--muted-foreground)); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; }
+.kpi .kpi-value { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-top: 0.4rem; }
+.kpi .kpi-value.success { color: hsl(var(--success)); }
+.kpi .kpi-value.warning { color: hsl(var(--warning)); }
+.kpi .kpi-value.destructive { color: hsl(var(--destructive)); }
+.kpi .kpi-hint { color: hsl(var(--muted-foreground)); margin-top: 0.25rem; font-size: 0.8125rem; }
+.card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1.25rem 1.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.card + .card { margin-top: 1rem; }
+.card .card-title { font-size: 0.95rem; font-weight: 600; display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0 0 0.5rem; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; }
+.badge.success { background: hsl(var(--success) / 0.12); color: hsl(var(--success)); border: 1px solid hsl(var(--success) / 0.3); }
+.badge.warning { background: hsl(var(--warning) / 0.12); color: hsl(var(--warning)); border: 1px solid hsl(var(--warning) / 0.3); }
+.badge.destructive { background: hsl(var(--destructive) / 0.12); color: hsl(var(--destructive)); border: 1px solid hsl(var(--destructive) / 0.3); }
+.badge.muted { background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); border: 1px solid hsl(var(--border)); }
+table { width: 100%; border-collapse: collapse; border: 1px solid hsl(var(--border)); border-radius: var(--radius); overflow: hidden; font-size: 0.875rem; margin: 0.85rem 0; }
+thead { background: hsl(var(--muted)); }
+th, td { padding: 0.55rem 0.85rem; text-align: left; vertical-align: top; }
+th { font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+tbody tr { border-top: 1px solid hsl(var(--border)); }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.muted { color: hsl(var(--muted-foreground)); font-size: 0.875rem; }
+.warning { border-left: 3px solid hsl(var(--warning)); background: hsl(var(--warning) / 0.08); color: hsl(var(--warning)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.fatal { border-left: 3px solid hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); color: hsl(var(--destructive)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.path-key { text-align: right; width: 200px; }
+.store-key { text-align: right; width: 160px; }
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page-header">
+  <h1>Storage migration report</h1>
+  <div class="meta">
+    <span><span class="badge success">OK</span></span>
+    <span>env <strong>mainnet</strong></span>
+    <span>generated <strong>2024-01-15 12:31:36</strong> UTC</span>
+    <span>duration <strong>1.23s</strong></span>
+  </div>
+</header>
+
+<section><h2>Summary</h2>
+<div class="kpi-grid">
+  <div class="kpi">
+    <div class="kpi-label">Status</div>
+    <div class="kpi-value success">OK</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Stores migrated</div>
+    <div class="kpi-value success">8</div>
+    <div class="kpi-hint">state + pending + debug + epochs</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Failures</div>
+    <div class="kpi-value success">0</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Total time</div>
+    <div class="kpi-value success">1.23s</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Unparsable rows</div>
+    <div class="kpi-value warning">3</div>
+  </div>
+</div>
+</section>
+
+
+<section><h2>State DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>state</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>120.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+<section><h2>Pending DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>pending</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>45.00ms</td></tr>
+  </tbody></table>
+
+
+
+  <h3>Unparsable rows (2)</h3>
+  <table><thead><tr><th>CF</th><th>Key</th><th>Error</th></tr></thead><tbody>
+
+    <tr><td><code>pending_queue</code></td><td><code class="mono break">00000000000000010000000000000005</code></td><td>invalid varint</td></tr>
+
+    <tr><td><code>pending_queue</code></td><td><code class="mono break">0000000000000002000000000000000a</code></td><td>BadCertificateVersion { version: 7 }</td></tr>
+
+  </tbody></table>
+
+</div>
+
+</section>
+
+<section><h2>Debug DB</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>debug</span>
+    <span class="badge success">OK</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>30.00ms</td></tr>
+  </tbody></table>
+
+
+
+</div>
+
+</section>
+
+
+<section><h2>Epoch DBs</h2>
+
+<div class="card">
+  <div class="card-title">
+    <span>aggregate (/var/agglayer/epochs)</span>
+    <span class="badge success">OK</span>
+  </div>
+  <div class="kpi-grid">
+    <div class="kpi"><div class="kpi-label">Discovered</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Processed</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Successful</div><div class="kpi-value success">5</div></div>
+    <div class="kpi"><div class="kpi-label">Failed</div><div class="kpi-value success">0</div></div>
+    <div class="kpi"><div class="kpi-label">Diagnostics failed</div><div class="kpi-value warning">0</div></div>
+    <div class="kpi"><div class="kpi-label">Duration</div><div class="kpi-value success">800.00ms</div></div>
+  </div>
+
+
+
+
+  <h3>Unparsable rows (1)</h3>
+  <table><thead><tr><th>CF</th><th>Source</th><th>Key</th><th>Error</th></tr></thead><tbody>
+
+    <tr><td><code>epoch_certificate_per_index</code></td><td>epoch 17</td><td><code class="mono break">0000000000000003</code></td><td>decode error</td></tr>
+
+  </tbody></table>
+
+</div>
+
+</section>
+
+<h2>Run configuration</h2>
+<table><tbody>
+  <tr><th class="path-key">Environment label</th><td>mainnet</td></tr>
+
+  <tr><th class="path-key">state path</th><td><code class="mono break">/var/agglayer/state</code></td></tr>
+
+  <tr><th class="path-key">pending path</th><td><code class="mono break">/var/agglayer/pending</code></td></tr>
+
+  <tr><th class="path-key">debug path</th><td><code class="mono break">/var/agglayer/debug</code></td></tr>
+
+  <tr><th class="path-key">epochs path</th><td><code class="mono break">/var/agglayer/epochs</code></td></tr>
+
+</tbody></table>
+
+</div>
+</body>
+</html>

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_all_ok.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_all_ok.snap
@@ -1,0 +1,16 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_markdown(&outcome_all_ok())
+---
+## mainnet
+
+Migration run at 2024-01-15 12:31:36 UTC, total 1.23s. Status: **OK**.
+
+| Store | Status | Duration | Notes |
+|---|---|---:|---|
+| state | ✅ OK | 120.00ms | — |
+| pending | ✅ OK | 45.00ms | — |
+| debug | ✅ OK | 30.00ms | — |
+| epochs | ✅ OK | 800.00ms | 5 processed; 5 OK; 0 failed |
+
+---

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_epoch_diagnostics_warnings.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_epoch_diagnostics_warnings.snap
@@ -1,0 +1,20 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_markdown(&o)
+---
+## mainnet
+
+Migration run at 2024-01-15 12:31:36 UTC, total 1.23s. Status: **OK**.
+
+| Store | Status | Duration | Notes |
+|---|---|---:|---|
+| state | ✅ OK | 120.00ms | — |
+| pending | ✅ OK | 45.00ms | — |
+| debug | ✅ OK | 30.00ms | — |
+| epochs | ✅ OK | 800.00ms | 5 processed; 5 OK; 0 failed; 1 diagnostics failed |
+
+**Diagnostics warnings**
+
+- epoch 99: read-only diagnostics open failed
+
+---

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_epoch_discovery_error.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_epoch_discovery_error.snap
@@ -1,0 +1,20 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_markdown(&o)
+---
+## mainnet
+
+Migration run at 2024-01-15 12:31:36 UTC, total 1.23s. Status: **FAILED**.
+
+| Store | Status | Duration | Notes |
+|---|---|---:|---|
+| state | ✅ OK | 120.00ms | — |
+| pending | ✅ OK | 45.00ms | — |
+| debug | ✅ OK | 30.00ms | — |
+| epochs | ❌ FAILED | 10.00ms | failed to read epoch directory |
+
+**Fatal errors**
+
+- epochs: failed to read epoch directory
+
+---

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_per_store_diagnostics_warning.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_per_store_diagnostics_warning.snap
@@ -1,0 +1,20 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_markdown(&o)
+---
+## mainnet
+
+Migration run at 2024-01-15 12:31:36 UTC, total 1.23s. Status: **OK**.
+
+| Store | Status | Duration | Notes |
+|---|---|---:|---|
+| state | ✅ OK | 120.00ms | — |
+| pending | ⚠️ INCOMPLETE | 45.00ms | diagnostics failed: pending scan failed |
+| debug | ✅ OK | 30.00ms | — |
+| epochs | ✅ OK | 800.00ms | 5 processed; 5 OK; 0 failed |
+
+**Diagnostics warnings**
+
+- pending: pending scan failed
+
+---

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_skipped_epochs.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_skipped_epochs.snap
@@ -1,0 +1,16 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_markdown(&o)
+---
+## mainnet
+
+Migration run at 2024-01-15 12:31:36 UTC, total 1.23s. Status: **OK**.
+
+| Store | Status | Duration | Notes |
+|---|---|---:|---|
+| state | ✅ OK | 120.00ms | — |
+| pending | ✅ OK | 45.00ms | — |
+| debug | ✅ OK | 30.00ms | — |
+| epochs | — | — | skipped via --skip-epochs |
+
+---

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_with_failures.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_with_failures.snap
@@ -1,0 +1,22 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_markdown(&outcome_with_failures())
+---
+## mainnet
+
+Migration run at 2024-01-15 12:31:36 UTC, total 1.23s. Status: **FAILED**.
+
+| Store | Status | Duration | Notes |
+|---|---|---:|---|
+| state | ❌ FAILED | 120.00ms | schema mismatch |
+| pending | ✅ OK | 45.00ms | — |
+| debug | ✅ OK | 30.00ms | — |
+| epochs | ❌ FAILED | 500.00ms | 3 processed; 1 OK; 2 failed |
+
+**Fatal errors**
+
+- state: schema mismatch
+- epoch 17: missing CF debug_certificates
+- epoch 42: decode error
+
+---

--- a/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_with_unparsable_rows.snap
+++ b/crates/agglayer/src/snapshots/agglayer__migrate_report__tests__migration_report_markdown_with_unparsable_rows.snap
@@ -1,0 +1,22 @@
+---
+source: crates/agglayer/src/migrate_report.rs
+expression: render_markdown(&outcome_with_unparsable_rows())
+---
+## mainnet
+
+Migration run at 2024-01-15 12:31:36 UTC, total 1.23s. Status: **OK**.
+
+| Store | Status | Duration | Notes |
+|---|---|---:|---|
+| state | ✅ OK | 120.00ms | — |
+| pending | ✅ OK | 45.00ms | 2 unparsable rows |
+| debug | ✅ OK | 30.00ms | — |
+| epochs | ✅ OK | 800.00ms | 5 processed; 5 OK; 0 failed; 1 unparsable |
+
+**Unparsable rows (3)**
+
+- `pending_queue` (pending) at key `00000000000000010000000000000005`: invalid varint
+- `pending_queue` (pending) at key `0000000000000002000000000000000a`: BadCertificateVersion { version: 7 }
+- `epoch_certificate_per_index` (epoch 17) at key `0000000000000003`: decode error
+
+---

--- a/crates/agglayer/src/templates/migration-report.css
+++ b/crates/agglayer/src/templates/migration-report.css
@@ -1,0 +1,70 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --success: 142 71% 35%;
+  --warning: 38 92% 45%;
+  --destructive: 0 72% 50%;
+  --radius: 0.625rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --border: 240 3.7% 15.9%;
+    --success: 142 60% 45%;
+    --warning: 38 90% 55%;
+    --destructive: 0 70% 60%;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  margin: 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+header.page-header { margin-bottom: 2rem; }
+header.page-header h1 { font-size: 1.875rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.4rem; }
+header.page-header .meta { color: hsl(var(--muted-foreground)); font-size: 0.875rem; display: flex; flex-wrap: wrap; gap: 0.4rem 1.25rem; }
+h2 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; margin: 2.5rem 0 1rem; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: hsl(var(--muted)); padding: 0.1em 0.35em; border-radius: 4px; font-size: 0.875em; }
+.mono.break { word-break: break-all; }
+.kpi-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 1rem; }
+.kpi { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.kpi .kpi-label { color: hsl(var(--muted-foreground)); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 500; }
+.kpi .kpi-value { font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-top: 0.4rem; }
+.kpi .kpi-value.success { color: hsl(var(--success)); }
+.kpi .kpi-value.warning { color: hsl(var(--warning)); }
+.kpi .kpi-value.destructive { color: hsl(var(--destructive)); }
+.kpi .kpi-hint { color: hsl(var(--muted-foreground)); margin-top: 0.25rem; font-size: 0.8125rem; }
+.card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: 1.25rem 1.5rem; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.card + .card { margin-top: 1rem; }
+.card .card-title { font-size: 0.95rem; font-weight: 600; display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0 0 0.5rem; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.75rem; font-weight: 600; white-space: nowrap; }
+.badge.success { background: hsl(var(--success) / 0.12); color: hsl(var(--success)); border: 1px solid hsl(var(--success) / 0.3); }
+.badge.warning { background: hsl(var(--warning) / 0.12); color: hsl(var(--warning)); border: 1px solid hsl(var(--warning) / 0.3); }
+.badge.destructive { background: hsl(var(--destructive) / 0.12); color: hsl(var(--destructive)); border: 1px solid hsl(var(--destructive) / 0.3); }
+.badge.muted { background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); border: 1px solid hsl(var(--border)); }
+table { width: 100%; border-collapse: collapse; border: 1px solid hsl(var(--border)); border-radius: var(--radius); overflow: hidden; font-size: 0.875rem; margin: 0.85rem 0; }
+thead { background: hsl(var(--muted)); }
+th, td { padding: 0.55rem 0.85rem; text-align: left; vertical-align: top; }
+th { font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; }
+tbody tr { border-top: 1px solid hsl(var(--border)); }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.muted { color: hsl(var(--muted-foreground)); font-size: 0.875rem; }
+.warning { border-left: 3px solid hsl(var(--warning)); background: hsl(var(--warning) / 0.08); color: hsl(var(--warning)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.fatal { border-left: 3px solid hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); color: hsl(var(--destructive)); padding: 0.75rem 1rem; border-radius: 6px; margin-top: 0.75rem; font-size: 0.875rem; word-break: break-word; }
+.path-key { text-align: right; width: 200px; }
+.store-key { text-align: right; width: 160px; }

--- a/crates/agglayer/src/templates/migration-report.html
+++ b/crates/agglayer/src/templates/migration-report.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storage migration report — {{ env_label }}</title>
+<style>{{ style|safe }}</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page-header">
+  <h1>Storage migration report</h1>
+  <div class="meta">
+    <span><span class="badge {{ status_class }}">{{ status_label }}</span></span>
+    <span>env <strong>{{ env_label }}</strong></span>
+    <span>generated <strong>{{ started_at }}</strong> UTC</span>
+    <span>duration <strong>{{ overall_duration }}</strong></span>
+  </div>
+</header>
+
+<section><h2>Summary</h2>
+<div class="kpi-grid">
+  <div class="kpi">
+    <div class="kpi-label">Status</div>
+    <div class="kpi-value {{ status_class }}">{{ status_label }}</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Stores migrated</div>
+    <div class="kpi-value success">{{ store_count }}</div>
+    <div class="kpi-hint">state + pending + debug + epochs</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Failures</div>
+    <div class="kpi-value {{ status_class }}">{{ fatal_count }}</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Total time</div>
+    <div class="kpi-value success">{{ overall_duration }}</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-label">Unparsable rows</div>
+    <div class="kpi-value {{ unparsable_class }}">{{ unparsable_total }}</div>
+  </div>
+</div>
+</section>
+
+{% for card in store_cards %}
+<section><h2>{{ card.heading }}</h2>
+{% if card.skipped %}
+<div class="card">
+  <div class="card-title"><span>—</span><span class="badge muted">SKIPPED</span></div>
+  <p class="muted">not configured for this deployment</p>
+</div>
+{% else %}
+<div class="card">
+  <div class="card-title">
+    <span>{{ card.label }}</span>
+    <span class="badge {{ card.badge_class }}">{{ card.badge_label }}</span>
+  </div>
+  <table><tbody>
+    <tr><th class="store-key">Path</th><td><code class="mono break">{{ card.path }}</code></td></tr>
+    <tr><th class="store-key">Duration</th><td>{{ card.duration }}</td></tr>
+  </tbody></table>
+{% if card.has_error %}<div class="fatal">{{ card.error }}</div>{% endif %}
+{% if card.has_diagnostics_error %}<div class="warning">Diagnostics failed: {{ card.diagnostics_error }}</div>{% endif %}
+{% if card.has_unparsable %}
+  <h3>Unparsable rows ({{ card.unparsable_count }})</h3>
+  <table><thead><tr><th>CF</th><th>Key</th><th>Error</th></tr></thead><tbody>
+{% for u in card.unparsable %}
+    <tr><td><code>{{ u.cf }}</code></td><td><code class="mono break">{{ u.key_hex }}</code></td><td>{{ u.error }}</td></tr>
+{% endfor %}
+  </tbody></table>
+{% endif %}
+</div>
+{% endif %}
+</section>
+{% endfor %}
+
+<section><h2>Epoch DBs</h2>
+{% if epochs.kind_not_configured %}
+<div class="card">
+  <div class="card-title"><span>—</span><span class="badge muted">SKIPPED</span></div>
+  <p class="muted">not configured for this deployment</p>
+</div>
+{% else if epochs.kind_skipped %}
+<div class="card">
+  <div class="card-title"><span>aggregate</span><span class="badge muted">SKIPPED</span></div>
+  <p class="muted">{{ epochs.skip_reason }}</p>
+</div>
+{% else %}
+<div class="card">
+  <div class="card-title">
+    <span>aggregate ({{ epochs.path }})</span>
+    <span class="badge {{ epochs.badge_class }}">{{ epochs.badge_label }}</span>
+  </div>
+  <div class="kpi-grid">
+    <div class="kpi"><div class="kpi-label">Discovered</div><div class="kpi-value success">{{ epochs.discovered }}</div></div>
+    <div class="kpi"><div class="kpi-label">Processed</div><div class="kpi-value success">{{ epochs.processed }}</div></div>
+    <div class="kpi"><div class="kpi-label">Successful</div><div class="kpi-value success">{{ epochs.successful }}</div></div>
+    <div class="kpi"><div class="kpi-label">Failed</div><div class="kpi-value {{ epochs.failed_class }}">{{ epochs.failed_count }}</div></div>
+    <div class="kpi"><div class="kpi-label">Diagnostics failed</div><div class="kpi-value warning">{{ epochs.diagnostics_failure_count }}</div></div>
+    <div class="kpi"><div class="kpi-label">Duration</div><div class="kpi-value success">{{ epochs.duration }}</div></div>
+  </div>
+{% if epochs.has_discovery_error %}<div class="fatal">{{ epochs.discovery_error }}</div>{% endif %}
+{% if epochs.has_failures %}
+  <h3>Failed epochs ({{ epochs.failed_count }})</h3>
+  <table><thead><tr><th>Epoch</th><th>Error</th></tr></thead><tbody>
+{% for f in epochs.failures %}
+    <tr><td class="num"><strong>{{ f.epoch }}</strong></td><td>{{ f.error }}</td></tr>
+{% endfor %}
+  </tbody></table>
+{% endif %}
+{% if epochs.has_diagnostics_failures %}
+  <h3>Diagnostics warnings ({{ epochs.diagnostics_failure_count }})</h3>
+  <table><thead><tr><th>Epoch</th><th>Error</th></tr></thead><tbody>
+{% for f in epochs.diagnostics_failures %}
+    <tr><td class="num"><strong>{{ f.epoch }}</strong></td><td>{{ f.error }}</td></tr>
+{% endfor %}
+  </tbody></table>
+{% endif %}
+{% if epochs.has_unparsable %}
+  <h3>Unparsable rows ({{ epochs.unparsable_count }})</h3>
+  <table><thead><tr><th>CF</th><th>Source</th><th>Key</th><th>Error</th></tr></thead><tbody>
+{% for u in epochs.unparsable %}
+    <tr><td><code>{{ u.cf }}</code></td><td>{{ u.source }}</td><td><code class="mono break">{{ u.key_hex }}</code></td><td>{{ u.error }}</td></tr>
+{% endfor %}
+  </tbody></table>
+{% endif %}
+</div>
+{% endif %}
+</section>
+
+<h2>Run configuration</h2>
+<table><tbody>
+  <tr><th class="path-key">Environment label</th><td>{{ env_label }}</td></tr>
+{% for r in path_rows %}
+  <tr><th class="path-key">{{ r.label }}</th><td><code class="mono break">{{ r.path }}</code></td></tr>
+{% endfor %}
+</tbody></table>
+
+</div>
+</body>
+</html>

--- a/crates/agglayer/src/templates/migration-report.md
+++ b/crates/agglayer/src/templates/migration-report.md
@@ -1,0 +1,32 @@
+## {{ env_label }}
+
+Migration run at {{ started_at }} UTC, total {{ overall_duration }}. Status: **{{ status_label }}**.
+
+| Store | Status | Duration | Notes |
+|---|---|---:|---|
+{%- for row in rows %}
+| {{ row.label }} | {{ row.status }} | {{ row.duration }} | {{ row.notes }} |
+{%- endfor %}
+
+{% if !is_success -%}
+**Fatal errors**
+
+{% for fatal in fatals -%}
+- {{ fatal.label }}: {{ fatal.error }}
+{% endfor %}
+{% endif -%}
+{% if !diagnostics_warnings.is_empty() -%}
+**Diagnostics warnings**
+
+{% for warning in diagnostics_warnings -%}
+- {{ warning.label }}: {{ warning.error }}
+{% endfor %}
+{% endif -%}
+{% if has_unparsable -%}
+**Unparsable rows ({{ unparsable_count }})**
+
+{% for u in unparsable -%}
+- `{{ u.cf }}` ({{ u.source }}) at key `{{ u.key_hex }}`: {{ u.error }}
+{% endfor %}
+{% endif -%}
+---


### PR DESCRIPTION
Add the agglayer migrate-storage command and human-readable migration reports.

The command runs explicit storage migration and can render Markdown or self-contained HTML diagnostics for operator review.