### PR TITLE
feat(settlement): record certificate job ids before jobs

### DIFF
--- a/crates/agglayer-settlement-service/src/settlement_service.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 use agglayer_config::settlement_service::{SettlementServiceConfig, SettlementTransactionConfig};
-use agglayer_storage::stores::{SettlementReader, SettlementWriter};
-use agglayer_types::{SettlementJob, SettlementJobId, SettlementJobResult};
+use agglayer_storage::stores::{SettlementReader, SettlementWriter, StateReader, StateWriter};
+use agglayer_types::{CertificateId, SettlementJob, SettlementJobId, SettlementJobResult};
 use alloy::providers::{Provider, WalletProvider};
 use educe::Educe;
 use eyre::Context as _;
@@ -52,7 +52,7 @@ pub enum RetrievedSettlementResult {
 
 impl<
         L1Provider: Provider + WalletProvider + 'static,
-        SettlementStore: SettlementReader + SettlementWriter + Send + Sync + 'static,
+        SettlementStore: SettlementReader + SettlementWriter + StateReader + StateWriter + Send + Sync + 'static,
     > SettlementService<L1Provider, SettlementStore>
 {
     pub async fn start(
@@ -116,6 +116,7 @@ impl<
     #[tracing::instrument(skip(self))]
     pub async fn request_new_settlement(
         &self,
+        certificate_id: Option<CertificateId>,
         job: SettlementJob,
     ) -> eyre::Result<SettlementJobWatcher> {
         let (admin_sender, admin_receiver) = mpsc::channel(ADMIN_CHANNEL_BUFFER_SIZE);
@@ -123,6 +124,7 @@ impl<
         let (task_control_handle, task_control) =
             TaskControlHandle::new(&self.cancellation_token, admin_sender, admin_receiver);
         let (job_id, mut task) = SettlementTask::create(
+            certificate_id,
             job,
             self.tx_config.clone(),
             self.provider.clone(),
@@ -209,11 +211,15 @@ impl<
     }
 }
 
-pub struct RequestNewSettlement(pub SettlementJob);
+#[derive(Debug)]
+pub struct RequestNewSettlement {
+    pub certificate_id: Option<CertificateId>,
+    pub job: SettlementJob,
+}
 
 impl<
         L1Provider: Provider + WalletProvider + 'static,
-        SettlementStore: SettlementReader + SettlementWriter + Send + Sync + 'static,
+        SettlementStore: SettlementReader + SettlementWriter + StateReader + StateWriter + Send + Sync + 'static,
     > tower::Service<RequestNewSettlement> for SettlementService<L1Provider, SettlementStore>
 {
     type Response = SettlementJobWatcher;
@@ -229,7 +235,10 @@ impl<
 
     fn call(&mut self, req: RequestNewSettlement) -> Self::Future {
         let this = self.clone();
-        Box::pin(async move { this.request_new_settlement(req.0).await })
+        Box::pin(async move {
+            this.request_new_settlement(req.certificate_id, req.job)
+                .await
+        })
     }
 }
 
@@ -237,7 +246,7 @@ pub struct RetrieveSettlementResult(pub SettlementJobId);
 
 impl<
         L1Provider: Provider + WalletProvider + 'static,
-        SettlementStore: SettlementReader + SettlementWriter + Send + Sync + 'static,
+        SettlementStore: SettlementReader + SettlementWriter + StateReader + StateWriter + Send + Sync + 'static,
     > tower::Service<RetrieveSettlementResult> for SettlementService<L1Provider, SettlementStore>
 {
     type Response = RetrievedSettlementResult;
@@ -264,7 +273,7 @@ pub enum AdminCommand {
 
 impl<
         L1Provider: Provider + WalletProvider + 'static,
-        SettlementStore: SettlementReader + SettlementWriter + Send + Sync + 'static,
+        SettlementStore: SettlementReader + SettlementWriter + StateReader + StateWriter + Send + Sync + 'static,
     > tower::Service<AdminCommand> for SettlementService<L1Provider, SettlementStore>
 {
     type Response = ();
@@ -293,12 +302,13 @@ impl<
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use agglayer_storage::tests::mocks::MockStateStore;
     use agglayer_types::{
-        ContractCallOutcome, ContractCallResult, Digest, Nonce, SettlementAttemptNumber,
-        SettlementJobId, SettlementJobResult, SettlementTxHash, B256,
+        CertificateId, ContractCallOutcome, ContractCallResult, Digest, Nonce,
+        SettlementAttemptNumber, SettlementJob, SettlementJobId, SettlementJobResult,
+        SettlementTxHash, B256, U256,
     };
     use alloy::{
         network::EthereumWallet, providers::ProviderBuilder, signers::local::PrivateKeySigner,
@@ -321,12 +331,19 @@ mod tests {
     async fn mk_service(
         store: Arc<MockStateStore>,
     ) -> SettlementService<impl Provider + WalletProvider + 'static, MockStateStore> {
+        mk_service_with_token(store, CancellationToken::new()).await
+    }
+
+    async fn mk_service_with_token(
+        store: Arc<MockStateStore>,
+        cancellation_token: CancellationToken,
+    ) -> SettlementService<impl Provider + WalletProvider + 'static, MockStateStore> {
         SettlementService::start(
             SettlementServiceConfig::default(),
             Arc::new(SettlementTransactionConfig::default()),
             Arc::new(mk_provider()),
             store,
-            CancellationToken::new(),
+            cancellation_token,
         )
         .await
         .expect("settlement service should start")
@@ -334,6 +351,15 @@ mod tests {
 
     fn mk_job_id(seed: u128) -> SettlementJobId {
         SettlementJobId::from(ulid::Ulid::from(seed))
+    }
+
+    fn mk_job(seed: u8) -> SettlementJob {
+        SettlementJob {
+            contract_address: agglayer_types::Address::from([seed; 20]),
+            calldata: vec![seed, seed.wrapping_add(1)].into(),
+            eth_value: U256::from(seed),
+            gas_limit: seed as u128 + 100_000,
+        }
     }
 
     fn mk_result(seed: u8, outcome: ContractCallOutcome) -> SettlementJobResult {
@@ -421,5 +447,58 @@ mod tests {
         let error = result.err().expect("result should be an error");
 
         assert!(error.to_string().contains("No settlement job found for id"));
+    }
+
+    #[tokio::test]
+    async fn request_new_settlement_records_certificate_link_before_job() {
+        let mut store = MockStateStore::new();
+        let certificate_id = CertificateId::new(Digest::from([7; 32]));
+        let job = mk_job(7);
+        let expected_job = job.clone();
+        let recorded_job_id = Arc::new(Mutex::new(None));
+        let ordering = Arc::new(Mutex::new(Vec::new()));
+
+        store
+            .expect_insert_certificate_settlement_job_id()
+            .once()
+            .withf(move |recorded_certificate_id, _| recorded_certificate_id == &certificate_id)
+            .return_once({
+                let ordering = ordering.clone();
+                let recorded_job_id = recorded_job_id.clone();
+                move |_, settlement_job_id| {
+                    ordering.lock().unwrap().push("write_link");
+                    *recorded_job_id.lock().unwrap() = Some(*settlement_job_id);
+                    Ok(())
+                }
+            });
+
+        store
+            .expect_insert_settlement_job()
+            .once()
+            .withf(move |_, recorded_job| recorded_job == &expected_job)
+            .return_once({
+                let ordering = ordering.clone();
+                let recorded_job_id = recorded_job_id.clone();
+                move |settlement_job_id, _| {
+                    ordering.lock().unwrap().push("write_job");
+                    assert_eq!(*recorded_job_id.lock().unwrap(), Some(*settlement_job_id));
+                    Ok(())
+                }
+            });
+
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+        let service = mk_service_with_token(Arc::new(store), cancellation_token).await;
+
+        let watcher = service
+            .request_new_settlement(Some(certificate_id), job)
+            .await
+            .expect("settlement request should be accepted");
+
+        assert_eq!(*recorded_job_id.lock().unwrap(), Some(watcher.job_id()));
+        assert_eq!(
+            ordering.lock().unwrap().as_slice(),
+            ["write_link", "write_job"]
+        );
     }
 }

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -321,7 +321,7 @@ impl<
         store: Arc<SettlementStore>,
         control: TaskControl,
     ) -> eyre::Result<(SettlementJobId, Self)> {
-        let id = Self::settlement_job_id_for(store.as_ref(), certificate_id).await?;
+        let id = Self::reserve_settlement_job_id(store.as_ref(), certificate_id).await?;
         let this = Self {
             id,
             job,
@@ -335,7 +335,7 @@ impl<
         Ok((id, this))
     }
 
-    async fn settlement_job_id_for(
+    async fn reserve_settlement_job_id(
         store: &SettlementStore,
         certificate_id: Option<CertificateId>,
     ) -> eyre::Result<SettlementJobId> {

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -6,10 +6,10 @@ use std::{
 };
 
 use agglayer_config::settlement_service::{SettlementPolicy, SettlementTransactionConfig};
-use agglayer_storage::stores::{SettlementReader, SettlementWriter};
+use agglayer_storage::stores::{SettlementReader, SettlementWriter, StateReader, StateWriter};
 use agglayer_types::{
-    ClientError, ClientErrorType, ContractCallOutcome, ContractCallResult, Digest, Nonce,
-    SettlementAttempt, SettlementAttemptNumber, SettlementAttemptResult, SettlementJob,
+    CertificateId, ClientError, ClientErrorType, ContractCallOutcome, ContractCallResult, Digest,
+    Nonce, SettlementAttempt, SettlementAttemptNumber, SettlementAttemptResult, SettlementJob,
     SettlementJobId, SettlementJobResult, SettlementTxHash,
 };
 use alloy::{
@@ -310,27 +310,18 @@ static ID_GENERATOR: OnceLock<std::sync::Mutex<ulid::Generator>> = OnceLock::new
 
 impl<
         L1Provider: Provider + WalletProvider + 'static,
-        SettlementStore: SettlementReader + SettlementWriter,
+        SettlementStore: SettlementReader + SettlementWriter + StateReader + StateWriter,
     > SettlementTask<L1Provider, SettlementStore>
 {
     pub async fn create(
+        certificate_id: Option<CertificateId>,
         job: SettlementJob,
         tx_config: Arc<SettlementTransactionConfig>,
         provider: Arc<L1Provider>,
         store: Arc<SettlementStore>,
         control: TaskControl,
     ) -> eyre::Result<(SettlementJobId, Self)> {
-        let id = loop {
-            if let Ok(id) = ID_GENERATOR
-                .get_or_init(|| std::sync::Mutex::new(ulid::Generator::new()))
-                .lock()
-                .unwrap()
-                .generate()
-            {
-                break SettlementJobId::from(id);
-            }
-            tokio::time::sleep(std::time::Duration::from_micros(100)).await;
-        };
+        let id = Self::settlement_job_id_for(store.as_ref(), certificate_id).await?;
         let this = Self {
             id,
             job,
@@ -342,6 +333,41 @@ impl<
         };
         this.save_settlement_job_to_db().await?;
         Ok((id, this))
+    }
+
+    async fn settlement_job_id_for(
+        store: &SettlementStore,
+        certificate_id: Option<CertificateId>,
+    ) -> eyre::Result<SettlementJobId> {
+        let Some(certificate_id) = certificate_id else {
+            return Ok(Self::generate_settlement_job_id().await);
+        };
+
+        let settlement_job_id = Self::generate_settlement_job_id().await;
+        store
+            .insert_certificate_settlement_job_id(&certificate_id, &settlement_job_id)
+            .wrap_err_with(|| {
+                format!(
+                    "Failed to write settlement job id {settlement_job_id} for certificate \
+                     {certificate_id}"
+                )
+            })?;
+
+        Ok(settlement_job_id)
+    }
+
+    async fn generate_settlement_job_id() -> SettlementJobId {
+        loop {
+            if let Ok(id) = ID_GENERATOR
+                .get_or_init(|| std::sync::Mutex::new(ulid::Generator::new()))
+                .lock()
+                .unwrap()
+                .generate()
+            {
+                return SettlementJobId::from(id);
+            }
+            tokio::time::sleep(std::time::Duration::from_micros(100)).await;
+        }
     }
 
     pub async fn load(
@@ -1392,14 +1418,14 @@ mod tests {
     use std::{
         collections::BTreeMap,
         panic::{catch_unwind, AssertUnwindSafe},
-        sync::Arc,
+        sync::{Arc, Mutex},
     };
 
     use agglayer_config::Multiplier;
     use agglayer_storage::{error::Error, tests::mocks::MockStateStore};
     use agglayer_types::{
-        ClientError, ClientErrorType, ContractCallOutcome, Digest, SettlementAttemptResult, B256,
-        U256,
+        CertificateId, ClientError, ClientErrorType, ContractCallOutcome, Digest,
+        SettlementAttemptResult, B256, U256,
     };
     use alloy::{
         consensus::{Signed, TxEip1559},
@@ -1618,6 +1644,133 @@ mod tests {
         task.save_settlement_job_to_db()
             .await
             .expect("settlement job should be saved");
+    }
+
+    #[tokio::test]
+    async fn create_generates_settlement_job_id() {
+        let mut store = MockStateStore::new();
+        let job = mk_job();
+        let expected_job = job.clone();
+        let recorded_job_id = Arc::new(Mutex::new(None));
+        let recorded_job_id_for_store = recorded_job_id.clone();
+
+        store
+            .expect_insert_settlement_job()
+            .once()
+            .withf(move |_, recorded_job| recorded_job == &expected_job)
+            .return_once(move |recorded_job_id, _| {
+                *recorded_job_id_for_store.lock().unwrap() = Some(*recorded_job_id);
+                Ok(())
+            });
+
+        let (job_id, task) = SettlementTask::create(
+            None,
+            job,
+            Arc::new(SettlementTransactionConfig::default()),
+            Arc::new(mk_provider()),
+            Arc::new(store),
+            mk_control(),
+        )
+        .await
+        .expect("settlement task should be created");
+
+        assert_eq!(task.id, job_id);
+        assert_eq!(*recorded_job_id.lock().unwrap(), Some(job_id));
+    }
+
+    #[tokio::test]
+    async fn create_records_certificate_link_before_settlement_job() {
+        let mut store = MockStateStore::new();
+        let certificate_id = CertificateId::new(Digest::from([7; 32]));
+        let job = mk_job();
+        let expected_job = job.clone();
+        let recorded_job_id = Arc::new(Mutex::new(None));
+        let ordering = Arc::new(Mutex::new(Vec::new()));
+
+        store
+            .expect_insert_certificate_settlement_job_id()
+            .once()
+            .withf(move |recorded_certificate_id, _| recorded_certificate_id == &certificate_id)
+            .return_once({
+                let ordering = ordering.clone();
+                let recorded_job_id = recorded_job_id.clone();
+                move |_, settlement_job_id| {
+                    ordering.lock().unwrap().push("write_link");
+                    *recorded_job_id.lock().unwrap() = Some(*settlement_job_id);
+                    Ok(())
+                }
+            });
+
+        store
+            .expect_insert_settlement_job()
+            .once()
+            .withf(move |_, recorded_job| recorded_job == &expected_job)
+            .return_once({
+                let ordering = ordering.clone();
+                let recorded_job_id = recorded_job_id.clone();
+                move |settlement_job_id, _| {
+                    ordering.lock().unwrap().push("write_job");
+                    assert_eq!(*recorded_job_id.lock().unwrap(), Some(*settlement_job_id));
+                    Ok(())
+                }
+            });
+
+        let (job_id, task) = SettlementTask::create(
+            Some(certificate_id),
+            job,
+            Arc::new(SettlementTransactionConfig::default()),
+            Arc::new(mk_provider()),
+            Arc::new(store),
+            mk_control(),
+        )
+        .await
+        .expect("settlement task should be created");
+
+        assert_eq!(task.id, job_id);
+        assert_eq!(*recorded_job_id.lock().unwrap(), Some(job_id));
+        assert_eq!(
+            ordering.lock().unwrap().as_slice(),
+            ["write_link", "write_job"]
+        );
+    }
+
+    #[tokio::test]
+    async fn create_fails_when_certificate_link_already_exists() {
+        let mut store = MockStateStore::new();
+        let certificate_id = CertificateId::new(Digest::from([8; 32]));
+        let job = mk_job();
+
+        store
+            .expect_insert_certificate_settlement_job_id()
+            .once()
+            .withf(move |recorded_certificate_id, _| recorded_certificate_id == &certificate_id)
+            .return_once(|_, _| {
+                Err(Error::Unexpected(
+                    "Certificate already has a settlement job id".to_string(),
+                ))
+            });
+
+        store.expect_insert_settlement_job().never();
+
+        let result = SettlementTask::create(
+            Some(certificate_id),
+            job,
+            Arc::new(SettlementTransactionConfig::default()),
+            Arc::new(mk_provider()),
+            Arc::new(store),
+            mk_control(),
+        )
+        .await;
+
+        let error = result
+            .err()
+            .expect("duplicate certificate link should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to write settlement job id"),
+            "{error:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/agglayer-storage/src/stores/interfaces/writer.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/writer.rs
@@ -73,8 +73,9 @@ pub trait StateWriter: Send + Sync {
     /// Inserts the settlement job id associated with `certificate_id`.
     ///
     /// This is an insert-only operation and must fail if `certificate_id`
-    /// already has a stored settlement job id. The settlement job must already
-    /// exist.
+    /// already has a stored settlement job id. The settlement job may be
+    /// created after this link, so startup recovery can recreate a missing job
+    /// from the certificate-side id.
     fn insert_certificate_settlement_job_id(
         &self,
         certificate_id: &CertificateId,

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -33,7 +33,6 @@ use crate::{
         local_exit_tree_per_network as LET,
         metadata::MetadataColumn,
         nullifier_tree_per_network::NullifierTreePerNetworkColumn,
-        settlement_jobs::SettlementJobsColumn,
     },
     error::Error,
     schema::ColumnSchema,
@@ -222,16 +221,6 @@ impl StateWriter for StateStore {
         {
             return Err(Error::UnprocessedAction(format!(
                 "Certificate {certificate_id} already has a settlement job id"
-            )));
-        }
-
-        if self
-            .db
-            .get::<SettlementJobsColumn>(settlement_job_id)?
-            .is_none()
-        {
-            return Err(Error::UnprocessedAction(format!(
-                "Settlement job does not exist for id {settlement_job_id}"
             )));
         }
 

--- a/crates/agglayer-storage/src/stores/state/tests/settlement.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/settlement.rs
@@ -106,14 +106,26 @@ fn get_certificate_settlement_job_id_returns_none_when_missing() {
 }
 
 #[test]
-fn insert_certificate_settlement_job_id_requires_existing_job() {
-    let (_tmp, _db, store) = setup_store();
+fn insert_certificate_settlement_job_id_allows_missing_job() {
+    let (_tmp, db, store) = setup_store();
     let certificate_id = mk_certificate_id(2);
     let job_id = mk_job_id(200);
 
-    let res = store.insert_certificate_settlement_job_id(&certificate_id, &job_id);
+    store
+        .insert_certificate_settlement_job_id(&certificate_id, &job_id)
+        .expect("mapping insert must not require an existing job");
 
-    assert!(matches!(res, Err(Error::UnprocessedAction(_))));
+    assert_eq!(
+        db.get::<CertificateSettlementJobColumn>(&certificate_id)
+            .expect("Unable to read stored value"),
+        Some(job_id)
+    );
+
+    assert_eq!(
+        db.get::<SettlementJobsColumn>(&job_id)
+            .expect("Unable to read stored value"),
+        None
+    );
 }
 
 #[test]


### PR DESCRIPTION
Record certificate-to-settlement-job mappings during settlement task creation so the certificate link is persisted before the settlement job row and before the task starts executing.

This keeps the settlement service on one creation path, with the tower request carrying an optional certificate id and the inherent service API taking certificate id and job as separate parameters.

The storage insert remains insert-only for duplicate certificate mappings, but no longer requires the settlement job row to exist first.

Verified with:
- cargo make ci-format
- cargo make ci-clippy
- cargo make ci-typos
- cargo test -p agglayer-settlement-service
- cargo test -p agglayer-storage stores::state::tests::settlement

Fixes #1453 