### PR TITLE
docs: remove stale PR-number references from comments

### DIFF
--- a/crates/agglayer-sp1/src/ext.rs
+++ b/crates/agglayer-sp1/src/ext.rs
@@ -13,7 +13,7 @@ use crate::{
 ///
 /// The trait keeps the `sp1-sdk` dependency hidden from callers in
 /// `agglayer-types` and `agglayer-grpc-types`, which must not depend on
-/// `sp1-sdk` directly after #1508's storage decoupling work.
+/// `sp1-sdk` directly after the storage decoupling work.
 pub trait ProofExt {
     /// Borrow the inner SP1 stark context carried by this proof.
     fn sp1(&self) -> &SP1StarkWithContext;

--- a/crates/agglayer-storage/src/columns/debug_certificates/mod.rs
+++ b/crates/agglayer-storage/src/columns/debug_certificates/mod.rs
@@ -6,8 +6,8 @@ use crate::types::LegacyCertificate;
 /// Legacy column family for debug certificates.
 ///
 /// Kept readable so the proto migration can backfill existing rows. The CF
-/// historically received bincode rows (pre-#1519) and proto rows
-/// (#1519..this PR), so its `Value` codec is `LegacyCertificate`, which
+/// historically received both bincode rows and (later) proto rows, so its
+/// `Value` codec is `LegacyCertificate`, which
 /// accepts both. Runtime reads and writes go through
 /// [`DebugCertificatesProtoColumn`].
 ///

--- a/crates/agglayer-storage/src/columns/epochs/certificates/mod.rs
+++ b/crates/agglayer-storage/src/columns/epochs/certificates/mod.rs
@@ -8,8 +8,8 @@ use crate::{
 /// Legacy column family for the certificates in an epoch.
 ///
 /// Kept readable so the proto migration can backfill existing rows. The CF
-/// historically received bincode rows (pre-#1519) and proto rows
-/// (#1519..this PR), so its `Value` codec is `LegacyCertificate`, which
+/// historically received both bincode rows and (later) proto rows, so its
+/// `Value` codec is `LegacyCertificate`, which
 /// accepts both. Runtime reads and writes go through
 /// [`CertificatePerIndexProtoColumn`].
 ///

--- a/crates/agglayer-storage/src/columns/pending_queue/mod.rs
+++ b/crates/agglayer-storage/src/columns/pending_queue/mod.rs
@@ -7,8 +7,8 @@ use crate::types::LegacyCertificate;
 /// Legacy column family for the pending certificates queue.
 ///
 /// Kept readable so the proto migration can backfill existing rows. The CF
-/// historically received bincode rows (pre-#1519) and proto rows
-/// (#1519..this PR), so its `Value` codec is `LegacyCertificate`, which
+/// historically received both bincode rows and (later) proto rows, so its
+/// `Value` codec is `LegacyCertificate`, which
 /// accepts both. Runtime reads and writes go through
 /// [`PendingQueueProtoColumn`].
 ///

--- a/crates/agglayer-storage/src/stores/migration_helpers.rs
+++ b/crates/agglayer-storage/src/stores/migration_helpers.rs
@@ -3,7 +3,7 @@
 //! The three certificate-bearing stores (pending, per-epoch, debug) all run
 //! the same shape of backfill at startup: iterate the legacy CF, decode
 //! each row through [`crate::types::LegacyCertificate`] (which accepts both
-//! historical bincode and post-#1519 proto), and write the resulting
+//! historical bincode and proto), and write the resulting
 //! [`agglayer_types::Certificate`] into the proto CF.
 //!
 //! This module provides one helper, [`copy_legacy_certificate_cf_into_proto`],

--- a/crates/agglayer-storage/src/stores/pending/mod.rs
+++ b/crates/agglayer-storage/src/stores/pending/mod.rs
@@ -84,7 +84,7 @@ impl PendingStore {
 /// [`super::migration_helpers::copy_legacy_certificate_cf_into_proto`],
 /// which streams the legacy keyspace, skips and logs rows whose bytes cannot
 /// be decoded as a certificate, and copies the rest into the proto CF. The
-/// legacy CF stays in place for this PR; runtime reads and writes only use
+/// legacy CF stays in place for now; runtime reads and writes only use
 /// the proto CF after this backfill completes.
 fn backfill_pending_certificates_proto_from_legacy_bincode(
     db: &crate::storage::DbAccess,

--- a/crates/agglayer-storage/src/types/certificate/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/mod.rs
@@ -14,8 +14,8 @@
 //!   column families. Encoding emits `v1` bincode (runtime code does not write
 //!   to legacy CFs after the proto migration). Decoding accepts *either* legacy
 //!   bincode (`v0`/`v1`) *or* protobuf, because the legacy CFs historically
-//!   received both: bincode rows pre-#1519 and proto rows between #1519 (proto
-//!   codec switch) and this PR (proto CF split).
+//!   received both: bincode rows from before the proto codec switch and proto
+//!   rows written before the proto CF split.
 //!
 //! Splitting the codecs is deliberate: the proto CF is byte-unambiguous and
 //! its codec is strictly proto. Format sniffing is restricted to the
@@ -397,10 +397,10 @@ impl crate::schema::Codec for Certificate {
 /// deliberately permissive about format because the legacy CFs received
 /// rows in *both* historical encodings:
 ///
-/// * Bincode `v0`/`v1` rows written before the proto codec switch (#1519).
-/// * Proto rows written between #1519 (proto codec became the default encode
-///   for `Certificate`) and this PR (which created dedicated proto-backed CFs
-///   and moved runtime writes there).
+/// * Bincode `v0`/`v1` rows written before the proto codec switch.
+/// * Proto rows written after the proto codec became the default encode for
+///   `Certificate` but before dedicated proto-backed CFs took over runtime
+///   writes.
 ///
 /// Decoding tries the bincode path on first byte `0` or `1` and falls back
 /// to proto for anything else. Encoding is intentionally unsupported because
@@ -439,8 +439,8 @@ impl crate::schema::Codec for LegacyCertificate {
             Some(0) => decode_v0(bytes)?,
             Some(1) => decode_legacy::<CertificateV1>(bytes)?,
             Some(_) => {
-                // Post-#1519 / pre-this-PR rows were proto-encoded into the
-                // legacy CF before runtime writes moved to the proto CF.
+                // These rows were proto-encoded into the legacy CF before
+                // runtime writes moved to the proto CF.
                 let proto = proto::Certificate::decode(bytes)?;
                 Certificate::try_from(proto)
                     .map_err(|error| CodecError::Conversion(error.to_string()))?

--- a/crates/agglayer-storage/src/types/certificate/tests/mod.rs
+++ b/crates/agglayer-storage/src/types/certificate/tests/mod.rs
@@ -382,7 +382,7 @@ fn encoding_starts_with(#[case] cert: impl Serialize, #[case] start: &[u8]) {
 
 // SP1 v6 made the legacy `CertificateV1` → `Certificate` conversion fallible
 // (`TryFrom`) and dropped the `From<&Certificate> for CertificateV1` impl, so
-// the synthesised round-trip case from #1519 is no longer expressible. The
+// the synthesised round-trip case is no longer expressible. The
 // pre-existing fixtures still exercise the legacy CF decode path.
 #[rstest::rstest]
 #[case(CertificateV0::test0(), Certificate::from(CertificateV0::test0()))]
@@ -503,7 +503,7 @@ fn legacy_certificate_decode_per_byte_dispatch() {
     }
 
     // Other bytes enter the proto path. The legacy CF carried proto rows
-    // between #1519 and this PR, so this branch must be live. With no
+    // before the proto CF split, so this branch must be live. With no
     // payload the proto decoder either rejects the bytes outright or
     // produces a default-valued message that fails `Certificate::try_from`.
     for v in 2..=u8::MAX {


### PR DESCRIPTION
Issue #1535 asked to clean up code comments that referenced specific
PR numbers, which become meaningless once merged. Reword the affected
doc and inline comments in agglayer-storage and agglayer-sp1 to drop
"#1519", "#1508", and "this PR" markers while preserving the migration
context they described (legacy column families decode both historical
bincode and later proto rows).

The pull/819 permalink in agglayer-certificate-orchestrator is kept
intentionally, as it documents real design rationale rather than an
ephemeral "this PR" marker.

Comment-only change: no code, doctests, or intra-doc links altered.

Closes #1535
