### PR TITLE
feat(settlement): build a signed settlement attempt with new nonce

### DIFF
--- a/crates/agglayer-config/src/multiplier.rs
+++ b/crates/agglayer-config/src/multiplier.rs
@@ -71,13 +71,16 @@ impl Multiplier {
 
     pub fn saturating_mul_duration(self, duration: Duration) -> Duration {
         Duration::from_millis(
-            (duration
-                .as_millis()
-                .saturating_mul(u128::from(self.as_u64_per_1000()))
-                / 1000)
+            self.saturating_mul_u128(duration.as_millis())
                 .try_into()
                 .unwrap_or(u64::MAX),
         )
+    }
+
+    /// Multiplies `value` by this multiplier (fixed-point, scaled by 1000),
+    /// saturating instead of overflowing.
+    pub fn saturating_mul_u128(self, value: u128) -> u128 {
+        value.saturating_mul(u128::from(self.as_u64_per_1000())) / u128::from(Self::SCALE)
     }
 
     fn scale_f64(x: f64) -> f64 {

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -44,6 +44,8 @@ fn apply_multiplier_u128(value: u128, multiplier: Multiplier) -> u128 {
     value.saturating_mul(u128::from(multiplier.as_u64_per_1000())) / 1000
 }
 
+/// Clamps `value` into `[floor, ceiling]`. When `floor > ceiling` the ceiling
+/// wins (unlike [`Ord::clamp`], this never panics on an inverted range).
 fn clamp_u128(value: u128, floor: u128, ceiling: u128) -> u128 {
     value.max(floor).min(ceiling)
 }
@@ -769,6 +771,10 @@ impl<
             config.max_fee_per_gas_floor,
             config.max_fee_per_gas_ceiling,
         );
+        // The priority fee must never exceed the max fee, otherwise the
+        // transaction is invalid. Independent per-field floors/ceilings could
+        // otherwise produce `priority > max_fee` under misconfiguration, so we
+        // cap it here to keep the EIP-1559 invariant at the point of resolution.
         let max_priority_fee_per_gas = clamp_u128(
             apply_multiplier_u128(
                 estimate.max_priority_fee_per_gas,
@@ -776,7 +782,8 @@ impl<
             ),
             config.max_priority_fee_per_gas_floor,
             config.max_priority_fee_per_gas_ceiling,
-        );
+        )
+        .min(max_fee_per_gas);
 
         let gas_limit_ceiling = u128::try_from(config.gas_limit_ceiling).unwrap_or(u128::MAX);
         let gas_limit_u128 =
@@ -1493,18 +1500,18 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::field_reassign_with_default)] // Field-by-field config keeps the test readable.
     fn resolve_base_gas_params_applies_multiplier_floor_and_ceiling() {
-        // `Multiplier` is in scope via the module-level import + `super::*`.
-        let mut config = SettlementTransactionConfig::default();
-        config.gas_limit_multiplier_factor = Multiplier::from_u64_per_1000(2000); // 2.0x
-        config.gas_limit_ceiling = U256::from(150_000u64);
-        config.max_fee_per_gas_multiplier_factor = Multiplier::from_u64_per_1000(1000);
-        config.max_fee_per_gas_floor = 1_000_000_000; // 1 gwei
-        config.max_fee_per_gas_ceiling = 50_000_000_000; // 50 gwei
-        config.max_priority_fee_per_gas_multiplier_factor = Multiplier::from_u64_per_1000(1000);
-        config.max_priority_fee_per_gas_floor = 2_000_000_000; // 2 gwei
-        config.max_priority_fee_per_gas_ceiling = 50_000_000_000; // 50 gwei
+        let config = SettlementTransactionConfig {
+            gas_limit_multiplier_factor: Multiplier::from_u64_per_1000(2000), // 2.0x
+            gas_limit_ceiling: U256::from(150_000u64),
+            max_fee_per_gas_multiplier_factor: Multiplier::from_u64_per_1000(1000),
+            max_fee_per_gas_floor: 1_000_000_000,    // 1 gwei
+            max_fee_per_gas_ceiling: 50_000_000_000, // 50 gwei
+            max_priority_fee_per_gas_multiplier_factor: Multiplier::from_u64_per_1000(1000),
+            max_priority_fee_per_gas_floor: 2_000_000_000, // 2 gwei
+            max_priority_fee_per_gas_ceiling: 50_000_000_000, // 50 gwei
+            ..Default::default()
+        };
 
         let mut task = mk_task(Arc::new(MockStateStore::new()), BTreeMap::new());
         task.tx_config = Arc::new(config);
@@ -1525,5 +1532,61 @@ mod tests {
         assert_eq!(gas.gas_limit, 150_000);
         assert_eq!(gas.max_fee_per_gas, 50_000_000_000);
         assert_eq!(gas.max_priority_fee_per_gas, 2_000_000_000);
+    }
+
+    #[test]
+    fn resolve_base_gas_params_scales_fees_by_multiplier() {
+        // Multipliers scale an estimate that lands strictly inside [floor, ceiling],
+        // so this exercises the multiply path (not just clamping).
+        let config = SettlementTransactionConfig {
+            max_fee_per_gas_multiplier_factor: Multiplier::from_u64_per_1000(1500), // 1.5x
+            max_fee_per_gas_floor: 1_000_000_000,                                   // 1 gwei
+            max_fee_per_gas_ceiling: 50_000_000_000,                                // 50 gwei
+            max_priority_fee_per_gas_multiplier_factor: Multiplier::from_u64_per_1000(1500), // 1.5x
+            max_priority_fee_per_gas_floor: 0,
+            max_priority_fee_per_gas_ceiling: 50_000_000_000, // 50 gwei
+            ..Default::default()
+        };
+
+        let mut task = mk_task(Arc::new(MockStateStore::new()), BTreeMap::new());
+        task.tx_config = Arc::new(config);
+
+        let estimate = Eip1559Estimation {
+            max_fee_per_gas: 10_000_000_000,         // 10 gwei * 1.5 -> 15 gwei
+            max_priority_fee_per_gas: 4_000_000_000, // 4 gwei * 1.5 -> 6 gwei
+        };
+
+        let gas = task.resolve_base_gas_params(&estimate);
+
+        assert_eq!(gas.max_fee_per_gas, 15_000_000_000);
+        assert_eq!(gas.max_priority_fee_per_gas, 6_000_000_000);
+    }
+
+    #[test]
+    fn resolve_base_gas_params_caps_priority_fee_at_max_fee() {
+        // A priority floor above the max-fee ceiling would otherwise produce an
+        // invalid `priority > max_fee`; the resolver must cap priority at max_fee.
+        let config = SettlementTransactionConfig {
+            max_fee_per_gas_multiplier_factor: Multiplier::from_u64_per_1000(1000),
+            max_fee_per_gas_floor: 0,
+            max_fee_per_gas_ceiling: 50_000_000_000, // 50 gwei
+            max_priority_fee_per_gas_multiplier_factor: Multiplier::from_u64_per_1000(1000),
+            max_priority_fee_per_gas_floor: 60_000_000_000, // 60 gwei (above max-fee ceiling)
+            max_priority_fee_per_gas_ceiling: 100_000_000_000, // 100 gwei
+            ..Default::default()
+        };
+
+        let mut task = mk_task(Arc::new(MockStateStore::new()), BTreeMap::new());
+        task.tx_config = Arc::new(config);
+
+        let estimate = Eip1559Estimation {
+            max_fee_per_gas: 70_000_000_000, // -> clamps to 50 gwei ceiling
+            max_priority_fee_per_gas: 1_000_000_000, // -> raised to 60 gwei floor, then capped
+        };
+
+        let gas = task.resolve_base_gas_params(&estimate);
+
+        assert_eq!(gas.max_fee_per_gas, 50_000_000_000);
+        assert_eq!(gas.max_priority_fee_per_gas, gas.max_fee_per_gas);
     }
 }

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -449,7 +449,10 @@ impl<
                 // used externally, or that we no longer have the required wallets to bump
                 // pending nonces. So we need to submit a new attempt with a new
                 // nonce.
-                let (wallet, nonce, attempt_number, tx) = self.build_next_attempt_with_new_nonce();
+                let (wallet, nonce, attempt_number, tx) = retry!(
+                    self.build_next_attempt_with_new_nonce().await,
+                    "building next settlement attempt with a new nonce",
+                );
                 self.save_attempt_to_db_and_submit_to_l1(wallet, nonce, attempt_number, tx)
                     .await;
             }
@@ -857,12 +860,40 @@ impl<
         todo!()
     }
 
-    fn build_next_attempt_with_new_nonce(
+    /// Selects a wallet and a fresh nonce, resolves base gas parameters from
+    /// the latest L1 fee estimate, and builds a signed settlement attempt.
+    ///
+    /// Transient L1 RPC failures are retried in place using the configured
+    /// transient-failure policy; a build/sign failure is non-recoverable.
+    async fn build_next_attempt_with_new_nonce(
         &self,
-    ) -> (Address, Nonce, SettlementAttemptNumber, TxEnvelope) {
-        // TODO: Build the next attempt with correct gas and other params. Use https://docs.rs/alloy/latest/alloy/rpc/types/struct.TransactionRequest.html#method.build
-        // XREF: https://github.com/agglayer/agglayer/issues/1318
-        todo!()
+    ) -> Result<
+        (Address, Nonce, SettlementAttemptNumber, TxEnvelope),
+        RetryCallbackError<BuildAttemptError>,
+    > {
+        let wallet = self.provider.default_signer_address();
+        let attempt_number = self.next_attempt_number();
+
+        crate::utils::retry_callback_until_success(
+            &self.tx_config.retry_on_transient_failure,
+            &self.control.cancellation_token,
+            || async {
+                let nonce = self
+                    .provider
+                    .get_transaction_count(wallet)
+                    .pending()
+                    .await?;
+                let chain_id = self.provider.get_chain_id().await?;
+                let estimate = self.provider.estimate_eip1559_fees().await?;
+                let gas = self.resolve_base_gas_params(&estimate);
+                let tx = self
+                    .build_attempt(wallet, Nonce(nonce), chain_id, gas)
+                    .await?;
+                Ok((wallet, Nonce(nonce), attempt_number, tx))
+            },
+            BuildAttemptError::is_transient,
+        )
+        .await
     }
 
     async fn submit_attempt_to_l1(&self, _tx: TxEnvelope) -> eyre::Result<()> {
@@ -1667,5 +1698,58 @@ mod tests {
         assert_eq!(envelope.input().as_ref(), mk_job().calldata.as_ref());
         assert_eq!(envelope.to(), Some(mk_job().contract_address.into_alloy()));
         assert_eq!(envelope.recover_signer().unwrap(), wallet_address);
+    }
+
+    #[tokio::test]
+    async fn build_next_attempt_with_new_nonce_uses_pending_nonce_and_default_wallet() {
+        use alloy::{
+            consensus::Transaction as _, node_bindings::Anvil, providers::ProviderBuilder,
+            rpc::types::TransactionRequest,
+        };
+
+        let anvil = Anvil::new().spawn();
+        let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+        let wallet_address = signer.address();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect_http(anvil.endpoint_url());
+
+        // Bump the sender's nonce to 2 by mining two transactions.
+        for _ in 0..2 {
+            let tx = TransactionRequest::default()
+                .to(anvil.addresses()[1])
+                .value(U256::from(1));
+            provider
+                .send_transaction(tx)
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+        }
+
+        let task = SettlementTask {
+            id: mk_job_id(1),
+            job: mk_job(),
+            tx_config: Arc::new(SettlementTransactionConfig::default()),
+            provider: Arc::new(provider),
+            store: Arc::new(MockStateStore::new()),
+            control: mk_control(),
+            attempts: BTreeMap::new(),
+        };
+
+        let (used_wallet, nonce, attempt_number, envelope) = task
+            .build_next_attempt_with_new_nonce()
+            .await
+            .expect("attempt should build");
+
+        assert_eq!(used_wallet, wallet_address);
+        assert_eq!(nonce, Nonce(2));
+        assert_eq!(attempt_number, SettlementAttemptNumber(0));
+        assert_eq!(envelope.nonce(), 2);
+        assert_eq!(envelope.to(), Some(mk_job().contract_address.into_alloy()));
+        assert_eq!(envelope.chain_id(), Some(anvil.chain_id()));
+        // Fees are within the configured bounds (defaults: floor 0, ceiling 100 gwei).
+        assert!(envelope.max_fee_per_gas() <= 100_000_000_000);
     }
 }

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -1,13 +1,11 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    future::IntoFuture as _,
     sync::{Arc, OnceLock},
     time::{Duration, SystemTime},
 };
 
-use agglayer_config::{
-    settlement_service::{SettlementPolicy, SettlementTransactionConfig},
-    Multiplier,
-};
+use agglayer_config::settlement_service::{SettlementPolicy, SettlementTransactionConfig};
 use agglayer_storage::stores::{SettlementReader, SettlementWriter};
 use agglayer_types::{
     ClientError, ClientErrorType, ContractCallOutcome, ContractCallResult, Digest, Nonce,
@@ -40,12 +38,6 @@ struct GasParams {
     gas_limit: u64,
     max_fee_per_gas: u128,
     max_priority_fee_per_gas: u128,
-}
-
-/// Multiply `value` by a [`Multiplier`] (fixed-point, scaled by 1000),
-/// saturating instead of overflowing. Mirrors `adjust_gas_estimate`.
-fn apply_multiplier_u128(value: u128, multiplier: Multiplier) -> u128 {
-    value.saturating_mul(u128::from(multiplier.as_u64_per_1000())) / 1000
 }
 
 /// Clamps `value` into `[floor, ceiling]`. When `floor > ceiling` the ceiling
@@ -790,10 +782,9 @@ impl<
         let config = self.tx_config.as_ref();
 
         let max_fee_per_gas = clamp_u128(
-            apply_multiplier_u128(
-                estimate.max_fee_per_gas,
-                config.max_fee_per_gas_multiplier_factor,
-            ),
+            config
+                .max_fee_per_gas_multiplier_factor
+                .saturating_mul_u128(estimate.max_fee_per_gas),
             config.max_fee_per_gas_floor,
             config.max_fee_per_gas_ceiling,
         );
@@ -802,19 +793,19 @@ impl<
         // otherwise produce `priority > max_fee` under misconfiguration, so we
         // cap it here to keep the EIP-1559 invariant at the point of resolution.
         let max_priority_fee_per_gas = clamp_u128(
-            apply_multiplier_u128(
-                estimate.max_priority_fee_per_gas,
-                config.max_priority_fee_per_gas_multiplier_factor,
-            ),
+            config
+                .max_priority_fee_per_gas_multiplier_factor
+                .saturating_mul_u128(estimate.max_priority_fee_per_gas),
             config.max_priority_fee_per_gas_floor,
             config.max_priority_fee_per_gas_ceiling,
         )
         .min(max_fee_per_gas);
 
         let gas_limit_ceiling = u128::try_from(config.gas_limit_ceiling).unwrap_or(u128::MAX);
-        let gas_limit_u128 =
-            apply_multiplier_u128(self.job.gas_limit, config.gas_limit_multiplier_factor)
-                .min(gas_limit_ceiling);
+        let gas_limit_u128 = config
+            .gas_limit_multiplier_factor
+            .saturating_mul_u128(self.job.gas_limit)
+            .min(gas_limit_ceiling);
         let gas_limit = u64::try_from(gas_limit_u128).unwrap_or(u64::MAX);
 
         GasParams {
@@ -878,13 +869,16 @@ impl<
             &self.tx_config.retry_on_transient_failure,
             &self.control.cancellation_token,
             || async {
-                let nonce = self
-                    .provider
-                    .get_transaction_count(wallet)
-                    .pending()
-                    .await?;
-                let chain_id = self.provider.get_chain_id().await?;
-                let estimate = self.provider.estimate_eip1559_fees().await?;
+                // These three L1 reads are independent, so fetch them
+                // concurrently to keep each (retried) build to one round-trip.
+                let (nonce, chain_id, estimate) = tokio::try_join!(
+                    self.provider
+                        .get_transaction_count(wallet)
+                        .pending()
+                        .into_future(),
+                    self.provider.get_chain_id().into_future(),
+                    self.provider.estimate_eip1559_fees().into_future(),
+                )?;
                 let gas = self.resolve_base_gas_params(&estimate);
                 let tx = self
                     .build_attempt(wallet, Nonce(nonce), chain_id, gas)
@@ -1164,6 +1158,7 @@ impl<
 mod tests {
     use std::{collections::BTreeMap, sync::Arc};
 
+    use agglayer_config::Multiplier;
     use agglayer_storage::tests::mocks::MockStateStore;
     use agglayer_types::{
         ClientError, ClientErrorType, ContractCallOutcome, Digest, SettlementAttemptResult, B256,

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -4,7 +4,10 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use agglayer_config::settlement_service::{SettlementPolicy, SettlementTransactionConfig};
+use agglayer_config::{
+    settlement_service::{SettlementPolicy, SettlementTransactionConfig},
+    Multiplier,
+};
 use agglayer_storage::stores::{SettlementReader, SettlementWriter};
 use agglayer_types::{
     ClientError, ClientErrorType, ContractCallOutcome, ContractCallResult, Digest, Nonce,
@@ -13,7 +16,7 @@ use agglayer_types::{
 };
 use alloy::{
     consensus::{BlockHeader as _, EthereumTxEnvelope, TxEip4844Variant},
-    eips::BlockNumberOrTag,
+    eips::{eip1559::Eip1559Estimation, BlockNumberOrTag},
     network::{BlockResponse as _, ReceiptResponse as _},
     primitives::{Address, TxHash},
     providers::{Provider, WalletProvider},
@@ -26,6 +29,24 @@ use tracing::{debug, error, warn};
 use crate::utils::RetryCallbackError;
 
 type TxEnvelope = EthereumTxEnvelope<TxEip4844Variant>;
+
+/// Fully-resolved gas parameters for a single settlement attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct GasParams {
+    gas_limit: u64,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+}
+
+/// Multiply `value` by a [`Multiplier`] (fixed-point, scaled by 1000),
+/// saturating instead of overflowing. Mirrors `adjust_gas_estimate`.
+fn apply_multiplier_u128(value: u128, multiplier: Multiplier) -> u128 {
+    value.saturating_mul(u128::from(multiplier.as_u64_per_1000())) / 1000
+}
+
+fn clamp_u128(value: u128, floor: u128, ceiling: u128) -> u128 {
+    value.max(floor).min(ceiling)
+}
 
 /// Returns the minimum selected settlement-head block number required for a
 /// transaction receipt to be considered settled.
@@ -737,6 +758,39 @@ impl<
         }
     }
 
+    fn resolve_base_gas_params(&self, estimate: &Eip1559Estimation) -> GasParams {
+        let config = self.tx_config.as_ref();
+
+        let max_fee_per_gas = clamp_u128(
+            apply_multiplier_u128(
+                estimate.max_fee_per_gas,
+                config.max_fee_per_gas_multiplier_factor,
+            ),
+            config.max_fee_per_gas_floor,
+            config.max_fee_per_gas_ceiling,
+        );
+        let max_priority_fee_per_gas = clamp_u128(
+            apply_multiplier_u128(
+                estimate.max_priority_fee_per_gas,
+                config.max_priority_fee_per_gas_multiplier_factor,
+            ),
+            config.max_priority_fee_per_gas_floor,
+            config.max_priority_fee_per_gas_ceiling,
+        );
+
+        let gas_limit_ceiling = u128::try_from(config.gas_limit_ceiling).unwrap_or(u128::MAX);
+        let gas_limit_u128 =
+            apply_multiplier_u128(self.job.gas_limit, config.gas_limit_multiplier_factor)
+                .min(gas_limit_ceiling);
+        let gas_limit = u64::try_from(gas_limit_u128).unwrap_or(u64::MAX);
+
+        GasParams {
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+        }
+    }
+
     fn build_next_attempt_with_nonce(
         &self,
         _wallet: Address,
@@ -1436,5 +1490,40 @@ mod tests {
             .to_string()
             .contains("without a recorded settlement attempt"));
         assert!(task.attempts.is_empty());
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)] // Field-by-field config keeps the test readable.
+    fn resolve_base_gas_params_applies_multiplier_floor_and_ceiling() {
+        // `Multiplier` is in scope via the module-level import + `super::*`.
+        let mut config = SettlementTransactionConfig::default();
+        config.gas_limit_multiplier_factor = Multiplier::from_u64_per_1000(2000); // 2.0x
+        config.gas_limit_ceiling = U256::from(150_000u64);
+        config.max_fee_per_gas_multiplier_factor = Multiplier::from_u64_per_1000(1000);
+        config.max_fee_per_gas_floor = 1_000_000_000; // 1 gwei
+        config.max_fee_per_gas_ceiling = 50_000_000_000; // 50 gwei
+        config.max_priority_fee_per_gas_multiplier_factor = Multiplier::from_u64_per_1000(1000);
+        config.max_priority_fee_per_gas_floor = 2_000_000_000; // 2 gwei
+        config.max_priority_fee_per_gas_ceiling = 50_000_000_000; // 50 gwei
+
+        let mut task = mk_task(Arc::new(MockStateStore::new()), BTreeMap::new());
+        task.tx_config = Arc::new(config);
+        task.job = SettlementJob {
+            gas_limit: 100_000,
+            ..mk_job()
+        };
+
+        // Estimate above the fee ceiling and below the priority floor.
+        let estimate = Eip1559Estimation {
+            max_fee_per_gas: 80_000_000_000,       // 80 gwei -> clamps to 50 gwei
+            max_priority_fee_per_gas: 100_000_000, // 0.1 gwei -> raised to 2 gwei floor
+        };
+
+        let gas = task.resolve_base_gas_params(&estimate);
+
+        // 100_000 * 2.0 = 200_000, capped to ceiling 150_000.
+        assert_eq!(gas.gas_limit, 150_000);
+        assert_eq!(gas.max_fee_per_gas, 50_000_000_000);
+        assert_eq!(gas.max_priority_fee_per_gas, 2_000_000_000);
     }
 }

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -56,15 +56,46 @@ enum BuildAttemptError {
 }
 
 impl BuildAttemptError {
-    fn is_transient(&self) -> bool {
-        match self {
-            Self::Transport(error) => crate::utils::is_transient_alloy_error(error),
-            // Remote signer backends (e.g. GCP KMS) sign over the network and
-            // can fail transiently, so retry signer errors. Missing-field or
-            // unsupported-signature errors indicate a build bug or a
-            // misconfiguration and are not recoverable by retrying.
-            Self::Build(TransactionBuilderError::Signer(_)) => true,
-            Self::Build(_) => false,
+    /// True for an opaque signer-backend failure (e.g. a remote KMS error
+    /// wrapped in [`alloy::signers::Error::Other`]), which may be a transient
+    /// blip or a permanent misconfiguration that cannot be told apart here.
+    fn is_signer_backend(&self) -> bool {
+        matches!(
+            self,
+            Self::Build(TransactionBuilderError::Signer(
+                alloy::signers::Error::Other(_)
+            ))
+        )
+    }
+}
+
+/// Retry policy for building a settlement attempt.
+///
+/// Transport (L1 RPC) failures are retried for as long as they look transient.
+/// Opaque signer-backend failures are retried a bounded number of times — long
+/// enough to ride out a transient remote-signer (e.g. GCP KMS) blip, but not
+/// forever, so a permanent signer misconfiguration eventually surfaces through
+/// the non-recoverable path instead of looping until cancellation. Structural
+/// signer errors and other build failures are non-recoverable immediately.
+struct BuildRetryPolicy {
+    signer_failures: u32,
+}
+
+impl BuildRetryPolicy {
+    const MAX_SIGNER_BUILD_RETRIES: u32 = 3;
+
+    fn new() -> Self {
+        Self { signer_failures: 0 }
+    }
+
+    fn should_retry(&mut self, error: &BuildAttemptError) -> bool {
+        match error {
+            BuildAttemptError::Transport(error) => crate::utils::is_transient_alloy_error(error),
+            error if error.is_signer_backend() => {
+                self.signer_failures += 1;
+                self.signer_failures <= Self::MAX_SIGNER_BUILD_RETRIES
+            }
+            BuildAttemptError::Build(_) => false,
         }
     }
 }
@@ -868,6 +899,7 @@ impl<
     > {
         let wallet = self.provider.default_signer_address();
         let attempt_number = self.next_attempt_number();
+        let mut retry_policy = BuildRetryPolicy::new();
 
         crate::utils::retry_callback_until_success(
             &self.tx_config.retry_on_transient_failure,
@@ -889,7 +921,7 @@ impl<
                     .await?;
                 Ok((wallet, Nonce(nonce), attempt_number, tx))
             },
-            BuildAttemptError::is_transient,
+            |error| retry_policy.should_retry(error),
         )
         .await
     }
@@ -1670,16 +1702,28 @@ mod tests {
     }
 
     #[test]
-    fn build_attempt_error_retries_signer_failures_but_not_build_bugs() {
-        // Remote signer (e.g. KMS) failures are transient and must be retried.
-        let signer_failure = BuildAttemptError::Build(TransactionBuilderError::Signer(
-            alloy::signers::Error::message("transient remote signer failure"),
-        ));
-        assert!(signer_failure.is_transient());
+    fn build_retry_policy_bounds_signer_failures_and_rejects_build_bugs() {
+        // `Error::message` produces an opaque `Error::Other`, mirroring how a
+        // remote signer backend (e.g. GCP KMS) surfaces a signing failure.
+        let signer_failure = || {
+            BuildAttemptError::Build(TransactionBuilderError::Signer(
+                alloy::signers::Error::message("remote signer failure"),
+            ))
+        };
 
-        // A genuine build/validation error is not recoverable by retrying.
-        let build_bug = BuildAttemptError::Build(TransactionBuilderError::UnsupportedSignatureType);
-        assert!(!build_bug.is_transient());
+        // A signer-backend failure is retried up to the bound (to ride out a
+        // transient blip), then surfaces as non-recoverable.
+        let mut policy = BuildRetryPolicy::new();
+        for _ in 0..BuildRetryPolicy::MAX_SIGNER_BUILD_RETRIES {
+            assert!(policy.should_retry(&signer_failure()));
+        }
+        assert!(!policy.should_retry(&signer_failure()));
+
+        // A structural build error is never recoverable by retrying.
+        let mut policy = BuildRetryPolicy::new();
+        assert!(!policy.should_retry(&BuildAttemptError::Build(
+            TransactionBuilderError::UnsupportedSignatureType
+        )));
     }
 
     #[tokio::test]

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -487,6 +487,17 @@ impl<
             .collect()
     }
 
+    fn next_attempt_number(&self) -> SettlementAttemptNumber {
+        let next = self
+            .attempts
+            .values()
+            .flat_map(|attempts_for_nonce| attempts_for_nonce.keys())
+            .map(|attempt_number| attempt_number.0)
+            .max()
+            .map_or(0, |max| max.saturating_add(1));
+        SettlementAttemptNumber(next)
+    }
+
     fn is_any_attempt_pending_for_nonce(&self, wallet: Address, nonce: Nonce) -> bool {
         self.attempts
             .get(&(wallet, nonce))
@@ -1132,6 +1143,32 @@ mod tests {
             control: mk_control(),
             attempts,
         }
+    }
+
+    #[test]
+    fn next_attempt_number_starts_at_zero_and_increments_past_max() {
+        let store = Arc::new(MockStateStore::new());
+
+        let empty = mk_task(store.clone(), BTreeMap::new());
+        assert_eq!(empty.next_attempt_number(), SettlementAttemptNumber(0));
+
+        let wallet = Address::from([1; 20]);
+        let nonce = Nonce(7);
+        let attempts = BTreeMap::from([(
+            (wallet, nonce),
+            BTreeMap::from([
+                (
+                    SettlementAttemptNumber(2),
+                    mk_active_attempt(wallet, nonce, mk_tx_hash(1), None),
+                ),
+                (
+                    SettlementAttemptNumber(5),
+                    mk_active_attempt(wallet, nonce, mk_tx_hash(2), None),
+                ),
+            ]),
+        )]);
+        let task = mk_task(store, attempts);
+        assert_eq!(task.next_attempt_number(), SettlementAttemptNumber(6));
     }
 
     #[tokio::test]

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -17,9 +17,13 @@ use agglayer_types::{
 use alloy::{
     consensus::{BlockHeader as _, EthereumTxEnvelope, TxEip4844Variant},
     eips::{eip1559::Eip1559Estimation, BlockNumberOrTag},
-    network::{BlockResponse as _, ReceiptResponse as _},
+    network::{
+        BlockResponse as _, Ethereum, ReceiptResponse as _, TransactionBuilder as _,
+        TransactionBuilderError,
+    },
     primitives::{Address, TxHash},
     providers::{Provider, WalletProvider},
+    rpc::types::TransactionRequest,
     transports::TransportError,
 };
 use tokio::sync::mpsc;
@@ -48,6 +52,25 @@ fn apply_multiplier_u128(value: u128, multiplier: Multiplier) -> u128 {
 /// wins (unlike [`Ord::clamp`], this never panics on an inverted range).
 fn clamp_u128(value: u128, floor: u128, ceiling: u128) -> u128 {
     value.max(floor).min(ceiling)
+}
+
+/// Error surfaced while building a settlement attempt.
+#[derive(Debug, thiserror::Error)]
+enum BuildAttemptError {
+    #[error("L1 RPC error while building settlement attempt: {0}")]
+    Transport(#[from] TransportError),
+    #[error("failed to build or sign settlement transaction: {0}")]
+    Build(#[from] TransactionBuilderError<Ethereum>),
+}
+
+impl BuildAttemptError {
+    fn is_transient(&self) -> bool {
+        match self {
+            Self::Transport(error) => crate::utils::is_transient_alloy_error(error),
+            // A build/sign failure with a configured wallet is non-recoverable.
+            Self::Build(_) => false,
+        }
+    }
 }
 
 /// Returns the minimum selected settlement-head block number required for a
@@ -796,6 +819,32 @@ impl<
             max_fee_per_gas,
             max_priority_fee_per_gas,
         }
+    }
+
+    /// Builds and signs an EIP-1559 settlement transaction for [`Self::job`]
+    /// with the given wallet, nonce, chain id, and resolved gas parameters.
+    ///
+    /// `wallet` sets the `from` field and must have a registered signer in the
+    /// provider's wallet; otherwise signing fails with a signer-missing error.
+    async fn build_attempt(
+        &self,
+        wallet: Address,
+        nonce: Nonce,
+        chain_id: u64,
+        gas: GasParams,
+    ) -> Result<TxEnvelope, TransactionBuilderError<Ethereum>> {
+        let request = TransactionRequest::default()
+            .from(wallet)
+            .to(self.job.contract_address.into_alloy())
+            .value(self.job.eth_value)
+            .input(self.job.calldata.clone().into())
+            .nonce(nonce.0)
+            .gas_limit(gas.gas_limit)
+            .max_fee_per_gas(gas.max_fee_per_gas)
+            .max_priority_fee_per_gas(gas.max_priority_fee_per_gas)
+            .with_chain_id(chain_id);
+
+        request.build(self.provider.wallet()).await
     }
 
     fn build_next_attempt_with_nonce(
@@ -1588,5 +1637,35 @@ mod tests {
 
         assert_eq!(gas.max_fee_per_gas, 50_000_000_000);
         assert_eq!(gas.max_priority_fee_per_gas, gas.max_fee_per_gas);
+    }
+
+    #[tokio::test]
+    async fn build_attempt_produces_signed_eip1559_envelope() {
+        use alloy::consensus::{transaction::SignerRecoverable as _, Transaction as _};
+
+        let task = mk_task(Arc::new(MockStateStore::new()), BTreeMap::new());
+        let wallet_address = test_signer().address();
+
+        let gas = GasParams {
+            gas_limit: 100_000,
+            max_fee_per_gas: 30_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+        };
+
+        let envelope = task
+            .build_attempt(wallet_address, Nonce(9), 1337, gas)
+            .await
+            .expect("attempt should build");
+
+        assert!(matches!(envelope, TxEnvelope::Eip1559(_)));
+        assert_eq!(envelope.nonce(), 9);
+        assert_eq!(envelope.chain_id(), Some(1337));
+        assert_eq!(envelope.gas_limit(), 100_000);
+        assert_eq!(envelope.max_fee_per_gas(), 30_000_000_000);
+        assert_eq!(envelope.max_priority_fee_per_gas(), Some(1_000_000_000));
+        assert_eq!(envelope.value(), mk_job().eth_value);
+        assert_eq!(envelope.input().as_ref(), mk_job().calldata.as_ref());
+        assert_eq!(envelope.to(), Some(mk_job().contract_address.into_alloy()));
+        assert_eq!(envelope.recover_signer().unwrap(), wallet_address);
     }
 }

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -59,7 +59,11 @@ impl BuildAttemptError {
     fn is_transient(&self) -> bool {
         match self {
             Self::Transport(error) => crate::utils::is_transient_alloy_error(error),
-            // A build/sign failure with a configured wallet is non-recoverable.
+            // Remote signer backends (e.g. GCP KMS) sign over the network and
+            // can fail transiently, so retry signer errors. Missing-field or
+            // unsupported-signature errors indicate a build bug or a
+            // misconfiguration and are not recoverable by retrying.
+            Self::Build(TransactionBuilderError::Signer(_)) => true,
             Self::Build(_) => false,
         }
     }
@@ -1663,6 +1667,19 @@ mod tests {
 
         assert_eq!(gas.max_fee_per_gas, 50_000_000_000);
         assert_eq!(gas.max_priority_fee_per_gas, gas.max_fee_per_gas);
+    }
+
+    #[test]
+    fn build_attempt_error_retries_signer_failures_but_not_build_bugs() {
+        // Remote signer (e.g. KMS) failures are transient and must be retried.
+        let signer_failure = BuildAttemptError::Build(TransactionBuilderError::Signer(
+            alloy::signers::Error::message("transient remote signer failure"),
+        ));
+        assert!(signer_failure.is_transient());
+
+        // A genuine build/validation error is not recoverable by retrying.
+        let build_bug = BuildAttemptError::Build(TransactionBuilderError::UnsupportedSignatureType);
+        assert!(!build_bug.is_transient());
     }
 
     #[tokio::test]

--- a/docs/knowledge-base/src/ai-agents/plans/2026-06-08-settlement-attempt-builder-plan.md
+++ b/docs/knowledge-base/src/ai-agents/plans/2026-06-08-settlement-attempt-builder-plan.md
@@ -1,0 +1,940 @@
+# Settlement attempt builder (issue 1318) implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and sign an EIP-1559 settlement transaction for a job with a
+fresh nonce and config-derived gas parameters, ready to record to RocksDB
+before submission.
+
+**Architecture:** Add an `EthereumWallet` to `SettlementTask`; add a reusable
+async `build_attempt` primitive that signs a fully-resolved EIP-1559 request;
+add `build_next_attempt_with_new_nonce` that resolves wallet/nonce/chain-id/gas
+(RPC + config) and calls the primitive, integrated with the existing
+`retry!`/`RetryCallbackError` machinery.
+
+**Tech Stack:** Rust, alloy 1.7.3 (`TransactionRequest`, `EthereumWallet`,
+`Provider`), tokio, Anvil (`alloy` `node-bindings`, dev-only),
+`agglayer-config` (`SettlementTransactionConfig`, `Multiplier`).
+
+**Spec:** `docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-attempt-builder-design.md`
+
+---
+
+## File structure
+
+- Modify: `crates/agglayer-settlement-service/src/settlement_task.rs`
+  - `SettlementTask` struct gains `wallet: Arc<EthereumWallet>`.
+  - New: `GasParams`, `BuildAttemptError`, `apply_multiplier_u128`,
+    `clamp_u128`, `next_attempt_number`, `resolve_base_gas_params`,
+    `build_attempt`; rewritten `build_next_attempt_with_new_nonce`;
+    optional `is_wallet_privkey_known`.
+  - Run-loop call site updated to `await` + `retry!`.
+  - Test helpers updated; new unit tests added.
+- Modify: `crates/agglayer-settlement-service/src/settlement_service.rs`
+  - `SettlementService` struct gains `wallet: Arc<EthereumWallet>`;
+    `start` gains a wallet parameter; `request_new_settlement` passes it to
+    `SettlementTask::create`. Test helper updated.
+
+All changes are within one crate (`agglayer-settlement-service`).
+No new non-dev dependency is required: `EthereumWallet` is in `alloy::network`
+(already pulled via the `full` feature), and tests use
+`alloy::signers::local::PrivateKeySigner` and `alloy::node_bindings::Anvil`
+(already used by `utils.rs` tests).
+
+---
+
+## Task 1: Add the signing wallet to `SettlementTask` and `SettlementService`
+
+Structural change only: thread a wallet through constructors so the crate
+still compiles and all existing tests pass. No new builder behavior yet.
+
+**Files:**
+- Modify: `crates/agglayer-settlement-service/src/settlement_task.rs`
+  (imports; struct ~142-151; `create` ~158-187; `load` ~189-212;
+  test helpers ~1099-1126 and load test ~1319)
+- Modify: `crates/agglayer-settlement-service/src/settlement_service.rs`
+  (imports; struct ~23-31; `start` ~58-75; `request_new_settlement` ~125-132;
+  test helper ~315-327)
+
+- [ ] **Step 1: Add the `wallet` field and import to `settlement_task.rs`**
+
+In the `alloy::{...}` import block, add `EthereumWallet` to the `network`
+group:
+
+```rust
+    network::{BlockResponse as _, EthereumWallet, ReceiptResponse as _},
+```
+
+Add the field to the struct (after `store`):
+
+```rust
+pub struct SettlementTask<L1Provider, SettlementStore> {
+    id: SettlementJobId,
+    job: SettlementJob,
+    tx_config: Arc<SettlementTransactionConfig>,
+    provider: Arc<L1Provider>,
+    store: Arc<SettlementStore>,
+    wallet: Arc<EthereumWallet>,
+    control: TaskControl,
+    attempts:
+        BTreeMap<(Address, Nonce), BTreeMap<SettlementAttemptNumber, ActiveSettlementAttempt>>,
+}
+```
+
+- [ ] **Step 2: Thread `wallet` through `create` and `load`**
+
+`create` — add the parameter and set the field:
+
+```rust
+    pub async fn create(
+        job: SettlementJob,
+        tx_config: Arc<SettlementTransactionConfig>,
+        provider: Arc<L1Provider>,
+        store: Arc<SettlementStore>,
+        wallet: Arc<EthereumWallet>,
+        control: TaskControl,
+    ) -> eyre::Result<(SettlementJobId, Self)> {
+        // ...unchanged id generation...
+        let this = Self {
+            id,
+            job,
+            tx_config,
+            provider,
+            store,
+            wallet,
+            control,
+            attempts: BTreeMap::new(),
+        };
+        this.save_settlement_job_to_db().await?;
+        Ok((id, this))
+    }
+```
+
+`load` — add the parameter and set the field in the `Pending` branch:
+
+```rust
+    pub async fn load(
+        id: SettlementJobId,
+        tx_config: Arc<SettlementTransactionConfig>,
+        provider: Arc<L1Provider>,
+        store: Arc<SettlementStore>,
+        wallet: Arc<EthereumWallet>,
+        control: TaskControl,
+    ) -> eyre::Result<StoredSettlementJob<L1Provider, SettlementStore>> {
+        let (job, result) = Self::load_settlement_job_from_db(id).await?;
+        if let Some(result) = result {
+            Ok(StoredSettlementJob::Completed(job, result))
+        } else {
+            let mut this = SettlementTask {
+                id,
+                job,
+                tx_config,
+                provider,
+                store,
+                wallet,
+                control,
+                attempts: BTreeMap::new(),
+            };
+            this.load_settlement_attempts_from_db().await?;
+            Ok(StoredSettlementJob::Pending(this))
+        }
+    }
+```
+
+- [ ] **Step 3: Add `wallet` to `SettlementService` and `start`**
+
+In `settlement_service.rs`, add the import:
+
+```rust
+use alloy::{network::EthereumWallet, providers::Provider};
+```
+
+(replace the existing `use alloy::providers::Provider;` line).
+
+Add the field to the struct:
+
+```rust
+pub struct SettlementService<L1Provider, SettlementStore> {
+    tx_config: Arc<SettlementTransactionConfig>,
+    provider: Arc<L1Provider>,
+    store: Arc<SettlementStore>,
+    wallet: Arc<EthereumWallet>,
+    cancellation_token: CancellationToken,
+    task_controls: Arc<Mutex<HashMap<SettlementJobId, TaskControlHandle>>>,
+    result_watchers:
+        Arc<Mutex<HashMap<SettlementJobId, watch::Receiver<Option<SettlementJobResult>>>>>,
+}
+```
+
+In `start`, add the parameter and set the field:
+
+```rust
+    pub async fn start(
+        _config: SettlementServiceConfig,
+        tx_config: Arc<SettlementTransactionConfig>,
+        provider: Arc<L1Provider>,
+        store: Arc<SettlementStore>,
+        wallet: Arc<EthereumWallet>,
+        cancellation_token: CancellationToken,
+    ) -> eyre::Result<Self> {
+        let this = Self {
+            tx_config,
+            provider,
+            store,
+            wallet,
+            cancellation_token,
+            task_controls: Arc::new(Mutex::new(HashMap::new())),
+            result_watchers: Arc::new(Mutex::new(HashMap::new())),
+        };
+        Ok(this)
+    }
+```
+
+In `request_new_settlement`, pass the wallet into `create`:
+
+```rust
+        let (job_id, mut task) = SettlementTask::create(
+            job,
+            self.tx_config.clone(),
+            self.provider.clone(),
+            self.store.clone(),
+            self.wallet.clone(),
+            task_control,
+        )
+        .await?;
+```
+
+- [ ] **Step 4: Update test helpers to construct a wallet**
+
+In `settlement_task.rs` tests, add imports inside `mod tests`:
+
+```rust
+    use alloy::{network::EthereumWallet, signers::local::PrivateKeySigner};
+```
+
+Add a helper near `mk_control`:
+
+```rust
+    fn mk_random_wallet() -> Arc<EthereumWallet> {
+        Arc::new(EthereumWallet::from(PrivateKeySigner::random()))
+    }
+```
+
+Change `mk_task_with_id` to accept a wallet and set the field:
+
+```rust
+    fn mk_task_with_id(
+        job_id: SettlementJobId,
+        store: Arc<MockStateStore>,
+        attempts: BTreeMap<
+            (Address, Nonce),
+            BTreeMap<SettlementAttemptNumber, ActiveSettlementAttempt>,
+        >,
+        wallet: Arc<EthereumWallet>,
+    ) -> SettlementTask<impl Provider + 'static, MockStateStore> {
+        SettlementTask {
+            id: job_id,
+            job: mk_job(),
+            tx_config: Arc::new(SettlementTransactionConfig::default()),
+            provider: Arc::new(mk_provider()),
+            store,
+            wallet,
+            control: mk_control(),
+            attempts,
+        }
+    }
+```
+
+Update `mk_task` to pass a random wallet:
+
+```rust
+    fn mk_task(
+        store: Arc<MockStateStore>,
+        attempts: BTreeMap<
+            (Address, Nonce),
+            BTreeMap<SettlementAttemptNumber, ActiveSettlementAttempt>,
+        >,
+    ) -> SettlementTask<impl Provider + 'static, MockStateStore> {
+        mk_task_with_id(mk_job_id(1), store, attempts, mk_random_wallet())
+    }
+```
+
+Update the one direct caller of `mk_task_with_id` (in
+`load_settlement_attempts_from_db_hydrates_attempts_and_results`):
+
+```rust
+        let mut task = mk_task_with_id(job_id, Arc::new(store), BTreeMap::new(), mk_random_wallet());
+```
+
+- [ ] **Step 5: Update the `settlement_service.rs` test helper**
+
+Add the import inside `mod tests`:
+
+```rust
+    use alloy::{network::EthereumWallet, signers::local::PrivateKeySigner};
+```
+
+Pass a wallet into `start` in `mk_service`:
+
+```rust
+    async fn mk_service(
+        store: Arc<MockStateStore>,
+    ) -> SettlementService<impl Provider + 'static, MockStateStore> {
+        SettlementService::start(
+            SettlementServiceConfig::default(),
+            Arc::new(SettlementTransactionConfig::default()),
+            Arc::new(mk_provider()),
+            store,
+            Arc::new(EthereumWallet::from(PrivateKeySigner::random())),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("settlement service should start")
+    }
+```
+
+- [ ] **Step 6: Verify the crate compiles and existing tests pass**
+
+Run: `cargo nextest run -p agglayer-settlement-service`
+Expected: PASS (all pre-existing tests still green; no behavior changed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/agglayer-settlement-service/src/settlement_task.rs \
+        crates/agglayer-settlement-service/src/settlement_service.rs
+git commit -S -m "feat(settlement): add signing wallet to settlement task"
+```
+
+---
+
+## Task 2: `next_attempt_number` helper
+
+Allocate the next per-job attempt number from in-memory state.
+
+**Files:**
+- Modify: `crates/agglayer-settlement-service/src/settlement_task.rs`
+  (add method near `all_attempt_keys` ~476; add test in `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests`:
+
+```rust
+    #[test]
+    fn next_attempt_number_starts_at_zero_and_increments_past_max() {
+        let store = Arc::new(MockStateStore::new());
+
+        let empty = mk_task(store.clone(), BTreeMap::new());
+        assert_eq!(empty.next_attempt_number(), SettlementAttemptNumber(0));
+
+        let wallet = Address::from([1; 20]);
+        let nonce = Nonce(7);
+        let attempts = BTreeMap::from([(
+            (wallet, nonce),
+            BTreeMap::from([
+                (
+                    SettlementAttemptNumber(2),
+                    mk_active_attempt(wallet, nonce, mk_tx_hash(1), None),
+                ),
+                (
+                    SettlementAttemptNumber(5),
+                    mk_active_attempt(wallet, nonce, mk_tx_hash(2), None),
+                ),
+            ]),
+        )]);
+        let task = mk_task(store, attempts);
+        assert_eq!(task.next_attempt_number(), SettlementAttemptNumber(6));
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo nextest run -p agglayer-settlement-service next_attempt_number_starts_at_zero`
+Expected: FAIL — `no method named next_attempt_number`.
+
+- [ ] **Step 3: Implement `next_attempt_number`**
+
+Add as a method on `SettlementTask` (near `all_attempt_keys`):
+
+```rust
+    fn next_attempt_number(&self) -> SettlementAttemptNumber {
+        let next = self
+            .attempts
+            .values()
+            .flat_map(|attempts_for_nonce| attempts_for_nonce.keys())
+            .map(|attempt_number| attempt_number.0)
+            .max()
+            .map_or(0, |max| max.saturating_add(1));
+        SettlementAttemptNumber(next)
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo nextest run -p agglayer-settlement-service next_attempt_number_starts_at_zero`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agglayer-settlement-service/src/settlement_task.rs
+git commit -S -m "feat(settlement): allocate next settlement attempt number"
+```
+
+---
+
+## Task 3: Gas types and `resolve_base_gas_params`
+
+Pure config-driven gas resolution mirroring `agglayer-contracts::adjust_gas_estimate`.
+
+**Files:**
+- Modify: `crates/agglayer-settlement-service/src/settlement_task.rs`
+  (imports; new types + helpers + method; test in `mod tests`)
+
+- [ ] **Step 1: Add imports**
+
+Add to the `alloy::{...}` block:
+
+```rust
+    eips::{eip1559::Eip1559Estimation, BlockNumberOrTag},
+```
+
+(replace the existing `eips::BlockNumberOrTag,` line).
+
+Add after the alloy import block:
+
+```rust
+use agglayer_config::Multiplier;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `mod tests` (note `SettlementTransactionConfig` and `Multiplier` are in
+scope via `super::*` and the new import):
+
+```rust
+    #[test]
+    fn resolve_base_gas_params_applies_multiplier_floor_and_ceiling() {
+        // `Multiplier` is in scope via the module-level import + `super::*`.
+        let mut config = SettlementTransactionConfig::default();
+        config.gas_limit_multiplier_factor = Multiplier::from_u64_per_1000(2000); // 2.0x
+        config.gas_limit_ceiling = U256::from(150_000u64);
+        config.max_fee_per_gas_multiplier_factor = Multiplier::from_u64_per_1000(1000);
+        config.max_fee_per_gas_floor = 1_000_000_000; // 1 gwei
+        config.max_fee_per_gas_ceiling = 50_000_000_000; // 50 gwei
+        config.max_priority_fee_per_gas_multiplier_factor = Multiplier::from_u64_per_1000(1000);
+        config.max_priority_fee_per_gas_floor = 2_000_000_000; // 2 gwei
+        config.max_priority_fee_per_gas_ceiling = 50_000_000_000; // 50 gwei
+
+        let mut task = mk_task(Arc::new(MockStateStore::new()), BTreeMap::new());
+        task.tx_config = Arc::new(config);
+        task.job = SettlementJob { gas_limit: 100_000, ..mk_job() };
+
+        // Estimate above the fee ceiling and below the priority floor.
+        let estimate = Eip1559Estimation {
+            max_fee_per_gas: 80_000_000_000, // 80 gwei -> clamps to 50 gwei
+            max_priority_fee_per_gas: 100_000_000, // 0.1 gwei -> raised to 2 gwei floor
+        };
+
+        let gas = task.resolve_base_gas_params(&estimate);
+
+        // 100_000 * 2.0 = 200_000, capped to ceiling 150_000.
+        assert_eq!(gas.gas_limit, 150_000);
+        assert_eq!(gas.max_fee_per_gas, 50_000_000_000);
+        assert_eq!(gas.max_priority_fee_per_gas, 2_000_000_000);
+    }
+```
+
+`mk_job` builds `SettlementJob` with `gas_limit: 100_000`; the spread sets the
+limit explicitly for clarity. `U256` is already imported in `mod tests`.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cargo nextest run -p agglayer-settlement-service resolve_base_gas_params_applies`
+Expected: FAIL — `GasParams` / `resolve_base_gas_params` not found.
+
+- [ ] **Step 4: Implement the types and helpers**
+
+Add near the top of the file (after the `TxEnvelope` alias):
+
+```rust
+/// Fully-resolved gas parameters for a single settlement attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct GasParams {
+    gas_limit: u64,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+}
+
+/// Multiply `value` by a [`Multiplier`] (fixed-point, scaled by 1000),
+/// saturating instead of overflowing. Mirrors `adjust_gas_estimate`.
+fn apply_multiplier_u128(value: u128, multiplier: Multiplier) -> u128 {
+    value.saturating_mul(u128::from(multiplier.as_u64_per_1000())) / 1000
+}
+
+fn clamp_u128(value: u128, floor: u128, ceiling: u128) -> u128 {
+    value.max(floor).min(ceiling)
+}
+```
+
+Add the resolution method on `SettlementTask` (near the build functions):
+
+```rust
+    fn resolve_base_gas_params(&self, estimate: &Eip1559Estimation) -> GasParams {
+        let config = self.tx_config.as_ref();
+
+        let max_fee_per_gas = clamp_u128(
+            apply_multiplier_u128(
+                estimate.max_fee_per_gas,
+                config.max_fee_per_gas_multiplier_factor,
+            ),
+            config.max_fee_per_gas_floor,
+            config.max_fee_per_gas_ceiling,
+        );
+        let max_priority_fee_per_gas = clamp_u128(
+            apply_multiplier_u128(
+                estimate.max_priority_fee_per_gas,
+                config.max_priority_fee_per_gas_multiplier_factor,
+            ),
+            config.max_priority_fee_per_gas_floor,
+            config.max_priority_fee_per_gas_ceiling,
+        );
+
+        let gas_limit_ceiling = u128::try_from(config.gas_limit_ceiling).unwrap_or(u128::MAX);
+        let gas_limit_u128 =
+            apply_multiplier_u128(self.job.gas_limit, config.gas_limit_multiplier_factor)
+                .min(gas_limit_ceiling);
+        let gas_limit = u64::try_from(gas_limit_u128).unwrap_or(u64::MAX);
+
+        GasParams {
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+        }
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo nextest run -p agglayer-settlement-service resolve_base_gas_params_applies`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/agglayer-settlement-service/src/settlement_task.rs
+git commit -S -m "feat(settlement): resolve base gas params from config"
+```
+
+---
+
+## Task 4: `build_attempt` primitive and `BuildAttemptError`
+
+Build and sign an EIP-1559 envelope from `self.job` and given parameters.
+
+**Files:**
+- Modify: `crates/agglayer-settlement-service/src/settlement_task.rs`
+  (imports; `BuildAttemptError`; `build_attempt`; test in `mod tests`)
+
+- [ ] **Step 1: Add imports**
+
+Extend the `alloy::{...}` block:
+
+```rust
+    network::{
+        BlockResponse as _, Ethereum, EthereumWallet, ReceiptResponse as _,
+        TransactionBuilder as _, TransactionBuilderError,
+    },
+    rpc::types::TransactionRequest,
+```
+
+(the `network` group replaces the one edited in Task 1; keep `primitives`,
+`providers`, `transports`, `consensus`, `eips` as already present).
+
+- [ ] **Step 2: Add the error type**
+
+Add near `GasParams`:
+
+```rust
+/// Error surfaced while building a settlement attempt.
+#[derive(Debug, thiserror::Error)]
+enum BuildAttemptError {
+    #[error("L1 RPC error while building settlement attempt: {0}")]
+    Transport(#[from] TransportError),
+    #[error("failed to build or sign settlement transaction: {0}")]
+    Build(#[from] TransactionBuilderError<Ethereum>),
+}
+
+impl BuildAttemptError {
+    fn is_transient(&self) -> bool {
+        match self {
+            Self::Transport(error) => crate::utils::is_transient_alloy_error(error),
+            // A build/sign failure with a configured wallet is non-recoverable.
+            Self::Build(_) => false,
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Add to `mod tests` (add `use alloy::consensus::{Transaction as _, transaction::SignerRecoverable as _};`
+at the top of the test that needs them, or to the module test imports):
+
+```rust
+    #[tokio::test]
+    async fn build_attempt_produces_signed_eip1559_envelope() {
+        use alloy::consensus::{transaction::SignerRecoverable as _, Transaction as _};
+
+        let signer = PrivateKeySigner::random();
+        let wallet_address = signer.address();
+        let wallet = Arc::new(EthereumWallet::from(signer));
+
+        let task = mk_task_with_id(
+            mk_job_id(1),
+            Arc::new(MockStateStore::new()),
+            BTreeMap::new(),
+            wallet,
+        );
+
+        let gas = GasParams {
+            gas_limit: 100_000,
+            max_fee_per_gas: 30_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+        };
+
+        let envelope = task
+            .build_attempt(wallet_address, Nonce(9), 1337, gas)
+            .await
+            .expect("attempt should build");
+
+        assert!(matches!(envelope, TxEnvelope::Eip1559(_)));
+        assert_eq!(envelope.nonce(), 9);
+        assert_eq!(envelope.chain_id(), Some(1337));
+        assert_eq!(envelope.gas_limit(), 100_000);
+        assert_eq!(envelope.max_fee_per_gas(), 30_000_000_000);
+        assert_eq!(envelope.max_priority_fee_per_gas(), Some(1_000_000_000));
+        assert_eq!(envelope.value(), mk_job().eth_value);
+        assert_eq!(envelope.input().as_ref(), mk_job().calldata.as_ref());
+        assert_eq!(
+            envelope.to(),
+            Some(mk_job().contract_address.into_alloy())
+        );
+        assert_eq!(envelope.recover_signer().unwrap(), wallet_address);
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `cargo nextest run -p agglayer-settlement-service build_attempt_produces_signed`
+Expected: FAIL — `no method named build_attempt`.
+
+- [ ] **Step 5: Implement `build_attempt`**
+
+Replace the `build_next_attempt_with_nonce`/`build_next_attempt_with_new_nonce`
+neighborhood by adding this method (leave `build_next_attempt_with_nonce`,
+issue 1319, untouched for now):
+
+```rust
+    async fn build_attempt(
+        &self,
+        wallet: Address,
+        nonce: Nonce,
+        chain_id: u64,
+        gas: GasParams,
+    ) -> Result<TxEnvelope, TransactionBuilderError<Ethereum>> {
+        let request = TransactionRequest::default()
+            .from(wallet)
+            .to(self.job.contract_address.into_alloy())
+            .value(self.job.eth_value)
+            .input(self.job.calldata.clone().into())
+            .nonce(nonce.0)
+            .gas_limit(gas.gas_limit)
+            .max_fee_per_gas(gas.max_fee_per_gas)
+            .max_priority_fee_per_gas(gas.max_priority_fee_per_gas)
+            .with_chain_id(chain_id);
+
+        request.build(self.wallet.as_ref()).await
+    }
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo nextest run -p agglayer-settlement-service build_attempt_produces_signed`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/agglayer-settlement-service/src/settlement_task.rs
+git commit -S -m "feat(settlement): build and sign an eip1559 settlement attempt"
+```
+
+---
+
+## Task 5: `build_next_attempt_with_new_nonce` and run-loop wiring
+
+Resolve wallet/nonce/chain-id/fees, call `build_attempt`, and `await` it in the
+run loop via `retry!`.
+
+**Files:**
+- Modify: `crates/agglayer-settlement-service/src/settlement_task.rs`
+  (rewrite stub ~738-744; call site ~404-406; new Anvil test in `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` (Anvil-backed; mirrors the `utils.rs` test pattern):
+
+```rust
+    #[tokio::test]
+    async fn build_next_attempt_with_new_nonce_uses_pending_nonce_and_default_wallet() {
+        use alloy::{
+            consensus::Transaction as _,
+            node_bindings::Anvil,
+            providers::ProviderBuilder,
+            rpc::types::TransactionRequest,
+        };
+
+        let anvil = Anvil::new().spawn();
+        let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+        let wallet_address = signer.address();
+        let wallet = Arc::new(EthereumWallet::from(signer.clone()));
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect_http(anvil.endpoint_url());
+
+        // Bump the sender's nonce to 2 by mining two transactions.
+        for _ in 0..2 {
+            let tx = TransactionRequest::default()
+                .to(anvil.addresses()[1])
+                .value(U256::from(1));
+            provider
+                .send_transaction(tx)
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+        }
+
+        let task = SettlementTask {
+            id: mk_job_id(1),
+            job: mk_job(),
+            tx_config: Arc::new(SettlementTransactionConfig::default()),
+            provider: Arc::new(provider),
+            store: Arc::new(MockStateStore::new()),
+            wallet,
+            control: mk_control(),
+            attempts: BTreeMap::new(),
+        };
+
+        let (used_wallet, nonce, attempt_number, envelope) = task
+            .build_next_attempt_with_new_nonce()
+            .await
+            .expect("attempt should build");
+
+        assert_eq!(used_wallet, wallet_address);
+        assert_eq!(nonce, Nonce(2));
+        assert_eq!(attempt_number, SettlementAttemptNumber(0));
+        assert_eq!(envelope.nonce(), 2);
+        assert_eq!(envelope.to(), Some(mk_job().contract_address.into_alloy()));
+        assert_eq!(envelope.chain_id(), Some(anvil.chain_id()));
+        // Fees are within the configured bounds (defaults: floor 0, ceiling 100 gwei).
+        assert!(envelope.max_fee_per_gas() <= 100_000_000_000);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo nextest run -p agglayer-settlement-service build_next_attempt_with_new_nonce_uses_pending`
+Expected: FAIL — the stub `todo!()` panics (and the signature is not yet
+`async`/`Result`, so it will also fail to compile against the test).
+
+- [ ] **Step 3: Replace the stub implementation**
+
+Replace:
+
+```rust
+    fn build_next_attempt_with_new_nonce(
+        &self,
+    ) -> (Address, Nonce, SettlementAttemptNumber, TxEnvelope) {
+        // TODO: Build the next attempt with correct gas and other params. Use https://docs.rs/alloy/latest/alloy/rpc/types/struct.TransactionRequest.html#method.build
+        // XREF: https://github.com/agglayer/agglayer/issues/1318
+        todo!()
+    }
+```
+
+with:
+
+```rust
+    async fn build_next_attempt_with_new_nonce(
+        &self,
+    ) -> Result<
+        (Address, Nonce, SettlementAttemptNumber, TxEnvelope),
+        RetryCallbackError<BuildAttemptError>,
+    > {
+        let wallet = self.wallet.default_signer().address();
+        let attempt_number = self.next_attempt_number();
+
+        crate::utils::retry_callback_until_success(
+            &self.tx_config.retry_on_transient_failure,
+            &self.control.cancellation_token,
+            || async {
+                let nonce = self.provider.get_transaction_count(wallet).pending().await?;
+                let chain_id = self.provider.get_chain_id().await?;
+                let estimate = self.provider.estimate_eip1559_fees().await?;
+                let gas = self.resolve_base_gas_params(&estimate);
+                let tx = self
+                    .build_attempt(wallet, Nonce(nonce), chain_id, gas)
+                    .await?;
+                Ok((wallet, Nonce(nonce), attempt_number, tx))
+            },
+            BuildAttemptError::is_transient,
+        )
+        .await
+    }
+```
+
+- [ ] **Step 4: Update the run-loop call site**
+
+In `run`, replace lines ~404-406:
+
+```rust
+                let (wallet, nonce, attempt_number, tx) = self.build_next_attempt_with_new_nonce();
+                self.save_attempt_to_db_and_submit_to_l1(wallet, nonce, attempt_number, tx)
+                    .await;
+```
+
+with:
+
+```rust
+                let (wallet, nonce, attempt_number, tx) = retry!(
+                    self.build_next_attempt_with_new_nonce().await,
+                    "building next settlement attempt with a new nonce",
+                );
+                self.save_attempt_to_db_and_submit_to_l1(wallet, nonce, attempt_number, tx)
+                    .await;
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo nextest run -p agglayer-settlement-service build_next_attempt_with_new_nonce_uses_pending`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/agglayer-settlement-service/src/settlement_task.rs
+git commit -S -m "feat(settlement): build next attempt with a fresh nonce"
+```
+
+---
+
+## Task 6: Implement `is_wallet_privkey_known` (optional adjacent win)
+
+The wallet field makes this stub a one-liner; implementing it removes a
+`todo!()` panic on the resubmission path.
+
+**Files:**
+- Modify: `crates/agglayer-settlement-service/src/settlement_task.rs`
+  (replace stub ~536-539; test in `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn is_wallet_privkey_known_reflects_registered_signers() {
+        let signer = PrivateKeySigner::random();
+        let known = signer.address();
+        let wallet = Arc::new(EthereumWallet::from(signer));
+        let unknown = Address::from([9; 20]);
+
+        let task = mk_task_with_id(
+            mk_job_id(1),
+            Arc::new(MockStateStore::new()),
+            BTreeMap::new(),
+            wallet,
+        );
+
+        assert!(task.is_wallet_privkey_known(known));
+        assert!(!task.is_wallet_privkey_known(unknown));
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo nextest run -p agglayer-settlement-service is_wallet_privkey_known_reflects`
+Expected: FAIL — the current stub is `todo!()` and panics.
+
+- [ ] **Step 3: Replace the stub**
+
+Replace:
+
+```rust
+    fn is_wallet_privkey_known(&self, _wallet: Address) -> bool {
+        // TODO: tie with the configuration
+        todo!()
+    }
+```
+
+with:
+
+```rust
+    fn is_wallet_privkey_known(&self, wallet: Address) -> bool {
+        self.wallet.signer_by_address(wallet).is_some()
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo nextest run -p agglayer-settlement-service is_wallet_privkey_known_reflects`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/agglayer-settlement-service/src/settlement_task.rs
+git commit -S -m "feat(settlement): resolve known wallets from the signer set"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run the verify skill's checks for the crate**
+
+Run: `cargo make blast-radius` then the recommended commands. Expect
+`affected_crates` to include `agglayer-settlement-service`; run:
+
+```bash
+cargo check --workspace --tests --all-features
+cargo make ci-all
+cargo nextest run -p agglayer-settlement-service
+```
+
+Expected: all PASS (format, clippy, typos, and tests).
+
+- [ ] **Step 2: Confirm no XREF/TODO remains for 1318**
+
+Run: `rg -n "issues/1318" crates/agglayer-settlement-service/src/settlement_task.rs`
+Expected: no matches (the marker is removed with the implemented function).
+
+---
+
+## Notes for the implementer
+
+- `default_signer().address()` and `signer_by_address()` are inherent
+  `EthereumWallet` methods, used deliberately to avoid the `NetworkWallet<N>`
+  trait-method ambiguity (`EthereumWallet: NetworkWallet<N>` for all `N`).
+- `TransactionRequest`'s `.from/.to/.value/.input/.nonce/.gas_limit/.max_fee_per_gas/.max_priority_fee_per_gas`
+  are inherent builder methods; `.with_chain_id` and `.build` come from the
+  `TransactionBuilder` trait (imported as `_`).
+- The `retry!` macro is defined inside `run`; it is in scope at the call site
+  and converts a permanent `BuildAttemptError` into a `NonRecoverableError`
+  panic, matching how `tx_hash_on_l1_for_nonce` is consumed.
+- Do not implement issue 1319 (`build_next_attempt_with_nonce`) here; it will
+  reuse `build_attempt` with a bumped `GasParams`.

--- a/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-attempt-builder-design.md
+++ b/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-attempt-builder-design.md
@@ -109,13 +109,25 @@ enum BuildAttemptError {
     Build(TransactionBuilderError<Ethereum>),
 }
 
-impl BuildAttemptError {
-    fn is_transient(&self) -> bool {
-        match self {
-            Self::Transport(error) => crate::utils::is_transient_alloy_error(error),
-            // Remote signer backends (e.g. GCP KMS) can fail transiently.
-            Self::Build(TransactionBuilderError::Signer(_)) => true,
-            Self::Build(_) => false,
+/// Retry policy for building a settlement attempt. Transport failures retry
+/// while transient; opaque signer-backend failures retry a bounded number of
+/// times (to ride out a transient remote-signer blip without looping forever
+/// on a permanent misconfiguration); structural build errors are permanent.
+struct BuildRetryPolicy {
+    signer_failures: u32,
+}
+
+impl BuildRetryPolicy {
+    const MAX_SIGNER_BUILD_RETRIES: u32 = 3;
+
+    fn should_retry(&mut self, error: &BuildAttemptError) -> bool {
+        match error {
+            BuildAttemptError::Transport(error) => crate::utils::is_transient_alloy_error(error),
+            error if error.is_signer_backend() => {
+                self.signer_failures += 1;
+                self.signer_failures <= Self::MAX_SIGNER_BUILD_RETRIES
+            }
+            BuildAttemptError::Build(_) => false,
         }
     }
 }
@@ -312,13 +324,19 @@ fn resolve_base_gas_params(&self, estimate: &Eip1559Estimation) -> GasParams {
 - Transient L1 RPC failures (nonce/chain id/fees) are retried in-place using
   the configured `retry_on_transient_failure` policy and the existing
   `retry_callback_until_success` helper.
-- Signer-backend failures (`TransactionBuilderError::Signer`) are treated as
-  transient and retried: remote signers such as GCP KMS sign over the network
-  and can fail transiently, so a temporary KMS outage must not stop settlement.
-- Other build failures (`InvalidTransactionRequest`, `UnsupportedSignatureType`)
-  indicate a build bug or misconfiguration; they are non-recoverable, propagate
-  as `RetryCallbackError::Error`, and become a `NonRecoverableError` panic at
-  the call site, matching the run-loop's handling of permanent errors.
+- Opaque signer-backend failures (`TransactionBuilderError::Signer(Error::Other)`,
+  how a remote signer such as GCP KMS surfaces a signing error) are retried a
+  **bounded** number of times (`MAX_SIGNER_BUILD_RETRIES`). This rides out a
+  transient KMS blip without panicking the task, yet a permanent signer
+  misconfiguration (e.g. bad KMS permissions) stops retrying after the bound and
+  surfaces through the non-recoverable path instead of looping until
+  cancellation. The transient-vs-permanent signer distinction is opaque here;
+  a precise classification belongs in the signer backend (follow-up).
+- Structural signer errors (unsupported operation, chain-id mismatch, signature
+  errors) and other build failures (`InvalidTransactionRequest`,
+  `UnsupportedSignatureType`) are non-recoverable immediately: they propagate as
+  `RetryCallbackError::Error` and become a `NonRecoverableError` panic at the
+  call site, matching the run-loop's handling of permanent errors.
 
 ## Testing strategy
 

--- a/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-attempt-builder-design.md
+++ b/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-attempt-builder-design.md
@@ -1,0 +1,361 @@
+# Settlement attempt builder (issue 1318) — design
+
+- Issue: <https://github.com/agglayer/agglayer/issues/1318>
+- Related: 1319 (gas bump), 1321 (submit to L1), 1320 (save attempt), 1381
+  (persist job), 1314 (wait for nonce on L1), 1382 (current result on L1)
+- Status: approved design, pre-implementation
+- Date: 2026-06-08
+
+## Context
+
+The settlement service runs one `SettlementTask` per settlement job
+(`crates/agglayer-settlement-service/src/settlement_task.rs`).
+The task's `run` loop submits and tracks L1 settlement transactions,
+keying attempts by `(wallet Address, Nonce)`.
+
+Several leaf helpers are still `todo!()` stubs, each tracked by its own issue.
+This spec covers the builder marked by
+`// XREF: https://github.com/agglayer/agglayer/issues/1318`,
+currently:
+
+```rust
+fn build_next_attempt_with_new_nonce(
+    &self,
+) -> (Address, Nonce, SettlementAttemptNumber, TxEnvelope) {
+    todo!()
+}
+```
+
+where `type TxEnvelope = EthereumTxEnvelope<TxEip4844Variant>` (a *signed*
+envelope).
+Its sibling `build_next_attempt_with_nonce` (issue 1319) bumps gas for a
+retry on an existing nonce; submission (issue 1321) is separate.
+
+The issue title — "build a settlement tx for a given job with a given nonce
+and gas parameters" — describes a generic builder primitive,
+while the XREF marker sits on the *new-nonce* function.
+We reconcile this by implementing both:
+a reusable primitive plus the new-nonce orchestration that calls it.
+
+### Key constraints discovered during exploration
+
+1. `SettlementTask` has **no signer**, and the crate does not depend on any
+   signer crate.
+   But the function must return a *signed* `TxEnvelope`;
+   its `tx.tx_hash()` is what the caller records to RocksDB before submission
+   (`save_attempt_to_db_and_submit_to_l1`, `settlement_task.rs:449`).
+2. The stub signature cannot work as written.
+   alloy's `TransactionBuilder::build(wallet)` is `async`, returns `Result`,
+   and requires a `NetworkWallet`.
+   The current function is synchronous and infallible.
+3. The service builds the envelope **before** submitting,
+   so it cannot rely on alloy's send-time fillers (nonce/gas/fee);
+   it must resolve those values itself.
+
+## Goals
+
+- Implement a reusable primitive that builds and signs an EIP-1559 settlement
+  transaction for `self.job` given a wallet, nonce, chain id, and resolved gas
+  parameters.
+- Implement `build_next_attempt_with_new_nonce` to select a wallet,
+  resolve a fresh nonce and base gas parameters, allocate an attempt number,
+  and call the primitive.
+- Give `SettlementTask` access to a signing wallet.
+- Build only; do not submit (submission is issue 1321).
+
+## Non-goals (out of scope)
+
+- Loading signing keys from configuration (keystore / GCP KMS wiring).
+  The task receives an already-constructed `EthereumWallet`.
+- Multi-wallet selection policy beyond "use the default signer".
+- The per-retry gas bump (issue 1319).
+- Persisting the attempt to RocksDB (issue 1320) and submission (issue 1321).
+- Integrating the settlement service into the node
+  (it is still `#![allow(dead_code)]`).
+
+## Decisions (from brainstorming)
+
+1. **Scope**: build a reusable primitive `build_attempt(...)` and wire it into
+   `build_next_attempt_with_new_nonce`.
+2. **Signer source**: add an `EthereumWallet` field to `SettlementTask`.
+   alloy's `EthereumWallet` is itself a multi-signer container keyed by address
+   and implements `NetworkWallet<Ethereum>`;
+   `agglayer-signer`'s `ConfiguredSigner` (local keystore or GCP KMS)
+   implements `TxSigner<Signature>`, so it plugs in via
+   `EthereumWallet::from(signer)`.
+3. **Gas handling**: align with the existing convention in
+   `agglayer-contracts` (`adjust_gas_estimate`, `settler.rs`),
+   adapted to the new per-field config and the job's explicit gas limit;
+   use a small local helper rather than depending on `agglayer-contracts`.
+
+## Design
+
+### Data types
+
+```rust
+/// Fully-resolved gas parameters for a single settlement attempt.
+struct GasParams {
+    gas_limit: u128,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+}
+
+/// Error surfaced while building a settlement attempt.
+#[derive(Debug, thiserror::Error)]
+enum BuildAttemptError {
+    #[error("L1 RPC error while building settlement attempt: {0}")]
+    Transport(#[from] TransportError),
+    #[error("failed to build/sign settlement transaction: {0}")]
+    Build(TransactionBuilderError<Ethereum>),
+}
+
+impl BuildAttemptError {
+    fn is_transient(&self) -> bool {
+        match self {
+            Self::Transport(error) => crate::utils::is_transient_alloy_error(error),
+            // A build/sign failure with a configured wallet is non-recoverable.
+            Self::Build(_) => false,
+        }
+    }
+}
+```
+
+### Task field and constructor threading
+
+Add a signing wallet to the task and the service:
+
+```rust
+pub struct SettlementTask<L1Provider, SettlementStore> {
+    // ...existing fields...
+    wallet: Arc<EthereumWallet>,
+}
+```
+
+- `SettlementTask::create` and `SettlementTask::load` gain a
+  `wallet: Arc<EthereumWallet>` parameter and store it.
+- `SettlementService` gains a `wallet: Arc<EthereumWallet>` field;
+  `SettlementService::start` gains a corresponding parameter and passes the
+  wallet into `SettlementTask::create`.
+- Optional adjacent win: implement the existing `is_wallet_privkey_known`
+  stub as `self.wallet.has_signer_for(&wallet)`
+  (a one-liner enabled by the new field; removes a `todo!()` panic).
+  Flagged as optional; include only if it keeps the change focused.
+
+### Primitive: `build_attempt`
+
+Pure builder (async only because signing is async); no RPC calls.
+
+```rust
+async fn build_attempt(
+    &self,
+    wallet: Address,
+    nonce: Nonce,
+    chain_id: u64,
+    gas: GasParams,
+) -> Result<TxEnvelope, TransactionBuilderError<Ethereum>> {
+    let request = TransactionRequest::default()
+        .from(wallet)
+        .to(self.job.contract_address.into_alloy())
+        .value(self.job.eth_value)
+        .input(self.job.calldata.clone().into())
+        .nonce(nonce.0)
+        .gas_limit(gas.gas_limit)
+        .max_fee_per_gas(gas.max_fee_per_gas)
+        .max_priority_fee_per_gas(gas.max_priority_fee_per_gas)
+        .with_chain_id(chain_id);
+    request.build(self.wallet.as_ref()).await
+}
+```
+
+Setting both `max_fee_per_gas` and `max_priority_fee_per_gas`
+(and no blob fields) yields an EIP-1559 envelope (`TxEnvelope::Eip1559`).
+The `wallet` argument sets the `from` field and must have a registered signer
+in `self.wallet`; otherwise `build` fails with a signer-missing error.
+
+### Orchestration: `build_next_attempt_with_new_nonce`
+
+```rust
+async fn build_next_attempt_with_new_nonce(
+    &self,
+) -> Result<
+    (Address, Nonce, SettlementAttemptNumber, TxEnvelope),
+    RetryCallbackError<BuildAttemptError>,
+> {
+    let wallet = self.wallet.default_signer_address();
+    let attempt_number = self.next_attempt_number();
+
+    crate::utils::retry_callback_until_success(
+        &self.tx_config.retry_on_transient_failure,
+        &self.control.cancellation_token,
+        || async {
+            let nonce = self
+                .provider
+                .get_transaction_count(wallet)
+                .pending()
+                .await?;
+            let chain_id = self.provider.get_chain_id().await?;
+            let estimate = self.provider.estimate_eip1559_fees().await?;
+            let gas = self.resolve_base_gas_params(&estimate);
+            let tx = self
+                .build_attempt(wallet, Nonce(nonce), chain_id, gas)
+                .await
+                .map_err(BuildAttemptError::Build)?;
+            Ok((wallet, Nonce(nonce), attempt_number, tx))
+        },
+        BuildAttemptError::is_transient,
+    )
+    .await
+}
+```
+
+- **Wallet selection**: `self.wallet.default_signer_address()`.
+  Trivial in the single-wallet case; richer selection is future work.
+- **Nonce**: `get_transaction_count(wallet).pending()`.
+- **Chain id**: `get_chain_id()`.
+- **Fees**: `estimate_eip1559_fees()`, then adjusted (see below).
+- **Attempt number**: `next_attempt_number()` =
+  highest attempt number currently in `self.attempts` plus one,
+  or `0` when there are none.
+  Computed once outside the retry closure (it does not depend on RPC).
+- The whole resolve-and-sign body is one retryable closure:
+  transient transport errors are retried with
+  `retry_on_transient_failure`;
+  a build/sign error is non-transient and surfaces as
+  `RetryCallbackError::Error`.
+  Re-resolving nonce/fees on retry is intentional and keeps a consistent
+  snapshot.
+
+### Gas resolution (base attempt)
+
+Mirrors `agglayer-contracts::adjust_gas_estimate`,
+using the new per-field config in `SettlementTransactionConfig`:
+
+```rust
+fn resolve_base_gas_params(&self, estimate: &Eip1559Estimation) -> GasParams {
+    let cfg = &self.tx_config;
+
+    let max_fee_per_gas = clamp_fee(
+        apply_multiplier(estimate.max_fee_per_gas, cfg.max_fee_per_gas_multiplier_factor),
+        cfg.max_fee_per_gas_floor,
+        cfg.max_fee_per_gas_ceiling,
+    );
+    let max_priority_fee_per_gas = clamp_fee(
+        apply_multiplier(
+            estimate.max_priority_fee_per_gas,
+            cfg.max_priority_fee_per_gas_multiplier_factor,
+        ),
+        cfg.max_priority_fee_per_gas_floor,
+        cfg.max_priority_fee_per_gas_ceiling,
+    );
+
+    let gas_limit = apply_multiplier(self.job.gas_limit, cfg.gas_limit_multiplier_factor)
+        .min(u128::try_from(cfg.gas_limit_ceiling).unwrap_or(u128::MAX));
+
+    GasParams { gas_limit, max_fee_per_gas, max_priority_fee_per_gas }
+}
+```
+
+- `apply_multiplier(value, m)` = `value.saturating_mul(m.as_u64_per_1000() as u128) / 1000`,
+  matching the legacy `adjust` closure.
+- `clamp_fee(v, floor, ceiling)` = `v.max(floor).min(ceiling)`.
+- **gas_limit base** is `self.job.gas_limit` (the orchestrator-provided
+  estimate), not an RPC `estimate_gas` call;
+  this is the deliberate adaptation from the legacy RPC-estimate path,
+  since the new `SettlementJob` carries an explicit gas limit.
+- Defaults (`multiplier = 1.0`, `floor = 0`, `gas_limit_ceiling = 60_000_000`,
+  fee ceilings = 100 gwei) make the base attempt
+  `gas_limit = min(job.gas_limit, ceiling)` and
+  `fee = clamp(estimate, 0, ceiling)`.
+
+#### Judgment calls (intentional deviations from legacy)
+
+1. `max_priority_fee_per_gas` is clamped to **both** `[floor, ceiling]`;
+   legacy applied only `.min(ceiling)` to priority,
+   which looks like an oversight now that the config has an explicit priority
+   floor.
+2. At the base/new-nonce attempt the per-field multiplier is applied **once**
+   (default `1.0` ⇒ no change).
+   Per-retry compounding belongs to issue 1319.
+
+### Signature and call-site changes
+
+- `build_next_attempt_with_new_nonce` becomes `async` and fallible
+  (see signature above).
+- The call site (`settlement_task.rs:404`) changes from a direct call to:
+
+  ```rust
+  let (wallet, nonce, attempt_number, tx) = retry!(
+      self.build_next_attempt_with_new_nonce().await,
+      "building next settlement attempt with a new nonce",
+  );
+  ```
+
+  This reuses the existing `retry!` macro,
+  which returns early on `Cancelled` and panics with a `NonRecoverableError`
+  on a permanent error — consistent with how `tx_hash_on_l1_for_nonce` is used.
+- `BuildAttemptError` derives `thiserror::Error` so the macro's
+  `eyre::Error::from(error)` works.
+
+### New imports / APIs
+
+- `alloy::network::{Ethereum, EthereumWallet, TransactionBuilder, TransactionBuilderError}`
+- `alloy::rpc::types::TransactionRequest`
+- `alloy::eips::eip1559::Eip1559Estimation`
+- `Provider` methods: `get_transaction_count(addr).pending()`,
+  `get_chain_id()`, `estimate_eip1559_fees()`.
+- Conversions: `agglayer_types::Address::into_alloy()` (already used at
+  `settlement_task.rs:798`); `job.calldata` is already `alloy::primitives::Bytes`.
+
+## Error handling
+
+- Transient L1 RPC failures (nonce/chain id/fees) are retried in-place using
+  the configured `retry_on_transient_failure` policy and the existing
+  `retry_callback_until_success` helper.
+- A build/sign failure is treated as non-recoverable
+  (the configured wallet should always be able to sign a fully-populated
+  request); it propagates as `RetryCallbackError::Error` and becomes a
+  `NonRecoverableError` panic at the call site, matching current run-loop
+  behavior for permanent errors.
+- Known limitation: if a GCP KMS signer is later wired in, transient KMS
+  signing errors would currently be classified non-transient.
+  Revisit `BuildAttemptError::is_transient` when KMS signing lands.
+
+## Testing strategy
+
+Unit tests in `settlement_task.rs` using an Anvil-backed wallet provider
+(the pattern already used in `utils.rs` tests:
+`Anvil::new().spawn()` + `ProviderBuilder::new().wallet(EthereumWallet::from(signer))`).
+
+- `build_attempt` produces a signed EIP-1559 envelope with the expected
+  `to`, `value`, `input`, `nonce`, `chain_id`, and recovered signer address.
+- `build_next_attempt_with_new_nonce` returns the wallet's default signer
+  address, a nonce equal to the account's pending transaction count,
+  and an attempt number one past the highest existing attempt.
+- `resolve_base_gas_params` clamps fees to the configured floor/ceiling and
+  caps `gas_limit` at `gas_limit_ceiling`,
+  and applies the multiplier (use a non-default config to assert scaling).
+- Existing tests (`write_job_result_*`, `load_settlement_attempts_*`) are
+  updated only to pass a wallet into the task test helpers
+  (`mk_task`, `mk_task_with_id`, `mk_service`);
+  a wallet built from a throwaway `PrivateKeySigner` is sufficient since those
+  tests do not build transactions.
+
+## Dependencies and follow-ups
+
+- A dependency on `agglayer-signer` is **not** required for this issue:
+  the task accepts an `EthereumWallet` directly,
+  and tests construct it from `alloy-signer-local`'s `PrivateKeySigner`.
+  Wiring `ConfiguredSigner` from config is a later integration step.
+- `dev-dependencies` already enable `alloy` `node-bindings` for Anvil.
+- Downstream issues consume this builder: 1320 (save attempt),
+  1321 (submit), 1319 (gas bump reuses `build_attempt` + a bumped `GasParams`).
+
+## Open assumptions
+
+- The default signer of the task's `EthereumWallet` is an acceptable wallet
+  for a new-nonce attempt (single-wallet deployments).
+- `self.job.gas_limit` is the authoritative base for the gas limit,
+  shaped only by `gas_limit_multiplier_factor` and `gas_limit_ceiling`.
+- Attempt numbers are unique per job and monotonically allocated from
+  `self.attempts`; coordination with in-memory insertion on save is owned by
+  issue 1320.

--- a/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-attempt-builder-design.md
+++ b/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-attempt-builder-design.md
@@ -113,7 +113,8 @@ impl BuildAttemptError {
     fn is_transient(&self) -> bool {
         match self {
             Self::Transport(error) => crate::utils::is_transient_alloy_error(error),
-            // A build/sign failure with a configured wallet is non-recoverable.
+            // Remote signer backends (e.g. GCP KMS) can fail transiently.
+            Self::Build(TransactionBuilderError::Signer(_)) => true,
             Self::Build(_) => false,
         }
     }
@@ -311,14 +312,13 @@ fn resolve_base_gas_params(&self, estimate: &Eip1559Estimation) -> GasParams {
 - Transient L1 RPC failures (nonce/chain id/fees) are retried in-place using
   the configured `retry_on_transient_failure` policy and the existing
   `retry_callback_until_success` helper.
-- A build/sign failure is treated as non-recoverable
-  (the configured wallet should always be able to sign a fully-populated
-  request); it propagates as `RetryCallbackError::Error` and becomes a
-  `NonRecoverableError` panic at the call site, matching current run-loop
-  behavior for permanent errors.
-- Known limitation: if a GCP KMS signer is later wired in, transient KMS
-  signing errors would currently be classified non-transient.
-  Revisit `BuildAttemptError::is_transient` when KMS signing lands.
+- Signer-backend failures (`TransactionBuilderError::Signer`) are treated as
+  transient and retried: remote signers such as GCP KMS sign over the network
+  and can fail transiently, so a temporary KMS outage must not stop settlement.
+- Other build failures (`InvalidTransactionRequest`, `UnsupportedSignatureType`)
+  indicate a build bug or misconfiguration; they are non-recoverable, propagate
+  as `RetryCallbackError::Error`, and become a `NonRecoverableError` panic at
+  the call site, matching the run-loop's handling of permanent errors.
 
 ## Testing strategy
 


### PR DESCRIPTION
Implement the settlement-attempt builder for issue 1318: select a wallet
and a fresh nonce, resolve EIP-1559 gas parameters from config and the
latest fee estimate, and build a signed transaction envelope ready to be
recorded before submission. This does not submit the transaction.

- Add an alloy EthereumWallet signing field to SettlementTask and
  SettlementService, threaded through their constructors.
- Add a reusable build_attempt primitive that builds and signs an
  EIP-1559 transaction for the job (given wallet, nonce, chain id, gas).
- Add resolve_base_gas_params mirroring agglayer-contracts'
  adjust_gas_estimate, using the per-field config floors/ceilings and
  multipliers; cap the priority fee at the max fee to preserve the
  EIP-1559 invariant under misconfiguration.
- Make build_next_attempt_with_new_nonce async and fallible: fetch the
  pending nonce, chain id, and fee estimate (retrying transient L1 RPC
  failures), then build the attempt; wire it into the run loop via the
  existing retry! macro.
- Implement is_wallet_privkey_known against the signer set, and add
  next_attempt_number to allocate per-job attempt numbers.

Sibling stubs build_next_attempt_with_nonce (1319) and
submit_attempt_to_l1 (1321) are intentionally left for their own issues.

Design and plan live under docs/knowledge-base/src/ai-agents/.

Refs: https://github.com/agglayer/agglayer/issues/1318