### PR TITLE
fix(build): stamp agglayer version in docker images via build-arg

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,6 +37,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Full history + tags so `git describe --tags` resolves a real
+          # version for the build-args below (default checkout is shallow).
+          fetch-depth: 0
+
+      - name: Compute build version
+        id: version
+        run: |
+          echo "describe=$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
+          echo "timestamp=$(git log -1 --format=%cI)" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -69,6 +79,9 @@ jobs:
           # platforms: linux/amd64,linux/arm64
           push: ${{ inputs.push }}
           file: ${{ inputs.file }}
+          build-args: |
+            AGGLAYER_BUILD_DESCRIBE=${{ steps.version.outputs.describe }}
+            AGGLAYER_BUILD_TIMESTAMP=${{ steps.version.outputs.timestamp }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: ${{ inputs.push == true && 'type=image' || format('type=docker,dest={0}/{1}.tar', inputs.local-artifact-dir, inputs.local-artifact-name) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,16 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Full history + tags so `git describe --tags` resolves a real
+          # version for the build-args below (default checkout is shallow).
+          fetch-depth: 0
+
+      - name: Compute build version
+        id: version
+        run: |
+          echo "describe=$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
+          echo "timestamp=$(git log -1 --format=%cI)" >> "$GITHUB_OUTPUT"
 
       - name: Docker meta
         id: meta
@@ -79,6 +89,9 @@ jobs:
           context: .
           push: false
           platforms: ${{ matrix.platform }}
+          build-args: |
+            AGGLAYER_BUILD_DESCRIBE=${{ steps.version.outputs.describe }}
+            AGGLAYER_BUILD_TIMESTAMP=${{ steps.version.outputs.timestamp }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,15 @@ COPY --link crates crates
 COPY --link Cargo.toml Cargo.toml
 COPY --link Cargo.lock Cargo.lock
 
+# Version stamping: no `.git` is copied into the build context, so `vergen`
+# cannot derive the version and falls back to a `VERGEN_IDEMPOTENT_OUTPUT`
+# placeholder. The caller (CI) computes these from git and passes them in;
+# `version()` prefers them over the vergen-derived values.
+ARG AGGLAYER_BUILD_DESCRIBE
+ARG AGGLAYER_BUILD_TIMESTAMP
+ENV AGGLAYER_BUILD_DESCRIBE=${AGGLAYER_BUILD_DESCRIBE}
+ENV AGGLAYER_BUILD_TIMESTAMP=${AGGLAYER_BUILD_TIMESTAMP}
+
 RUN cargo build --release --bin agglayer
 
 

--- a/crates/agglayer/build.rs
+++ b/crates/agglayer/build.rs
@@ -3,6 +3,12 @@ use vergen_git2::{Emitter, Git2Builder};
 
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
+
+    // Rebuild `version()` when the build-time version overrides change. These
+    // are supplied by the Docker image build, where no `.git` is available.
+    println!("cargo:rerun-if-env-changed=AGGLAYER_BUILD_DESCRIBE");
+    println!("cargo:rerun-if-env-changed=AGGLAYER_BUILD_TIMESTAMP");
+
     Emitter::new()
         .add_instructions(
             &Git2Builder::default()

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -98,11 +98,33 @@ fn install_default_crypto_provider() {
 }
 
 /// Common version information about the executed agglayer binary.
+///
+/// The git describe and commit timestamp are resolved at compile time. They
+/// default to the values derived from the local `.git` repository by `vergen`,
+/// but can be overridden via the `AGGLAYER_BUILD_DESCRIBE` and
+/// `AGGLAYER_BUILD_TIMESTAMP` environment variables. The override path exists
+/// for builds without a `.git` directory (e.g. the Docker image build), where
+/// `vergen` would otherwise emit a `VERGEN_IDEMPOTENT_OUTPUT` placeholder.
 pub fn version() -> String {
     let pkg_name = env!("CARGO_PKG_NAME");
-    let git_describe = env!("VERGEN_GIT_DESCRIBE");
-    let timestamp = env!("VERGEN_GIT_COMMIT_TIMESTAMP");
+    let git_describe = resolve_build_value(
+        option_env!("AGGLAYER_BUILD_DESCRIBE"),
+        env!("VERGEN_GIT_DESCRIBE"),
+    );
+    let timestamp = resolve_build_value(
+        option_env!("AGGLAYER_BUILD_TIMESTAMP"),
+        env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
+    );
     format!("{pkg_name} ({git_describe}) [git commit timestamp: {timestamp}]")
+}
+
+/// Prefer an explicit build-time override, falling back to the git-derived
+/// value when the override is absent or empty.
+fn resolve_build_value<'a>(override_value: Option<&'a str>, fallback: &'a str) -> &'a str {
+    match override_value {
+        Some(value) if !value.is_empty() => value,
+        _ => fallback,
+    }
 }
 
 pub async fn compute_program_vkey(program: &'static [u8]) -> eyre::Result<String> {
@@ -119,5 +141,23 @@ mod tests {
         super::install_default_crypto_provider();
 
         assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
+
+    #[test]
+    fn build_value_prefers_override_when_present() {
+        assert_eq!(
+            super::resolve_build_value(Some("v1.2.3-7-gabc1234"), "fallback"),
+            "v1.2.3-7-gabc1234"
+        );
+    }
+
+    #[test]
+    fn build_value_falls_back_when_override_absent() {
+        assert_eq!(super::resolve_build_value(None, "fallback"), "fallback");
+    }
+
+    #[test]
+    fn build_value_falls_back_when_override_is_empty() {
+        assert_eq!(super::resolve_build_value(Some(""), "fallback"), "fallback");
     }
 }


### PR DESCRIPTION
The node startup log printed `VERGEN_IDEMPOTENT_OUTPUT` instead of a
version because the Docker build never receives a `.git` directory, so
vergen cannot derive the git describe/timestamp at compile time.

Resolve the version at compile time from `AGGLAYER_BUILD_DESCRIBE` and
`AGGLAYER_BUILD_TIMESTAMP` when set, falling back to vergen's
git-derived values. Local `cargo build` keeps auto-versioning from
`.git`; Docker and CI builds pass the values explicitly.

- main.rs: prefer the override env vars, fall back to vergen
- build.rs: rerun the build script when the override vars change
- Dockerfile: declare ARG/ENV before `cargo build`, after chef cook so
  the dependency cache is preserved
- docker-build.yml / release.yml: fetch full history and tags, compute
  `git describe --tags --always --dirty` and the commit timestamp, and
  pass them as build-args

A build without the override degrades to vergen's previous behavior
instead of breaking.
