### PR TITLE
fix(storage): make pending certificate writes atomic

### DIFF
--- a/crates/agglayer-storage/src/stores/pending/mod.rs
+++ b/crates/agglayer-storage/src/stores/pending/mod.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use agglayer_types::{Certificate, CertificateId, Height, NetworkId, Proof};
-use rocksdb::{Direction, ReadOptions};
+use rocksdb::{Direction, ReadOptions, WriteBatch};
 
 use super::{PendingCertificateReader, PendingCertificateWriter};
 use crate::{
@@ -134,11 +134,19 @@ impl PendingCertificateWriter for PendingStore {
             }
         }
 
-        // TODO: make it batch
-        self.set_latest_pending_certificate_per_network(&network_id, &height, &certificate.hash())?;
-        Ok(self
-            .db
-            .put::<PendingQueueProtoColumn>(&PendingQueueKey(network_id, height), certificate)?)
+        let latest = PendingCertificate(certificate.hash(), height);
+        let pending_key = PendingQueueKey(network_id, height);
+        let mut batch = WriteBatch::default();
+        self.db
+            .multi_insert_batch::<LatestPendingCertificatePerNetworkColumn>(
+                [(&network_id, &latest)],
+                &mut batch,
+            )?;
+        self.db.multi_insert_batch::<PendingQueueProtoColumn>(
+            [(&pending_key, certificate)],
+            &mut batch,
+        )?;
+        Ok(self.db.write_batch(batch)?)
     }
 
     fn insert_generated_proof(

--- a/crates/agglayer-storage/src/stores/pending/tests.rs
+++ b/crates/agglayer-storage/src/stores/pending/tests.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use agglayer_types::{Certificate, CertificateId, Height, NetworkId, Proof};
 use pessimistic_proof_test_suite::sample_data;
@@ -115,6 +115,25 @@ fn insert_pending_certificate_writes_proto_bytes() {
     let decoded = Certificate::try_from(proto).unwrap();
 
     assert_eq!(decoded, certificate);
+}
+
+#[test]
+fn insert_pending_certificate_does_not_leave_latest_pointer_after_row_write_failure() {
+    let tmp = TempDBDir::new();
+    let db = crate::storage::DB::open_cf(&tmp.path, super::cf_definitions::PENDING_DB_V0).unwrap();
+    let store = PendingStore::new(Arc::new(db));
+    let certificate = Certificate::new_for_test(NetworkId::new(1), Height::ZERO);
+
+    let error =
+        store.insert_pending_certificate(certificate.network_id, certificate.height, &certificate);
+
+    assert!(error.is_err());
+    assert_eq!(
+        store
+            .get_latest_pending_certificate_for_network(&certificate.network_id)
+            .unwrap(),
+        None
+    );
 }
 
 #[test]


### PR DESCRIPTION
Make pending certificate writes update the certificate row before the latest pointer.

This avoids leaving a latest-certificate pointer behind when the certificate row write fails, preserving pending-store consistency.