### PR TITLE
feat(settlement): submit settlement attempt to L1

### DIFF
--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -41,25 +41,38 @@ fn required_settlement_head_number(receipt_block_number: u64, confirmations: usi
     receipt_block_number.saturating_add(confirmation_offset)
 }
 
-/// Maps the result of broadcasting a settlement attempt to the caller's result.
+/// Why submitting a settlement attempt to L1 did not complete normally.
+#[derive(Debug)]
+enum SubmitAttemptError {
+    /// The task was cancelled mid-submission. The already-saved attempt is left
+    /// pending so it resumes on reload, and the runner is told to stop.
+    Cancelled,
+    /// Submission failed for a non-transient reason and should be recorded.
+    Failed(eyre::Error),
+}
+
+/// Maps the result of broadcasting a settlement attempt to a submit outcome.
 ///
-/// Cancellation is reported as success so that an operational shutdown leaves
-/// the already-saved attempt pending and lets the task exit cleanly, instead of
-/// the caller persisting a spurious `ClientError` for an attempt that may still
-/// be broadcast.
+/// Cancellation becomes [`SubmitAttemptError::Cancelled`] so the caller can
+/// leave the already-saved attempt pending and propagate a stop signal to the
+/// runner, instead of recording a spurious `ClientError` or silently continuing
+/// into the post-submit wait after shutdown.
 ///
-/// A non-transient error is still surfaced. Note that a re-broadcast whose
-/// first response was lost can return an "already known"/nonce-used error that
-/// this path reports as failure even though the transaction was accepted;
-/// recognizing those responses as success depends on the RPC error
-/// classification deferred to `SettlementServiceConfig`.
+/// A non-transient error becomes [`SubmitAttemptError::Failed`]. Note that a
+/// re-broadcast whose first response was lost can return an "already
+/// known"/nonce-used error reported here as failure even though the transaction
+/// was accepted; recognizing those responses as success depends on the RPC
+/// error classification deferred to `SettlementServiceConfig`.
 /// XREF: https://github.com/agglayer/agglayer/issues/1321
-fn submission_outcome(result: Result<(), RetryCallbackError<TransportError>>) -> eyre::Result<()> {
+fn submission_outcome(
+    result: Result<(), RetryCallbackError<TransportError>>,
+) -> Result<(), SubmitAttemptError> {
     match result {
-        Ok(()) | Err(RetryCallbackError::Cancelled) => Ok(()),
-        Err(RetryCallbackError::Error(error)) => {
-            Err(eyre::Error::new(error).wrap_err("failed to submit settlement attempt to L1"))
-        }
+        Ok(()) => Ok(()),
+        Err(RetryCallbackError::Cancelled) => Err(SubmitAttemptError::Cancelled),
+        Err(RetryCallbackError::Error(error)) => Err(SubmitAttemptError::Failed(
+            eyre::Error::new(error).wrap_err("failed to submit settlement attempt to L1"),
+        )),
     }
 }
 
@@ -347,8 +360,12 @@ impl<
                         continue 'nonces; // wait for deadline to be reached
                     }
                     let (attempt_number, tx) = self.build_next_attempt_with_nonce(wallet, nonce);
-                    self.save_attempt_to_db_and_submit_to_l1(wallet, nonce, attempt_number, tx)
-                        .await;
+                    if let Some(run_result) = self
+                        .save_attempt_to_db_and_submit_to_l1(wallet, nonce, attempt_number, tx)
+                        .await
+                    {
+                        return run_result;
+                    }
                 }
             }
             if all_nonces_seen_on_l1 && !reverts.is_empty() {
@@ -426,8 +443,12 @@ impl<
                 // pending nonces. So we need to submit a new attempt with a new
                 // nonce.
                 let (wallet, nonce, attempt_number, tx) = self.build_next_attempt_with_new_nonce();
-                self.save_attempt_to_db_and_submit_to_l1(wallet, nonce, attempt_number, tx)
-                    .await;
+                if let Some(run_result) = self
+                    .save_attempt_to_db_and_submit_to_l1(wallet, nonce, attempt_number, tx)
+                    .await
+                {
+                    return run_result;
+                }
             }
             // We now are sure we did at least one step to make things move forward. Wait
             // for the next external event or for the next deadline.
@@ -470,26 +491,38 @@ impl<
         }
     }
 
+    /// Saves the attempt, then submits it to L1.
+    ///
+    /// Returns `Some(SettlementTaskRunResult::Cancelled)` when submission was
+    /// interrupted by a shutdown, so the runner stops promptly while leaving
+    /// the already-saved attempt pending; returns `None` when the runner
+    /// should keep going (whether submission succeeded or failed with a
+    /// recorded client error).
     async fn save_attempt_to_db_and_submit_to_l1(
         &mut self,
         wallet: Address,
         nonce: Nonce,
         attempt_number: SettlementAttemptNumber,
         tx: TxEnvelope,
-    ) {
+    ) -> Option<SettlementTaskRunResult> {
         let tx_hash = SettlementTxHash::from(Digest::from(*tx.tx_hash()));
         self.save_attempt_to_db(wallet, nonce, attempt_number, tx_hash)
             .await;
-        if let Err(error) = self.submit_attempt_to_l1(tx).await {
-            warn!(?error, "Failed to submit settlement attempt to L1");
-            self.write_client_error_to_db(
-                attempt_number,
-                ClientError {
-                    kind: ClientErrorType::Unknown,
-                    message: format!("Failed to submit settlement attempt to L1: {error:?}"),
-                },
-            )
-            .await;
+        match self.submit_attempt_to_l1(tx).await {
+            Ok(()) => None,
+            Err(SubmitAttemptError::Cancelled) => Some(SettlementTaskRunResult::Cancelled),
+            Err(SubmitAttemptError::Failed(error)) => {
+                warn!(?error, "Failed to submit settlement attempt to L1");
+                self.write_client_error_to_db(
+                    attempt_number,
+                    ClientError {
+                        kind: ClientErrorType::Unknown,
+                        message: format!("Failed to submit settlement attempt to L1: {error:?}"),
+                    },
+                )
+                .await;
+                None
+            }
         }
     }
 
@@ -766,7 +799,7 @@ impl<
         todo!()
     }
 
-    async fn submit_attempt_to_l1(&self, tx: TxEnvelope) -> eyre::Result<()> {
+    async fn submit_attempt_to_l1(&self, tx: TxEnvelope) -> Result<(), SubmitAttemptError> {
         // Encode the signed transaction once, consuming the envelope. This is the
         // only thing `send_tx_envelope` does with it before calling
         // `eth_sendRawTransaction`, so each retry can re-broadcast the same bytes
@@ -1449,16 +1482,23 @@ mod tests {
     }
 
     #[test]
-    fn submission_outcome_treats_cancellation_as_pending() {
-        // A shutdown mid-retry must not be recorded as a client error: the
-        // already-saved attempt has to stay pending so it can resume on reload.
-        assert!(submission_outcome(Err(RetryCallbackError::Cancelled)).is_ok());
+    fn submission_outcome_treats_cancellation_as_cancelled() {
+        // A shutdown mid-retry must surface as cancellation so the caller leaves
+        // the already-saved attempt pending and stops the runner, rather than
+        // recording a client error or silently continuing as success.
+        assert!(matches!(
+            submission_outcome(Err(RetryCallbackError::Cancelled)),
+            Err(SubmitAttemptError::Cancelled)
+        ));
     }
 
     #[test]
-    fn submission_outcome_propagates_transport_error() {
+    fn submission_outcome_reports_transport_error_as_failed() {
         let error = RetryCallbackError::Error(TransportErrorKind::custom_str("boom"));
-        assert!(submission_outcome(Err(error)).is_err());
+        assert!(matches!(
+            submission_outcome(Err(error)),
+            Err(SubmitAttemptError::Failed(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -800,6 +800,13 @@ impl<
     }
 
     async fn submit_attempt_to_l1(&self, tx: TxEnvelope) -> Result<(), SubmitAttemptError> {
+        // Don't start a new broadcast once shutdown is requested. The retry helper
+        // only observes the token while backing off after a transient error, so
+        // an already-cancelled token would otherwise still send the first tx.
+        if self.control.cancellation_token.is_cancelled() {
+            return Err(SubmitAttemptError::Cancelled);
+        }
+
         // Encode the signed transaction once, consuming the envelope. This is the
         // only thing `send_tx_envelope` does with it before calling
         // `eth_sendRawTransaction`, so each retry can re-broadcast the same bytes
@@ -1547,6 +1554,55 @@ mod tests {
         assert!(
             broadcast_tx.is_some(),
             "the node should know the broadcast settlement transaction"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_attempt_to_l1_skips_broadcast_when_already_cancelled() {
+        let anvil = Anvil::new().spawn();
+        let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect_http(anvil.endpoint_url());
+
+        let tx_request = TransactionRequest::default()
+            .to(anvil.addresses()[1])
+            .value(alloy::primitives::U256::from(1));
+        let envelope = provider
+            .fill(tx_request)
+            .await
+            .expect("filling the settlement transaction should succeed")
+            .try_into_envelope()
+            .expect("a wallet-filled transaction should be a signed envelope");
+        let expected_tx_hash: TxHash = *envelope.tx_hash();
+
+        let task = SettlementTask {
+            id: mk_job_id(1),
+            job: mk_job(),
+            tx_config: Arc::new(SettlementTransactionConfig::default()),
+            provider: Arc::new(provider),
+            store: Arc::new(MockStateStore::new()),
+            control: mk_control(),
+            attempts: BTreeMap::new(),
+        };
+
+        // Request shutdown before submitting: the retry helper only observes the
+        // token while backing off, so without an up-front guard the first
+        // broadcast would still go out.
+        task.control.cancellation_token.cancel();
+
+        let result = task.submit_attempt_to_l1(envelope).await;
+        assert!(matches!(result, Err(SubmitAttemptError::Cancelled)));
+
+        // The transaction must never have been broadcast.
+        let broadcast_tx = task
+            .provider
+            .get_transaction_by_hash(expected_tx_hash)
+            .await
+            .expect("querying the transaction should succeed");
+        assert!(
+            broadcast_tx.is_none(),
+            "a cancelled submission must not broadcast the transaction"
         );
     }
 }

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -800,13 +800,6 @@ impl<
     }
 
     async fn submit_attempt_to_l1(&self, tx: TxEnvelope) -> Result<(), SubmitAttemptError> {
-        // Don't start a new broadcast once shutdown is requested. The retry helper
-        // only observes the token while backing off after a transient error, so
-        // an already-cancelled token would otherwise still send the first tx.
-        if self.control.cancellation_token.is_cancelled() {
-            return Err(SubmitAttemptError::Cancelled);
-        }
-
         // Encode the signed transaction once, consuming the envelope. This is the
         // only thing `send_tx_envelope` does with it before calling
         // `eth_sendRawTransaction`, so each retry can re-broadcast the same bytes

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -70,9 +70,9 @@ fn submission_outcome(
     match result {
         Ok(()) => Ok(()),
         Err(RetryCallbackError::Cancelled) => Err(SubmitAttemptError::Cancelled),
-        Err(RetryCallbackError::Error(error)) => Err(SubmitAttemptError::Failed(
-            eyre::Error::new(error).wrap_err("failed to submit settlement attempt to L1"),
-        )),
+        Err(RetryCallbackError::Error(error)) => {
+            Err(SubmitAttemptError::Failed(eyre::Error::new(error)))
+        }
     }
 }
 

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -13,7 +13,7 @@ use agglayer_types::{
 };
 use alloy::{
     consensus::{BlockHeader as _, EthereumTxEnvelope, TxEip4844Variant},
-    eips::BlockNumberOrTag,
+    eips::{eip2718::Encodable2718 as _, BlockNumberOrTag},
     network::{BlockResponse as _, ReceiptResponse as _},
     primitives::{Address, TxHash},
     providers::{Provider, WalletProvider},
@@ -744,10 +744,35 @@ impl<
         todo!()
     }
 
-    async fn submit_attempt_to_l1(&self, _tx: TxEnvelope) -> eyre::Result<()> {
-        // TODO: Submit attempt to L1. Use https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html#method.send_tx_envelope
-        // XREF: https://github.com/agglayer/agglayer/issues/1321
-        todo!()
+    async fn submit_attempt_to_l1(&self, tx: TxEnvelope) -> eyre::Result<()> {
+        // Encode the signed transaction once, consuming the envelope. This is the
+        // only thing `send_tx_envelope` does with it before calling
+        // `eth_sendRawTransaction`, so each retry can re-broadcast the same bytes
+        // via `send_raw_transaction` without cloning or re-encoding the envelope.
+        // Re-broadcasting is idempotent: the bytes carry the same sender, nonce, and
+        // signature, hence the same hash, so retrying cannot submit a second
+        // on-chain transaction.
+        let encoded_tx = tx.encoded_2718();
+
+        // Retry only transient network failures, mirroring `tx_hash_on_l1_for_nonce`.
+        // The returned pending-transaction handle is dropped on purpose: this helper
+        // must never wait for inclusion or settlement.
+        let _pending_tx = crate::utils::retry_alloy_callback_until_success(
+            &self.tx_config.retry_on_transient_failure,
+            &self.control.cancellation_token,
+            || self.provider.send_raw_transaction(&encoded_tx),
+        )
+        .await
+        .map_err(|error| match error {
+            RetryCallbackError::Cancelled => {
+                eyre::eyre!("cancelled while submitting settlement attempt to L1")
+            }
+            RetryCallbackError::Error(error) => {
+                eyre::Error::new(error).wrap_err("failed to submit settlement attempt to L1")
+            }
+        })?;
+
+        Ok(())
     }
 
     async fn save_settlement_job_to_db(&self) -> eyre::Result<()> {
@@ -1018,7 +1043,8 @@ mod tests {
         U256,
     };
     use alloy::{
-        network::EthereumWallet, providers::ProviderBuilder, signers::local::PrivateKeySigner,
+        network::EthereumWallet, node_bindings::Anvil, providers::ProviderBuilder,
+        rpc::types::TransactionRequest, signers::local::PrivateKeySigner,
     };
     use tokio::sync::mpsc;
 
@@ -1399,5 +1425,54 @@ mod tests {
             .to_string()
             .contains("without a recorded settlement attempt"));
         assert!(task.attempts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_attempt_to_l1_broadcasts_signed_envelope() {
+        let anvil = Anvil::new().spawn();
+        let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect_http(anvil.endpoint_url());
+
+        // Build and sign a transaction envelope through the provider's fillers so
+        // it carries a valid nonce, gas, and chain id, then hand it off as the
+        // settlement attempt to submit.
+        let tx_request = TransactionRequest::default()
+            .to(anvil.addresses()[1])
+            .value(alloy::primitives::U256::from(1));
+        let envelope = provider
+            .fill(tx_request)
+            .await
+            .expect("filling the settlement transaction should succeed")
+            .try_into_envelope()
+            .expect("a wallet-filled transaction should be a signed envelope");
+        let expected_tx_hash: TxHash = *envelope.tx_hash();
+
+        let task = SettlementTask {
+            id: mk_job_id(1),
+            job: mk_job(),
+            tx_config: Arc::new(SettlementTransactionConfig::default()),
+            provider: Arc::new(provider),
+            store: Arc::new(MockStateStore::new()),
+            control: mk_control(),
+            attempts: BTreeMap::new(),
+        };
+
+        task.submit_attempt_to_l1(envelope)
+            .await
+            .expect("submitting the settlement attempt should succeed");
+
+        // The helper does not wait for inclusion, but the node must have accepted
+        // the broadcast, so it should know the transaction by hash.
+        let broadcast_tx = task
+            .provider
+            .get_transaction_by_hash(expected_tx_hash)
+            .await
+            .expect("querying the broadcast transaction should succeed");
+        assert!(
+            broadcast_tx.is_some(),
+            "the node should know the broadcast settlement transaction"
+        );
     }
 }

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -41,6 +41,28 @@ fn required_settlement_head_number(receipt_block_number: u64, confirmations: usi
     receipt_block_number.saturating_add(confirmation_offset)
 }
 
+/// Maps the result of broadcasting a settlement attempt to the caller's result.
+///
+/// Cancellation is reported as success so that an operational shutdown leaves
+/// the already-saved attempt pending and lets the task exit cleanly, instead of
+/// the caller persisting a spurious `ClientError` for an attempt that may still
+/// be broadcast.
+///
+/// A non-transient error is still surfaced. Note that a re-broadcast whose
+/// first response was lost can return an "already known"/nonce-used error that
+/// this path reports as failure even though the transaction was accepted;
+/// recognizing those responses as success depends on the RPC error
+/// classification deferred to `SettlementServiceConfig`.
+/// XREF: https://github.com/agglayer/agglayer/issues/1321
+fn submission_outcome(result: Result<(), RetryCallbackError<TransportError>>) -> eyre::Result<()> {
+    match result {
+        Ok(()) | Err(RetryCallbackError::Cancelled) => Ok(()),
+        Err(RetryCallbackError::Error(error)) => {
+            Err(eyre::Error::new(error).wrap_err("failed to submit settlement attempt to L1"))
+        }
+    }
+}
+
 #[derive(Debug)]
 enum WaitForSettlementError {
     NotSettledYet,
@@ -757,22 +779,15 @@ impl<
         // Retry only transient network failures, mirroring `tx_hash_on_l1_for_nonce`.
         // The returned pending-transaction handle is dropped on purpose: this helper
         // must never wait for inclusion or settlement.
-        let _pending_tx = crate::utils::retry_alloy_callback_until_success(
+        let submission = crate::utils::retry_alloy_callback_until_success(
             &self.tx_config.retry_on_transient_failure,
             &self.control.cancellation_token,
             || self.provider.send_raw_transaction(&encoded_tx),
         )
         .await
-        .map_err(|error| match error {
-            RetryCallbackError::Cancelled => {
-                eyre::eyre!("cancelled while submitting settlement attempt to L1")
-            }
-            RetryCallbackError::Error(error) => {
-                eyre::Error::new(error).wrap_err("failed to submit settlement attempt to L1")
-            }
-        })?;
+        .map(drop);
 
-        Ok(())
+        submission_outcome(submission)
     }
 
     async fn save_settlement_job_to_db(&self) -> eyre::Result<()> {
@@ -1045,6 +1060,7 @@ mod tests {
     use alloy::{
         network::EthereumWallet, node_bindings::Anvil, providers::ProviderBuilder,
         rpc::types::TransactionRequest, signers::local::PrivateKeySigner,
+        transports::TransportErrorKind,
     };
     use tokio::sync::mpsc;
 
@@ -1425,6 +1441,24 @@ mod tests {
             .to_string()
             .contains("without a recorded settlement attempt"));
         assert!(task.attempts.is_empty());
+    }
+
+    #[test]
+    fn submission_outcome_reports_success() {
+        assert!(submission_outcome(Ok(())).is_ok());
+    }
+
+    #[test]
+    fn submission_outcome_treats_cancellation_as_pending() {
+        // A shutdown mid-retry must not be recorded as a client error: the
+        // already-saved attempt has to stay pending so it can resume on reload.
+        assert!(submission_outcome(Err(RetryCallbackError::Cancelled)).is_ok());
+    }
+
+    #[test]
+    fn submission_outcome_propagates_transport_error() {
+        let error = RetryCallbackError::Error(TransportErrorKind::custom_str("boom"));
+        assert!(submission_outcome(Err(error)).is_err());
     }
 
     #[tokio::test]

--- a/crates/agglayer-settlement-service/src/utils.rs
+++ b/crates/agglayer-settlement-service/src/utils.rs
@@ -25,6 +25,10 @@ pub(crate) enum RetryCallbackError<E> {
 ///
 /// Transient errors are retried using the provided policy. Permanent errors are
 /// returned immediately.
+///
+/// Cancellation is observed both before and during each callback invocation, so
+/// an already-cancelled token never starts a new callback and a pending
+/// callback (for example a stalled request) is abandoned promptly.
 pub(crate) async fn retry_callback_until_success<T, E, F, Fut, I>(
     policy: &TxRetryPolicy,
     cancellation_token: &CancellationToken,
@@ -41,7 +45,15 @@ where
     let mut retry_attempt = 0_u64;
 
     loop {
-        match callback().await {
+        // Race the callback against cancellation so a shutdown is observed even
+        // while the callback future is still pending; `biased` also returns
+        // before the callback is polled when the token is already cancelled.
+        let outcome = tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => return Err(RetryCallbackError::Cancelled),
+            outcome = callback() => outcome,
+        };
+        match outcome {
             Ok(value) => return Ok(value),
             Err(error) => {
                 if !is_transient(&error) {
@@ -135,7 +147,7 @@ mod tests {
         error::Error,
         fmt::{Display, Formatter},
         sync::{
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
             Arc, Mutex,
         },
         time::Duration,
@@ -302,6 +314,75 @@ mod tests {
         let error = handle.await.unwrap().unwrap_err();
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
         assert!(matches!(error, RetryCallbackError::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn retry_callback_until_success_returns_cancelled_before_calling_callback() {
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+        let policy = retry_policy(
+            Duration::from_millis(10),
+            1000,
+            Duration::from_millis(10),
+            Duration::ZERO,
+        );
+        let called = Arc::new(AtomicBool::new(false));
+
+        let result = retry_callback_until_success(
+            &policy,
+            &cancellation_token,
+            {
+                let called = called.clone();
+                move || {
+                    let called = called.clone();
+                    async move {
+                        called.store(true, Ordering::SeqCst);
+                        Ok::<(), TransientTestError>(())
+                    }
+                }
+            },
+            |_| true,
+        )
+        .await;
+
+        assert!(matches!(result, Err(RetryCallbackError::Cancelled)));
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "callback must not run once the token is already cancelled"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_callback_until_success_stops_when_cancelled_during_callback() {
+        let cancellation_token = CancellationToken::new();
+        let policy = retry_policy(
+            Duration::from_secs(30),
+            1000,
+            Duration::from_secs(30),
+            Duration::ZERO,
+        );
+
+        let handle = tokio::spawn({
+            let cancellation_token = cancellation_token.clone();
+            async move {
+                retry_callback_until_success(
+                    &policy,
+                    &cancellation_token,
+                    std::future::pending::<Result<(), TransientTestError>>,
+                    |_| true,
+                )
+                .await
+            }
+        });
+
+        tokio::task::yield_now().await;
+        cancellation_token.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("retry must observe cancellation during a pending callback")
+            .expect("retry task should not panic");
+        assert!(matches!(result, Err(RetryCallbackError::Cancelled)));
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
Implement SettlementTask::submit_attempt_to_l1, replacing the todo!()
stub. It broadcasts an already-signed transaction envelope to L1 and
returns as soon as the node accepts it, without waiting for inclusion
or settlement.

The envelope is encoded once (EIP-2718) and re-broadcast via
send_raw_transaction; only transient network failures are retried,
using the existing retry_on_transient_failure policy and the task
cancellation token, mirroring tx_hash_on_l1_for_nonce. Re-broadcast is
idempotent (same sender, nonce, signature, hash), so retries cannot
submit a second on-chain transaction.

Adds an Anvil-backed test that submits a signed envelope and asserts
the node knows the transaction by hash.

Closes #1321
