### PR TITLE
build(deps): bump openssl, rustls-webpki, rand for security fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
  "mockall",
  "pessimistic-proof",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.3",
  "reqwest 0.12.28",
  "rstest",
  "serde",
@@ -493,7 +493,7 @@ dependencies = [
  "pessimistic-proof",
  "pin-project",
  "prover-executor",
- "rand 0.9.2",
+ "rand 0.9.3",
  "reqwest 0.12.28",
  "reqwest 0.13.3",
  "rstest",
@@ -592,7 +592,7 @@ dependencies = [
  "derive_more 2.1.1",
  "educe",
  "eyre",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -659,7 +659,7 @@ dependencies = [
  "pessimistic-proof-test-suite",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rocksdb",
  "rstest",
  "serde",
@@ -766,7 +766,7 @@ dependencies = [
  "derive_more 2.1.1",
  "hex",
  "pessimistic-proof",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rstest",
  "serde",
  "serde_with",
@@ -893,7 +893,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1",
  "serde",
  "serde_json",
@@ -1150,7 +1150,7 @@ dependencies = [
  "alloy-signer-local",
  "k256",
  "libc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -1179,7 +1179,7 @@ dependencies = [
  "paste",
  "proptest",
  "proptest-derive",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rapidhash",
  "ruint",
  "rustc-hash 2.1.1",
@@ -1368,7 +1368,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "derive_more 2.1.1",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "strum 0.27.2",
 ]
@@ -1498,7 +1498,7 @@ dependencies = [
  "coins-bip39",
  "eth-keystore",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "zeroize",
 ]
@@ -1970,7 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1980,7 +1980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1990,7 +1990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2640,7 +2640,7 @@ dependencies = [
  "getrandom 0.2.17",
  "instant",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -2907,7 +2907,7 @@ dependencies = [
  "bolero-kani",
  "bolero-libfuzzer",
  "cfg-if",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -2930,7 +2930,7 @@ dependencies = [
  "bolero-generator",
  "lazy_static",
  "pretty-hex",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
 ]
 
@@ -3406,7 +3406,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
@@ -4507,7 +4507,7 @@ dependencies = [
  "hex",
  "hmac",
  "pbkdf2 0.11.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "scrypt",
  "serde",
  "serde_json",
@@ -4546,7 +4546,7 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4629,7 +4629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -5680,7 +5680,7 @@ dependencies = [
  "pessimistic-proof-test-suite",
  "pin-project",
  "prover-config",
- "rand 0.9.2",
+ "rand 0.9.3",
  "reqwest 0.12.28",
  "rstest",
  "serde",
@@ -5927,7 +5927,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -6756,15 +6756,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -6788,9 +6787,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -6878,7 +6877,7 @@ dependencies = [
  "glob",
  "opentelemetry 0.29.1",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
@@ -6895,7 +6894,7 @@ dependencies = [
  "futures-util",
  "opentelemetry 0.31.0",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
 ]
 
@@ -6961,7 +6960,7 @@ dependencies = [
  "p3-mds 0.2.3-succinct",
  "p3-poseidon2 0.2.3-succinct",
  "p3-symmetric 0.2.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -6977,7 +6976,7 @@ dependencies = [
  "p3-mds 0.4.3-succinct",
  "p3-poseidon2 0.4.3-succinct",
  "p3-symmetric 0.4.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc_version 0.4.1",
  "serde",
 ]
@@ -6993,7 +6992,7 @@ dependencies = [
  "p3-field 0.2.3-succinct",
  "p3-poseidon2 0.2.3-succinct",
  "p3-symmetric 0.2.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -7008,7 +7007,7 @@ dependencies = [
  "p3-field 0.4.3-succinct",
  "p3-poseidon2 0.4.3-succinct",
  "p3-symmetric 0.4.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -7104,7 +7103,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "p3-util 0.2.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -7118,7 +7117,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "p3-util 0.4.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -7222,7 +7221,7 @@ dependencies = [
  "p3-mds 0.4.3-succinct",
  "p3-poseidon2 0.4.3-succinct",
  "p3-symmetric 0.4.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc_version 0.4.1",
  "serde",
 ]
@@ -7237,7 +7236,7 @@ dependencies = [
  "p3-field 0.2.3-succinct",
  "p3-maybe-rayon 0.2.3-succinct",
  "p3-util 0.2.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tracing",
 ]
@@ -7252,7 +7251,7 @@ dependencies = [
  "p3-field 0.4.3-succinct",
  "p3-maybe-rayon 0.4.3-succinct",
  "p3-util 0.4.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tracing",
 ]
@@ -7287,7 +7286,7 @@ dependencies = [
  "p3-matrix 0.2.3-succinct",
  "p3-symmetric 0.2.3-succinct",
  "p3-util 0.2.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -7302,7 +7301,7 @@ dependencies = [
  "p3-matrix 0.4.3-succinct",
  "p3-symmetric 0.4.3-succinct",
  "p3-util 0.4.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -7349,7 +7348,7 @@ dependencies = [
  "p3-field 0.2.3-succinct",
  "p3-mds 0.2.3-succinct",
  "p3-symmetric 0.2.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -7363,7 +7362,7 @@ dependencies = [
  "p3-field 0.4.3-succinct",
  "p3-mds 0.4.3-succinct",
  "p3-symmetric 0.4.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -7525,7 +7524,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "lazy_static",
- "rand 0.8.5",
+ "rand 0.8.6",
  "static_assertions",
  "subtle",
 ]
@@ -7540,7 +7539,7 @@ dependencies = [
  "ff 0.13.1",
  "group 0.13.0",
  "lazy_static",
- "rand 0.8.5",
+ "rand 0.8.6",
  "static_assertions",
  "subtle",
 ]
@@ -7624,7 +7623,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "pessimistic-proof-core",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rs_merkle",
  "serde",
  "serde_json",
@@ -7649,7 +7648,7 @@ dependencies = [
  "arbitrary",
  "hex",
  "hex-literal",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rstest",
  "semver 1.0.27",
  "serde",
@@ -7678,7 +7677,7 @@ dependencies = [
  "lazy_static",
  "pessimistic-proof",
  "prover-executor",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "rstest",
  "serde",
@@ -8028,7 +8027,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -8074,7 +8073,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8284,7 +8283,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
@@ -8339,9 +8338,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -8351,9 +8350,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -8842,8 +8841,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.3",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -8935,7 +8934,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -8985,7 +8984,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -9006,7 +9005,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
@@ -9031,9 +9030,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -9214,7 +9213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys",
  "serde",
 ]
@@ -9699,7 +9698,7 @@ checksum = "ce348433feab7a98c2d18419c11320a63a9407a7bf360fcb1d12e98610def29d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "slop-algebra",
  "slop-alloc",
@@ -9805,7 +9804,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "num_cpus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "slop-algebra",
@@ -9906,7 +9905,7 @@ dependencies = [
  "derive-where",
  "futures",
  "num_cpus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "slop-algebra",
@@ -9995,7 +9994,7 @@ dependencies = [
  "arrayvec",
  "derive-where",
  "itertools 0.14.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "slop-algebra",
@@ -10035,7 +10034,7 @@ dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "slop-algebra",
@@ -10107,7 +10106,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
 ]
 
@@ -10160,7 +10159,7 @@ dependencies = [
  "p3-field 0.2.3-succinct",
  "p3-maybe-rayon 0.2.3-succinct",
  "p3-util 0.2.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "range-set-blaze",
  "rrs-succinct 0.1.0",
  "serde",
@@ -10288,7 +10287,7 @@ dependencies = [
  "p3-uni-stark 0.2.3-succinct",
  "p3-util 0.2.3-succinct",
  "pathdiff",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "rayon-scan",
  "serde",
@@ -10644,7 +10643,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "opentelemetry 0.23.0",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -10730,7 +10729,7 @@ dependencies = [
  "p3-symmetric 0.2.3-succinct",
  "p3-uni-stark 0.2.3-succinct",
  "p3-util 0.2.3-succinct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "sp1-core-executor 5.2.4",
@@ -10752,7 +10751,7 @@ checksum = "bfe43147fe2a5604b1c14d10f44cb7d4304127275470f676b03593a2a00da4f2"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "slop-air",
@@ -10857,7 +10856,7 @@ dependencies = [
  "p3-symmetric 0.2.3-succinct",
  "p3-util 0.2.3-succinct",
  "pathdiff",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sp1-core-machine 5.2.4",
  "sp1-derive 5.2.4",
@@ -10961,7 +10960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d741527465de17de5c3ef4f9465e77117d2a15599398f97e8fb0cf8c3e57b2f4"
 dependencies = [
  "itertools 0.14.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slop-air",
  "slop-algebra",
  "slop-basefold",
@@ -11168,7 +11167,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "lazy_static",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2 0.10.9",
  "slop-algebra",
  "sp1-lib 6.2.2",
@@ -11330,7 +11329,7 @@ dependencies = [
  "crunchy",
  "lazy_static",
  "num-bigint 0.4.6",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "sp1-lib 5.2.4",
 ]
@@ -11347,7 +11346,7 @@ dependencies = [
  "crunchy",
  "lazy_static",
  "num-bigint 0.4.6",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
 ]
 
@@ -12028,7 +12027,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -12279,7 +12278,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
@@ -12366,7 +12365,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "web-time",
 ]
@@ -13463,7 +13462,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "pasta_curves 0.5.1",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sha2 0.10.9",
  "sha3",


### PR DESCRIPTION
Resolve 11 open Dependabot alerts with in-range Cargo.lock bumps:

- openssl 0.10.76 -> 0.10.80 (8 alerts, 5 High)
- rustls-webpki 0.103.12 -> 0.103.13 (High, GHSA-82j2-j2ch-gfr8)
- rand 0.8.5 -> 0.8.6 and 0.9.2 -> 0.9.3 (GHSA-cq8v-f236-94qc)

Lockfile-only change. Verified with cargo check --workspace --tests
--all-features and cargo nextest run --workspace (745 passed).

Remaining alerts (lru, git2, rustls-webpki 0.101.7) are pinned by the
SP1 toolchain and require an upstream bump; p3-symmetric has no
upstream patch yet.
