### PR TITLE
fix(storage): reject implicit startup migrations

### DIFF
--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -85,8 +85,12 @@ impl Node {
         }
 
         // Initializing storage
-        let pending_db = Arc::new(PendingStore::init_db(&config.storage.pending_db_path)?);
-        let state_db = Arc::new(StateStore::init_db(&config.storage.state_db_path)?);
+        let pending_db = Arc::new(PendingStore::open_migrated_or_create_db(
+            &config.storage.pending_db_path,
+        )?);
+        let state_db = Arc::new(StateStore::open_migrated_or_create_db(
+            &config.storage.state_db_path,
+        )?);
 
         // Initialize backup engine
         let backup_client = if let BackupConfig::Enabled {
@@ -112,7 +116,9 @@ impl Node {
         let state_store = Arc::new(StateStore::new(state_db, backup_client.clone()));
         let pending_store = Arc::new(PendingStore::new(pending_db));
         let debug_store = if config.debug_mode {
-            Arc::new(DebugStore::new_with_path(&config.storage.debug_db_path)?)
+            Arc::new(DebugStore::open_migrated_or_create(
+                &config.storage.debug_db_path,
+            )?)
         } else {
             Arc::new(DebugStore::Disabled)
         };

--- a/crates/agglayer-storage/src/storage/migration/mod.rs
+++ b/crates/agglayer-storage/src/storage/migration/mod.rs
@@ -30,27 +30,39 @@ pub(crate) fn open_migrated_or_create(
     let inspection = inspect_schema(path, cfs_v0, current_cfs, declared_steps);
     match inspection.status {
         SchemaStatus::Missing | SchemaStatus::Empty | SchemaStatus::Current => open(path),
+        status => Err(storage_gate_error(path, status)),
+    }
+}
+
+/// Maps a schema status that is not openable into the appropriate open error.
+///
+/// Shared by the read-write gate ([`open_migrated_or_create`]) and the
+/// read-only gates so that an inspection failure and storage written by a
+/// newer binary are reported distinctly from a genuine migration requirement,
+/// rather than all being collapsed into [`DBOpenError::StorageNeedsMigration`].
+pub(crate) fn storage_gate_error(path: &Path, status: SchemaStatus) -> DBOpenError {
+    match status {
         // A failed inspection is an I/O/permission problem, not a migration
-        // requirement: surface it as such so operators don't run a migration
-        // that cannot fix it.
-        SchemaStatus::Unreadable(reason) => Err(DBOpenError::StorageInspectionFailed {
+        // requirement: surface it so operators don't run a migration that
+        // cannot fix it.
+        SchemaStatus::Unreadable(reason) => DBOpenError::StorageInspectionFailed {
             path: path.to_path_buf(),
             reason,
-        }),
+        },
         // More recorded steps than this binary declares means the storage was
         // written by a newer agglayer-node; the fix is to upgrade the binary,
         // not to migrate forward.
         SchemaStatus::FutureMigrationRecords { declared, recorded } => {
-            Err(DBOpenError::StorageFromNewerVersion {
+            DBOpenError::StorageFromNewerVersion {
                 path: path.to_path_buf(),
                 declared,
                 recorded,
-            })
+            }
         }
-        status => Err(DBOpenError::StorageNeedsMigration {
+        status => DBOpenError::StorageNeedsMigration {
             path: path.to_path_buf(),
             status,
-        }),
+        },
     }
 }
 

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -14,11 +14,11 @@ use crate::schema::{
 pub(crate) mod iterators;
 mod migration;
 
-pub(crate) use migration::open_migrated_or_create;
 pub use migration::{
     inspect_schema, Builder, DBMigrationError, DBMigrationErrorDetails, DBOpenError, DbAccess,
     SchemaInspection, SchemaStatus,
 };
+pub(crate) use migration::{open_migrated_or_create, storage_gate_error};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DBError {

--- a/crates/agglayer-storage/src/stores/debug/mod.rs
+++ b/crates/agglayer-storage/src/stores/debug/mod.rs
@@ -15,6 +15,8 @@ pub(crate) mod cf_definitions;
 #[cfg(test)]
 mod tests;
 
+const DECLARED_MIGRATION_STEPS: u32 = 2;
+
 pub enum DebugStore {
     Enabled(EnabledDebugStore),
     Disabled,
@@ -36,12 +38,27 @@ impl DebugStore {
             .finalize(cf_definitions::DEBUG_DB)
     }
 
+    pub fn open_migrated_or_create_db(path: &Path) -> Result<DB, crate::storage::DBOpenError> {
+        crate::storage::open_migrated_or_create(
+            path,
+            cf_definitions::DEBUG_DB_V0,
+            cf_definitions::DEBUG_DB,
+            DECLARED_MIGRATION_STEPS,
+            Self::init_db,
+        )
+    }
+
     pub fn new(db: Arc<DB>) -> Self {
         Self::Enabled(EnabledDebugStore { db })
     }
 
     pub fn new_with_path(path: &Path) -> Result<Self, crate::storage::DBOpenError> {
         let db = Arc::new(Self::init_db(path)?);
+        Ok(Self::new(db))
+    }
+
+    pub fn open_migrated_or_create(path: &Path) -> Result<Self, crate::storage::DBOpenError> {
+        let db = Arc::new(Self::open_migrated_or_create_db(path)?);
         Ok(Self::new(db))
     }
 }

--- a/crates/agglayer-storage/src/stores/debug/tests.rs
+++ b/crates/agglayer-storage/src/stores/debug/tests.rs
@@ -192,3 +192,44 @@ fn reopening_debug_store_skips_unparsable_legacy_rows() {
         "the corrupt row should be skipped, not migrated"
     );
 }
+
+fn create_raw_debug_v0(path: &std::path::Path) {
+    let mut options = rocksdb::Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let descriptors = super::cf_definitions::DEBUG_DB_V0
+        .iter()
+        .map(|cf| rocksdb::ColumnFamilyDescriptor::new(cf.name(), rocksdb::Options::default()));
+    let db = rocksdb::DB::open_cf_descriptors(&options, path, descriptors).unwrap();
+    drop(db);
+}
+
+#[test]
+fn migrated_or_create_debug_creates_missing_storage() {
+    let tmp = TempDBDir::new();
+    let path = tmp.path.join("debug");
+
+    let db = DebugStore::open_migrated_or_create_db(&path).unwrap();
+    drop(db);
+
+    let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &path).unwrap();
+    assert!(cfs.contains(&DebugCertificatesProtoColumn::COLUMN_FAMILY_NAME.to_string()));
+}
+
+#[test]
+fn migrated_or_create_debug_rejects_legacy_storage_without_mutating_it() {
+    let tmp = TempDBDir::new();
+    create_raw_debug_v0(&tmp.path);
+
+    let error = match DebugStore::open_migrated_or_create_db(&tmp.path) {
+        Ok(_) => panic!("migrated-or-create open should reject legacy debug storage"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        crate::storage::DBOpenError::StorageNeedsMigration { .. }
+    ));
+    let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &tmp.path).unwrap();
+    assert!(!cfs.contains(&DebugCertificatesProtoColumn::COLUMN_FAMILY_NAME.to_string()));
+}

--- a/crates/agglayer-storage/src/stores/debug/tests.rs
+++ b/crates/agglayer-storage/src/stores/debug/tests.rs
@@ -233,3 +233,10 @@ fn migrated_or_create_debug_rejects_legacy_storage_without_mutating_it() {
     let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &tmp.path).unwrap();
     assert!(!cfs.contains(&DebugCertificatesProtoColumn::COLUMN_FAMILY_NAME.to_string()));
 }
+
+#[test]
+fn migrated_or_create_debug_roundtrips_as_current() {
+    // Guards this store's DECLARED_MIGRATION_STEPS against init_db's recorded
+    // step count; see crate::tests::assert_storage_gate_roundtrips.
+    crate::tests::assert_storage_gate_roundtrips(DebugStore::open_migrated_or_create_db);
+}

--- a/crates/agglayer-storage/src/stores/pending/mod.rs
+++ b/crates/agglayer-storage/src/stores/pending/mod.rs
@@ -25,6 +25,8 @@ pub(crate) mod cf_definitions;
 #[cfg(test)]
 mod tests;
 
+const DECLARED_MIGRATION_STEPS: u32 = 2;
+
 /// A logical store for pending.
 #[derive(Clone)]
 pub struct PendingStore {
@@ -41,12 +43,26 @@ impl PendingStore {
             .finalize(cf_definitions::PENDING_DB)
     }
 
+    pub fn open_migrated_or_create_db(path: &Path) -> Result<DB, crate::storage::DBOpenError> {
+        crate::storage::open_migrated_or_create(
+            path,
+            cf_definitions::PENDING_DB_V0,
+            cf_definitions::PENDING_DB,
+            DECLARED_MIGRATION_STEPS,
+            Self::init_db,
+        )
+    }
+
     pub fn new(db: Arc<DB>) -> Self {
         Self { db }
     }
 
     pub fn new_with_path(path: &Path) -> Result<Self, crate::storage::DBOpenError> {
         Ok(Self::new(Arc::new(Self::init_db(path)?)))
+    }
+
+    pub fn open_migrated_or_create(path: &Path) -> Result<Self, crate::storage::DBOpenError> {
+        Ok(Self::new(Arc::new(Self::open_migrated_or_create_db(path)?)))
     }
 
     fn decode_readable_proof(certificate_id: CertificateId, bytes: &[u8]) -> Result<Proof, Error> {

--- a/crates/agglayer-storage/src/stores/pending/tests.rs
+++ b/crates/agglayer-storage/src/stores/pending/tests.rs
@@ -210,3 +210,44 @@ fn multi_get_proof_reports_unreadable_pending_proofs() {
 
     assert!(matches!(err, Error::UnreadableProof { id, .. } if id == invalid_id));
 }
+
+fn create_raw_pending_v0(path: &std::path::Path) {
+    let mut options = rocksdb::Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let descriptors = super::cf_definitions::PENDING_DB_V0
+        .iter()
+        .map(|cf| rocksdb::ColumnFamilyDescriptor::new(cf.name(), rocksdb::Options::default()));
+    let db = rocksdb::DB::open_cf_descriptors(&options, path, descriptors).unwrap();
+    drop(db);
+}
+
+#[test]
+fn migrated_or_create_pending_creates_missing_storage() {
+    let tmp = TempDBDir::new();
+    let path = tmp.path.join("pending");
+
+    let db = PendingStore::open_migrated_or_create_db(&path).unwrap();
+    drop(db);
+
+    let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &path).unwrap();
+    assert!(cfs.contains(&PendingQueueProtoColumn::COLUMN_FAMILY_NAME.to_string()));
+}
+
+#[test]
+fn migrated_or_create_pending_rejects_legacy_storage_without_mutating_it() {
+    let tmp = TempDBDir::new();
+    create_raw_pending_v0(&tmp.path);
+
+    let error = match PendingStore::open_migrated_or_create_db(&tmp.path) {
+        Ok(_) => panic!("migrated-or-create open should reject legacy pending storage"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        crate::storage::DBOpenError::StorageNeedsMigration { .. }
+    ));
+    let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &tmp.path).unwrap();
+    assert!(!cfs.contains(&PendingQueueProtoColumn::COLUMN_FAMILY_NAME.to_string()));
+}

--- a/crates/agglayer-storage/src/stores/pending/tests.rs
+++ b/crates/agglayer-storage/src/stores/pending/tests.rs
@@ -251,3 +251,10 @@ fn migrated_or_create_pending_rejects_legacy_storage_without_mutating_it() {
     let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &tmp.path).unwrap();
     assert!(!cfs.contains(&PendingQueueProtoColumn::COLUMN_FAMILY_NAME.to_string()));
 }
+
+#[test]
+fn migrated_or_create_pending_roundtrips_as_current() {
+    // Guards this store's DECLARED_MIGRATION_STEPS against init_db's recorded
+    // step count; see crate::tests::assert_storage_gate_roundtrips.
+    crate::tests::assert_storage_gate_roundtrips(PendingStore::open_migrated_or_create_db);
+}

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -93,10 +93,7 @@ impl<PendingStore, StateStore> PerEpochStore<PendingStore, StateStore> {
             crate::storage::SchemaStatus::Current => {
                 Ok(DB::open_cf_readonly(path, cf_definitions::EPOCHS_DB)?)
             }
-            status => Err(crate::storage::DBOpenError::StorageNeedsMigration {
-                path: path.to_path_buf(),
-                status,
-            }),
+            status => Err(crate::storage::storage_gate_error(path, status)),
         }
     }
 

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod cf_definitions;
 mod tests;
 
 const MAX_CERTIFICATE_PER_EPOCH: u64 = 1;
+const DECLARED_MIGRATION_STEPS: u32 = 2;
 
 /// A logical store for an Epoch.
 pub struct PerEpochStore<PendingStore, StateStore> {
@@ -67,6 +68,38 @@ impl<PendingStore, StateStore> PerEpochStore<PendingStore, StateStore> {
         DB::open_cf_readonly(path, cf_definitions::EPOCHS_DB)
     }
 
+    pub fn open_migrated_or_create_db(
+        path: &std::path::Path,
+    ) -> Result<DB, crate::storage::DBOpenError> {
+        crate::storage::open_migrated_or_create(
+            path,
+            cf_definitions::EPOCHS_DB_V0,
+            cf_definitions::EPOCHS_DB,
+            DECLARED_MIGRATION_STEPS,
+            Self::init_db,
+        )
+    }
+
+    pub fn open_migrated_readonly_db(
+        path: &std::path::Path,
+    ) -> Result<DB, crate::storage::DBOpenError> {
+        let inspection = crate::storage::inspect_schema(
+            path,
+            cf_definitions::EPOCHS_DB_V0,
+            cf_definitions::EPOCHS_DB,
+            DECLARED_MIGRATION_STEPS,
+        );
+        match inspection.status {
+            crate::storage::SchemaStatus::Current => {
+                Ok(DB::open_cf_readonly(path, cf_definitions::EPOCHS_DB)?)
+            }
+            status => Err(crate::storage::DBOpenError::StorageNeedsMigration {
+                path: path.to_path_buf(),
+                status,
+            }),
+        }
+    }
+
     #[tracing::instrument(skip_all, fields(store = "epoch", %epoch_number))]
     pub fn try_open(
         config: Arc<agglayer_config::Config>,
@@ -77,7 +110,7 @@ impl<PendingStore, StateStore> PerEpochStore<PendingStore, StateStore> {
         backup_client: BackupClient,
     ) -> Result<Self, Error> {
         let db = Arc::new(
-            Self::init_db(&config.storage.epoch_db_path(epoch_number))
+            Self::open_migrated_or_create_db(&config.storage.epoch_db_path(epoch_number))
                 .map_err(Error::DBOpenError)?,
         );
 
@@ -102,9 +135,10 @@ impl<PendingStore, StateStore> PerEpochStore<PendingStore, StateStore> {
         pending_store: Arc<PendingStore>,
         state_store: Arc<StateStore>,
     ) -> Result<Self, Error> {
-        let db = Arc::new(Self::init_db_readonly(
-            &config.storage.epoch_db_path(epoch_number),
-        )?);
+        let db = Arc::new(
+            Self::open_migrated_readonly_db(&config.storage.epoch_db_path(epoch_number))
+                .map_err(Error::DBOpenError)?,
+        );
 
         Self::try_open_with_db(
             db,

--- a/crates/agglayer-storage/src/stores/per_epoch/tests.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/tests.rs
@@ -25,7 +25,7 @@ use crate::{
     schema::{Codec as _, ColumnSchema as _},
     stores::{
         epochs::EpochsStore,
-        interfaces::writer::{PerEpochWriter, StateWriter},
+        interfaces::writer::{EpochStoreWriter as _, PerEpochWriter, StateWriter},
         pending::PendingStore,
         per_epoch::PerEpochStore,
         state::StateStore,
@@ -200,13 +200,15 @@ fn reopening_epoch_store_migrates_legacy_certificate_rows_to_proto() {
     seed_epoch_checkpoints(&epoch_path, network_id, height);
     write_raw_epoch_certificate_bytes(&epoch_path, index, legacy.clone());
 
-    let store = PerEpochStore::try_open(
-        config,
+    let db = Arc::new(PerEpochStore::<PendingStore, StateStore>::init_db(&epoch_path).unwrap());
+    let store = PerEpochStore::try_open_with_db(
+        db,
         epoch_number,
         pending_store,
         state_store,
         Some(std::iter::once((network_id, height)).collect()),
         BackupClient::noop(),
+        false,
     )
     .unwrap();
 
@@ -228,7 +230,7 @@ fn reopening_epoch_store_migrates_legacy_certificate_rows_to_proto() {
 }
 
 #[test]
-fn readonly_epoch_access_falls_back_to_legacy_cf_when_proto_cf_absent() {
+fn readonly_epoch_access_rejects_legacy_schema_when_proto_cf_absent() {
     let tmp = TempDBDir::new();
     let config = Arc::new(Config::new(&tmp.path));
     let epoch_number = EpochNumber::ZERO;
@@ -240,18 +242,88 @@ fn readonly_epoch_access_falls_back_to_legacy_cf_when_proto_cf_absent() {
     );
     let epochs_store =
         EpochsStore::new(config, pending_store, state_store, BackupClient::noop()).unwrap();
-    let expected = sample_data::load_certificate("n15-cert_h0.json");
     let legacy = load_v0_certificate_bytes("v0-n15-cert_h0.hex");
     let index = CertificateIndex::ZERO;
 
     write_raw_epoch_certificate_bytes(&epoch_path, index, legacy);
 
-    // The read must fall back to the still-present legacy CF instead of failing
-    // with `ColumnFamilyNotFound`.
-    assert_eq!(
-        epochs_store.get_certificate(epoch_number, index).unwrap(),
-        Some(expected)
+    let error = epochs_store
+        .get_certificate(epoch_number, index)
+        .expect_err("readonly epoch access should require migration for legacy storage");
+
+    assert!(matches!(
+        error,
+        Error::DBOpenError(crate::storage::DBOpenError::StorageNeedsMigration { .. })
+    ));
+
+    let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &epoch_path).unwrap();
+    assert!(!cfs.contains(&CertificatePerIndexProtoColumn::COLUMN_FAMILY_NAME.to_string()));
+}
+
+fn create_raw_epoch_v0(path: &std::path::Path) {
+    let mut options = rocksdb::Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let descriptors = super::cf_definitions::EPOCHS_DB_V0
+        .iter()
+        .map(|cf| rocksdb::ColumnFamilyDescriptor::new(cf.name(), rocksdb::Options::default()));
+    let db = rocksdb::DB::open_cf_descriptors(&options, path, descriptors).unwrap();
+    drop(db);
+}
+
+#[test]
+fn migrated_or_create_epoch_creates_missing_storage() {
+    let tmp = TempDBDir::new();
+    let path = tmp.path.join("epoch-7");
+
+    let db = PerEpochStore::<PendingStore, StateStore>::open_migrated_or_create_db(&path).unwrap();
+    drop(db);
+
+    let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &path).unwrap();
+    assert!(cfs.contains(&CertificatePerIndexProtoColumn::COLUMN_FAMILY_NAME.to_string()));
+}
+
+#[test]
+fn epochs_store_open_creates_missing_epoch_with_current_schema() {
+    let tmp = TempDBDir::new();
+    let config = Arc::new(Config::new(&tmp.path));
+    let epoch_number = EpochNumber::ZERO;
+    let epoch_path = config.storage.epoch_db_path(epoch_number);
+    let pending_store =
+        Arc::new(PendingStore::open_migrated_or_create(&config.storage.pending_db_path).unwrap());
+    let state_store = Arc::new(
+        StateStore::open_migrated_or_create(&config.storage.state_db_path, BackupClient::noop())
+            .unwrap(),
     );
+    let epochs_store =
+        EpochsStore::new(config, pending_store, state_store, BackupClient::noop()).unwrap();
+
+    assert!(!epoch_path.exists());
+
+    let epoch_store = epochs_store.open(epoch_number).unwrap();
+    drop(epoch_store);
+
+    let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &epoch_path).unwrap();
+    assert!(cfs.contains(&CertificatePerIndexProtoColumn::COLUMN_FAMILY_NAME.to_string()));
+}
+
+#[test]
+fn migrated_or_create_epoch_rejects_legacy_storage_without_mutating_it() {
+    let tmp = TempDBDir::new();
+    create_raw_epoch_v0(&tmp.path);
+
+    let error =
+        match PerEpochStore::<PendingStore, StateStore>::open_migrated_or_create_db(&tmp.path) {
+            Ok(_) => panic!("migrated-or-create open should reject legacy epoch storage"),
+            Err(error) => error,
+        };
+
+    assert!(matches!(
+        error,
+        crate::storage::DBOpenError::StorageNeedsMigration { .. }
+    ));
+    let cfs = rocksdb::DB::list_cf(&rocksdb::Options::default(), &tmp.path).unwrap();
+    assert!(!cfs.contains(&CertificatePerIndexProtoColumn::COLUMN_FAMILY_NAME.to_string()));
 }
 
 #[rstest]

--- a/crates/agglayer-storage/src/stores/per_epoch/tests.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/tests.rs
@@ -326,6 +326,37 @@ fn migrated_or_create_epoch_rejects_legacy_storage_without_mutating_it() {
     assert!(!cfs.contains(&CertificatePerIndexProtoColumn::COLUMN_FAMILY_NAME.to_string()));
 }
 
+#[test]
+fn migrated_or_create_epoch_roundtrips_as_current() {
+    // Guards this store's DECLARED_MIGRATION_STEPS against init_db's recorded
+    // step count; see crate::tests::assert_storage_gate_roundtrips.
+    crate::tests::assert_storage_gate_roundtrips(
+        PerEpochStore::<PendingStore, StateStore>::open_migrated_or_create_db,
+    );
+}
+
+#[test]
+fn migrated_readonly_epoch_reports_inspection_failure_for_unreadable_storage() {
+    // The read-only gate must report an inspection failure distinctly, like the
+    // read-write gate, rather than collapsing it into StorageNeedsMigration.
+    let tmp = TempDBDir::new();
+    let path = tmp.path.join("not-rocksdb");
+    std::fs::write(&path, b"not a rocksdb directory").unwrap();
+
+    let error = match PerEpochStore::<PendingStore, StateStore>::open_migrated_readonly_db(&path) {
+        Ok(_) => panic!("unreadable storage must not be opened read-only"),
+        Err(error) => error,
+    };
+
+    assert!(
+        matches!(
+            error,
+            crate::storage::DBOpenError::StorageInspectionFailed { .. }
+        ),
+        "expected StorageInspectionFailed, got {error:?}"
+    );
+}
+
 #[rstest]
 fn can_start_packing_an_unpacked_epoch(store: PerEpochStore<PendingStore, StateStore>) {
     assert!(store.start_packing().is_ok());


### PR DESCRIPTION
Require node startup and store open helpers to reject legacy storage that still needs explicit migration.

This keeps cross-chain settlement state changes operator-controlled instead of allowing startup paths to mutate storage implicitly.

BREAKING-CHANGE: Existing legacy storage must be migrated with agglayer migrate-storage before starting the node.