### PR TITLE
feat(storage): store certificate settlement job ids

### DIFF
--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -28,7 +28,8 @@ use agglayer_storage::{
 };
 use agglayer_types::{
     Certificate, CertificateHeader, CertificateId, CertificateIndex, CertificateStatus, Digest,
-    EpochNumber, ExecutionMode, Height, LocalNetworkStateData, NetworkId, Proof, SettlementTxHash,
+    EpochNumber, ExecutionMode, Height, LocalNetworkStateData, NetworkId, Proof, SettlementJobId,
+    SettlementTxHash,
 };
 use arc_swap::ArcSwap;
 use futures_util::poll;
@@ -144,6 +145,14 @@ impl StateReader for DummyPendingStore {
             .get(certificate_id)
             .cloned())
     }
+
+    fn get_certificate_settlement_job_id(
+        &self,
+        _certificate_id: &CertificateId,
+    ) -> Result<Option<SettlementJobId>, agglayer_storage::error::Error> {
+        unimplemented!()
+    }
+
     fn get_current_settled_height(
         &self,
     ) -> Result<Vec<(NetworkId, SettledCertificate)>, agglayer_storage::error::Error> {
@@ -322,6 +331,14 @@ impl StateWriter for DummyPendingStore {
         _certificate_id: &CertificateId,
     ) -> Result<(), agglayer_storage::error::Error> {
         todo!()
+    }
+
+    fn insert_certificate_settlement_job_id(
+        &self,
+        _certificate_id: &CertificateId,
+        _settlement_job_id: &SettlementJobId,
+    ) -> Result<(), agglayer_storage::error::Error> {
+        unimplemented!()
     }
 
     fn assign_certificate_to_epoch(

--- a/crates/agglayer-storage/src/columns/certificate_settlement_job/mod.rs
+++ b/crates/agglayer-storage/src/columns/certificate_settlement_job/mod.rs
@@ -1,0 +1,19 @@
+use agglayer_types::{CertificateId, SettlementJobId};
+
+use crate::{columns::CERTIFICATE_SETTLEMENT_JOB_CF, schema::ColumnSchema};
+
+/// Column family mapping certificates to their settlement jobs.
+///
+/// ## Column definition
+///
+/// | key             | value             |
+/// | --              | --                |
+/// | `CertificateId` | `SettlementJobId` |
+pub(crate) struct CertificateSettlementJobColumn;
+
+impl ColumnSchema for CertificateSettlementJobColumn {
+    type Key = CertificateId;
+    type Value = SettlementJobId;
+
+    const COLUMN_FAMILY_NAME: &'static str = CERTIFICATE_SETTLEMENT_JOB_CF;
+}

--- a/crates/agglayer-storage/src/columns/mod.rs
+++ b/crates/agglayer-storage/src/columns/mod.rs
@@ -9,6 +9,7 @@ pub const BALANCE_TREE_PER_NETWORK_CF: &str = "balance_tree_per_network_cf";
 pub const LOCAL_EXIT_TREE_PER_NETWORK_CF: &str = "local_exit_tree_per_network_cf";
 pub const NETWORK_INFO_CF: &str = "network_info_cf";
 pub const DISABLED_NETWORKS_CF: &str = "disabled_networks_cf";
+pub const CERTIFICATE_SETTLEMENT_JOB_CF: &str = "certificate_settlement_job_cf";
 
 // Metadata CFs
 pub const CERTIFICATE_HEADER_CF: &str = "certificate_header_cf";
@@ -76,6 +77,7 @@ pub const DEBUG_CERTIFICATES_PROTO_CF: &str = "debug_certificates_proto_cf";
 // State
 pub(crate) mod balance_tree_per_network;
 pub(crate) mod certificate_per_network;
+pub(crate) mod certificate_settlement_job;
 pub(crate) mod disabled_networks;
 pub(crate) mod local_exit_tree_per_network;
 pub(crate) mod network_info;

--- a/crates/agglayer-storage/src/stores/interfaces/reader.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/reader.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use agglayer_types::{
     Certificate, CertificateHeader, CertificateId, CertificateIndex, EpochNumber, Height,
-    LocalNetworkStateData, NetworkId, Proof,
+    LocalNetworkStateData, NetworkId, Proof, SettlementJobId,
 };
 
 use crate::{
@@ -88,6 +88,11 @@ pub trait StateReader: Send + Sync {
         &self,
         certificate_id: &CertificateId,
     ) -> Result<Option<CertificateHeader>, Error>;
+
+    fn get_certificate_settlement_job_id(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<SettlementJobId>, Error>;
 
     fn get_certificate_header_by_cursor(
         &self,

--- a/crates/agglayer-storage/src/stores/interfaces/writer.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/writer.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use agglayer_types::{
     primitives::Digest, Certificate, CertificateId, CertificateIndex, CertificateStatus,
-    EpochNumber, ExecutionMode, Height, LocalNetworkStateData, NetworkId, Proof, SettlementTxHash,
+    EpochNumber, ExecutionMode, Height, LocalNetworkStateData, NetworkId, Proof, SettlementJobId,
+    SettlementTxHash,
 };
 
 use crate::{error::Error, stores::PerEpochReader};
@@ -68,6 +69,17 @@ pub trait StateWriter: Send + Sync {
     ) -> Result<(), Error>;
 
     fn remove_settlement_tx_hash(&self, certificate_id: &CertificateId) -> Result<(), Error>;
+
+    /// Inserts the settlement job id associated with `certificate_id`.
+    ///
+    /// This is an insert-only operation and must fail if `certificate_id`
+    /// already has a stored settlement job id. The settlement job must already
+    /// exist.
+    fn insert_certificate_settlement_job_id(
+        &self,
+        certificate_id: &CertificateId,
+        settlement_job_id: &SettlementJobId,
+    ) -> Result<(), Error>;
 
     fn insert_certificate_header(
         &self,

--- a/crates/agglayer-storage/src/stores/state/cf_definitions.rs
+++ b/crates/agglayer-storage/src/stores/state/cf_definitions.rs
@@ -3,6 +3,7 @@ use crate::{
         balance_tree_per_network::BalanceTreePerNetworkColumn,
         certificate_header::CertificateHeaderColumn,
         certificate_per_network::CertificatePerNetworkColumn,
+        certificate_settlement_job::CertificateSettlementJobColumn,
         disabled_networks::DisabledNetworksColumn,
         latest_settled_certificate_per_network::LatestSettledCertificatePerNetworkColumn,
         local_exit_tree_per_network::LocalExitTreePerNetworkColumn, metadata::MetadataColumn,
@@ -20,8 +21,8 @@ use crate::{
 /// declaration so that legacy production snapshots — which still have
 /// just these eight CFs — pass the migration framework's schema gate
 /// when opened by the current binary. The remaining CFs declared in
-/// [`STATE_DB`] are brought in by an `ensure_cfs(STATE_DB)` step that
-/// creates whatever is missing and is a no-op when everything is already
+/// the later schema versions are brought in by recorded `ensure_cfs` steps
+/// that create whatever is missing and are no-ops when everything is already
 /// present.
 pub const STATE_DB_V0: &[ColumnDescriptor] = &[
     ColumnDescriptor::new::<CertificateHeaderColumn>(),
@@ -33,6 +34,20 @@ pub const STATE_DB_V0: &[ColumnDescriptor] = &[
     ColumnDescriptor::new::<NullifierTreePerNetworkColumn>(),
     ColumnDescriptor::new::<NetworkInfoColumn>(),
 ];
+
+/// CFs added by the first catch-up migration.
+pub const STATE_DB_V1_ADDED_CFS: &[ColumnDescriptor] = &[
+    ColumnDescriptor::new::<DisabledNetworksColumn>(),
+    ColumnDescriptor::new::<SettlementJobsColumn>(),
+    ColumnDescriptor::new::<SettlementJobResultsColumn>(),
+    ColumnDescriptor::new::<SettlementAttemptsColumn>(),
+    ColumnDescriptor::new::<SettlementAttemptResultsColumn>(),
+    ColumnDescriptor::new::<SettlementAttemptPerWalletColumn>(),
+];
+
+/// CFs added by the second catch-up migration.
+pub const STATE_DB_V2_ADDED_CFS: &[ColumnDescriptor] =
+    &[ColumnDescriptor::new::<CertificateSettlementJobColumn>()];
 
 /// Definitions for the column families in the state storage. The
 /// authoritative target schema: `init_db` ensures every CF listed here
@@ -48,6 +63,7 @@ pub const STATE_DB: &[ColumnDescriptor] = &[
     ColumnDescriptor::new::<NullifierTreePerNetworkColumn>(),
     ColumnDescriptor::new::<NetworkInfoColumn>(),
     ColumnDescriptor::new::<DisabledNetworksColumn>(),
+    ColumnDescriptor::new::<CertificateSettlementJobColumn>(),
     // Settlement related CFs
     ColumnDescriptor::new::<SettlementJobsColumn>(),
     ColumnDescriptor::new::<SettlementJobResultsColumn>(),

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -26,12 +26,14 @@ use crate::{
         balance_tree_per_network::BalanceTreePerNetworkColumn,
         certificate_header::CertificateHeaderColumn,
         certificate_per_network::{self, CertificatePerNetworkColumn},
+        certificate_settlement_job::CertificateSettlementJobColumn,
         latest_settled_certificate_per_network::{
             LatestSettledCertificatePerNetworkColumn, SettledCertificate,
         },
         local_exit_tree_per_network as LET,
         metadata::MetadataColumn,
         nullifier_tree_per_network::NullifierTreePerNetworkColumn,
+        settlement_jobs::SettlementJobsColumn,
     },
     error::Error,
     schema::ColumnSchema,
@@ -60,12 +62,12 @@ impl StateStore {
         // and the settlement family. Legacy production snapshots still
         // have only those CFs; running the current binary against them
         // would fail the migration framework's schema gate without this
-        // path. `ensure_cfs` is idempotent: passing the full `STATE_DB`
-        // list creates whatever is missing on disk and is a no-op when
-        // every CF is already present, so legacy V0 DBs converge to the
-        // current schema and existing post-V0 DBs are unaffected.
+        // path. Each `ensure_cfs` call is a recorded migration step, so new
+        // catch-up CFs must be added in a new step instead of changing an
+        // already-recorded target list.
         DB::builder(path, cf_definitions::STATE_DB_V0)?
-            .ensure_cfs(cf_definitions::STATE_DB)?
+            .ensure_cfs(cf_definitions::STATE_DB_V1_ADDED_CFS)?
+            .ensure_cfs(cf_definitions::STATE_DB_V2_ADDED_CFS)?
             .finalize(cf_definitions::STATE_DB)
     }
 
@@ -206,6 +208,36 @@ impl StateWriter for StateStore {
         }
 
         Ok(())
+    }
+
+    fn insert_certificate_settlement_job_id(
+        &self,
+        certificate_id: &CertificateId,
+        settlement_job_id: &SettlementJobId,
+    ) -> Result<(), Error> {
+        if self
+            .db
+            .get::<CertificateSettlementJobColumn>(certificate_id)?
+            .is_some()
+        {
+            return Err(Error::UnprocessedAction(format!(
+                "Certificate {certificate_id} already has a settlement job id"
+            )));
+        }
+
+        if self
+            .db
+            .get::<SettlementJobsColumn>(settlement_job_id)?
+            .is_none()
+        {
+            return Err(Error::UnprocessedAction(format!(
+                "Settlement job does not exist for id {settlement_job_id}"
+            )));
+        }
+
+        Ok(self
+            .db
+            .put::<CertificateSettlementJobColumn>(certificate_id, settlement_job_id)?)
     }
 
     fn assign_certificate_to_epoch(
@@ -592,6 +624,15 @@ impl StateReader for StateStore {
         certificate_id: &CertificateId,
     ) -> Result<Option<CertificateHeader>, Error> {
         Ok(self.db.get::<CertificateHeaderColumn>(certificate_id)?)
+    }
+
+    fn get_certificate_settlement_job_id(
+        &self,
+        certificate_id: &CertificateId,
+    ) -> Result<Option<SettlementJobId>, Error> {
+        Ok(self
+            .db
+            .get::<CertificateSettlementJobColumn>(certificate_id)?)
     }
 
     fn get_certificate_header_by_cursor(

--- a/crates/agglayer-storage/src/stores/state/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/tests.rs
@@ -37,6 +37,7 @@ fn init_db_adds_legacy_missing_cfs() {
     use std::collections::BTreeSet;
 
     use crate::columns::{
+        certificate_settlement_job::CertificateSettlementJobColumn,
         disabled_networks::DisabledNetworksColumn,
         settlement_attempt_per_wallet::SettlementAttemptPerWalletColumn,
         settlement_attempt_results::SettlementAttemptResultsColumn,
@@ -67,6 +68,7 @@ fn init_db_adds_legacy_missing_cfs() {
 
     for expected in [
         DisabledNetworksColumn::COLUMN_FAMILY_NAME,
+        CertificateSettlementJobColumn::COLUMN_FAMILY_NAME,
         SettlementJobsColumn::COLUMN_FAMILY_NAME,
         SettlementJobResultsColumn::COLUMN_FAMILY_NAME,
         SettlementAttemptsColumn::COLUMN_FAMILY_NAME,
@@ -78,6 +80,41 @@ fn init_db_adds_legacy_missing_cfs() {
             "expected legacy-add CF {expected:?} to be present after init_db; got {post_cfs:?}"
         );
     }
+    drop(db);
+}
+
+#[test]
+fn init_db_adds_certificate_settlement_job_cf_to_v1_schema() {
+    use std::collections::BTreeSet;
+
+    use crate::columns::certificate_settlement_job::CertificateSettlementJobColumn;
+
+    let tmp = TempDBDir::new();
+    {
+        let previous_schema = DB::builder(tmp.path.as_path(), cf_definitions::STATE_DB_V0)
+            .expect("V0 schema initialization should succeed")
+            .ensure_cfs(cf_definitions::STATE_DB_V1_ADDED_CFS)
+            .expect("V1 schema migration should succeed")
+            .finalize(cf_definitions::STATE_DB)
+            .expect("V1 schema finalization should succeed");
+        drop(previous_schema);
+    }
+
+    let db = StateStore::init_db(tmp.path.as_path())
+        .expect("init_db should ensure the certificate settlement job CF is added");
+
+    let post_cfs: BTreeSet<&str> =
+        rocksdb::DB::list_cf(&rocksdb::Options::default(), tmp.path.as_path())
+            .expect("list_cf should succeed after init_db")
+            .into_iter()
+            .map(|s| Box::leak(s.into_boxed_str()) as &str)
+            .collect();
+
+    assert!(
+        post_cfs.contains(CertificateSettlementJobColumn::COLUMN_FAMILY_NAME),
+        "expected CF {:?} to be present after init_db; got {post_cfs:?}",
+        CertificateSettlementJobColumn::COLUMN_FAMILY_NAME
+    );
     drop(db);
 }
 

--- a/crates/agglayer-storage/src/stores/state/tests/settlement.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/settlement.rs
@@ -4,20 +4,24 @@ use std::{
 };
 
 use agglayer_types::{
-    Address, ClientError, ClientErrorType, Digest, Nonce, SettlementAttempt,
+    Address, CertificateId, ClientError, ClientErrorType, Digest, Nonce, SettlementAttempt,
     SettlementAttemptResult, SettlementJob, SettlementJobId, SettlementTxHash, U256,
 };
 
 use crate::{
     backup::BackupClient,
     columns::{
+        certificate_settlement_job::CertificateSettlementJobColumn,
         settlement_attempt_per_wallet::SettlementAttemptPerWalletColumn,
         settlement_attempt_results::SettlementAttemptResultsColumn,
         settlement_attempts::SettlementAttemptsColumn,
         settlement_job_results::SettlementJobResultsColumn, settlement_jobs::SettlementJobsColumn,
     },
     error::Error,
-    stores::{state::StateStore, SettlementReader as _, SettlementWriter as _},
+    stores::{
+        state::StateStore, SettlementReader as _, SettlementWriter as _, StateReader as _,
+        StateWriter as _,
+    },
     tests::TempDBDir,
     types::{
         generated::agglayer::storage::v0,
@@ -32,6 +36,10 @@ use crate::{
 
 fn mk_job_id(seed: u128) -> SettlementJobId {
     SettlementJobId::from(seed)
+}
+
+fn mk_certificate_id(seed: u8) -> CertificateId {
+    CertificateId::new(Digest::from([seed; 32]))
 }
 
 fn mk_settlement_job(seed: u8) -> SettlementJob {
@@ -82,6 +90,77 @@ fn insert_settlement_job_duplicate_fails() {
         db.get::<SettlementJobsColumn>(&job_id)
             .expect("Unable to read stored value"),
         Some((&first).into())
+    );
+}
+
+#[test]
+fn get_certificate_settlement_job_id_returns_none_when_missing() {
+    let (_tmp, _db, store) = setup_store();
+
+    assert_eq!(
+        store
+            .get_certificate_settlement_job_id(&mk_certificate_id(1))
+            .expect("read must succeed"),
+        None
+    );
+}
+
+#[test]
+fn insert_certificate_settlement_job_id_requires_existing_job() {
+    let (_tmp, _db, store) = setup_store();
+    let certificate_id = mk_certificate_id(2);
+    let job_id = mk_job_id(200);
+
+    let res = store.insert_certificate_settlement_job_id(&certificate_id, &job_id);
+
+    assert!(matches!(res, Err(Error::UnprocessedAction(_))));
+}
+
+#[test]
+fn insert_certificate_settlement_job_id_returns_value_after_insert() {
+    let (_tmp, _db, store) = setup_store();
+    let certificate_id = mk_certificate_id(3);
+    let job_id = mk_job_id(300);
+
+    store
+        .insert_settlement_job(&job_id, &mk_settlement_job(3))
+        .expect("job insert must succeed");
+    store
+        .insert_certificate_settlement_job_id(&certificate_id, &job_id)
+        .expect("mapping insert must succeed");
+
+    assert_eq!(
+        store
+            .get_certificate_settlement_job_id(&certificate_id)
+            .expect("read must succeed"),
+        Some(job_id)
+    );
+}
+
+#[test]
+fn insert_certificate_settlement_job_id_duplicate_fails() {
+    let (_tmp, db, store) = setup_store();
+    let certificate_id = mk_certificate_id(4);
+    let first_job_id = mk_job_id(400);
+    let second_job_id = mk_job_id(401);
+
+    store
+        .insert_settlement_job(&first_job_id, &mk_settlement_job(4))
+        .expect("first job insert must succeed");
+    store
+        .insert_settlement_job(&second_job_id, &mk_settlement_job(5))
+        .expect("second job insert must succeed");
+    store
+        .insert_certificate_settlement_job_id(&certificate_id, &first_job_id)
+        .expect("first mapping insert must succeed");
+
+    let res = store.insert_certificate_settlement_job_id(&certificate_id, &second_job_id);
+
+    assert!(matches!(res, Err(Error::UnprocessedAction(_))));
+    assert_eq!(
+        db.get::<CertificateSettlementJobColumn>(&certificate_id)
+            .expect("Unable to read stored value"),
+        Some(first_job_id)
     );
 }
 

--- a/crates/agglayer-storage/src/tests/mocks/state_store.rs
+++ b/crates/agglayer-storage/src/tests/mocks/state_store.rs
@@ -48,6 +48,12 @@ mock! {
             certificate_id: &CertificateId,
         ) -> Result<(), Error>;
 
+        fn insert_certificate_settlement_job_id(
+            &self,
+            certificate_id: &CertificateId,
+            settlement_job_id: &SettlementJobId,
+        ) -> Result<(), Error>;
+
         fn assign_certificate_to_epoch(
             &self,
             certificate_id: &CertificateId,
@@ -105,6 +111,11 @@ mock! {
             &self,
             certificate_id: &CertificateId,
         ) -> Result<Option<CertificateHeader>, Error>;
+
+        fn get_certificate_settlement_job_id(
+            &self,
+            certificate_id: &CertificateId,
+        ) -> Result<Option<SettlementJobId>, Error>;
 
         fn get_certificate_header_by_cursor(
             &self,


### PR DESCRIPTION
Adds certificate ID to settlement job ID storage so certificate tasks can resolve settlement jobs directly.

The state store now has a certificate_settlement_job_cf column family with required StateReader and StateWriter helpers, insert-only semantics, and migration coverage for existing DBs. Test doubles implement the required methods for unit tests.

Fixes #1430