### PR TITLE
fix(settlement-service): cleanup watchers after terminal settlement jobs

### DIFF
--- a/crates/agglayer-settlement-service/src/settlement_service.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service.rs
@@ -25,65 +25,6 @@ use crate::{
     wallet_nonce_locks::WalletNonceLocks,
 };
 
-type ResultWatchersMap =
-    Arc<Mutex<HashMap<SettlementJobId, watch::Receiver<Option<SettlementJobResult>>>>>;
-type TaskControlsMap = Arc<std::sync::Mutex<HashMap<SettlementJobId, TaskControlHandle>>>;
-
-async fn remove_job_from_active_tracking(
-    job_id: SettlementJobId,
-    result_watchers: &ResultWatchersMap,
-    task_controls: &TaskControlsMap,
-) {
-    result_watchers.lock().await.remove(&job_id);
-    task_controls
-        .lock()
-        .expect("settlement task_controls lock poisoned")
-        .remove(&job_id);
-}
-
-/// Ensures in-memory job tracking is removed when a spawned settlement task
-/// ends abnormally (e.g. panics) before explicit cleanup can run.
-struct JobTrackingGuard {
-    job_id: SettlementJobId,
-    result_watchers: ResultWatchersMap,
-    task_controls: TaskControlsMap,
-    armed: bool,
-}
-
-impl JobTrackingGuard {
-    fn new(
-        job_id: SettlementJobId,
-        result_watchers: ResultWatchersMap,
-        task_controls: TaskControlsMap,
-    ) -> Self {
-        Self {
-            job_id,
-            result_watchers,
-            task_controls,
-            armed: true,
-        }
-    }
-
-    fn disarm(&mut self) {
-        self.armed = false;
-    }
-}
-
-impl Drop for JobTrackingGuard {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-
-        let job_id = self.job_id;
-        let result_watchers = self.result_watchers.clone();
-        let task_controls = self.task_controls.clone();
-        tokio::spawn(async move {
-            remove_job_from_active_tracking(job_id, &result_watchers, &task_controls).await;
-        });
-    }
-}
-
 /// How the live task for a job (if any) was told about an admin mutation.
 ///
 /// Admin mutations are declarative edits of stored state; a running task only
@@ -156,7 +97,6 @@ fn tag_admin_storage_error(error: agglayer_storage::error::Error) -> eyre::Repor
     eyre::Report::new(error).wrap_err(code)
 }
 
-
 /// The Settlement Service is responsible for managing settlement jobs and
 /// answering settlement result requests.
 ///
@@ -173,8 +113,9 @@ pub struct SettlementService<L1Provider, SettlementStore> {
     store: Arc<SettlementStore>,
     cancellation_token: CancellationToken,
     task_controls: Arc<std::sync::Mutex<HashMap<SettlementJobId, TaskControlHandle>>>,
-    result_watchers:
-        Arc<Mutex<HashMap<SettlementJobId, watch::Receiver<Option<SettlementJobResult>>>>>,
+    result_watchers: Arc<
+        std::sync::Mutex<HashMap<SettlementJobId, watch::Receiver<Option<SettlementJobResult>>>>,
+    >,
     /// Serializes the spawn-capable force-remove and reload admin operations
     /// so two concurrent calls cannot both conclude that a job needs a fresh
     /// task and spawn duplicates. A global lock is deliberate at this stack's
@@ -189,13 +130,26 @@ pub struct SettlementService<L1Provider, SettlementStore> {
     wallet_nonce_locks: Arc<WalletNonceLocks>,
 }
 
-struct TaskControlRegistrationGuard {
+/// Tears down both in-memory registrations when the spawned task exits,
+/// including panic unwind.
+///
+/// Drop removes the watcher first, then the control entry. Admin reload
+/// refuses to respawn while a control is still registered; reversing this
+/// order would let reload install a fresh task that this Drop then deletes.
+struct TaskRegistrationGuard {
     job_id: SettlementJobId,
+    result_watchers: Arc<
+        std::sync::Mutex<HashMap<SettlementJobId, watch::Receiver<Option<SettlementJobResult>>>>,
+    >,
     task_controls: Arc<std::sync::Mutex<HashMap<SettlementJobId, TaskControlHandle>>>,
 }
 
-impl Drop for TaskControlRegistrationGuard {
+impl Drop for TaskRegistrationGuard {
     fn drop(&mut self) {
+        self.result_watchers
+            .lock()
+            .expect("settlement result_watchers lock poisoned")
+            .remove(&self.job_id);
         self.task_controls
             .lock()
             .expect("settlement task_controls lock poisoned")
@@ -278,7 +232,7 @@ impl<
             store,
             cancellation_token,
             task_controls: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            result_watchers: Arc::new(Mutex::new(HashMap::new())),
+            result_watchers: Arc::new(std::sync::Mutex::new(HashMap::new())),
             admin_operation_lock: Arc::new(Mutex::new(())),
             wallet_nonce_locks: Arc::new(WalletNonceLocks::default()),
         };
@@ -371,7 +325,7 @@ impl<
         // harmless pending watcher, never a task without a watcher.
         self.result_watchers
             .lock()
-            .await
+            .expect("settlement result_watchers lock poisoned")
             .insert(job_id, result_receiver.clone());
         self.task_controls
             .lock()
@@ -385,12 +339,14 @@ impl<
         let wallet_nonce_locks = self.wallet_nonce_locks.clone();
         let cancellation_token = self.cancellation_token.clone();
         tokio::task::spawn(async move {
-            let _task_control_registration = TaskControlRegistrationGuard {
+            // Lives outside the run loop so ReloadAndRestart → Pending keeps
+            // both registrations; Drop runs on Completed, Cancelled, reload
+            // error, reload-to-completed, and panic unwind.
+            let _task_registration = TaskRegistrationGuard {
                 job_id,
+                result_watchers,
                 task_controls: task_controls.clone(),
             };
-            let mut cleanup_guard =
-                JobTrackingGuard::new(job_id, result_watchers.clone(), task_controls.clone());
             loop {
                 match task.run().await {
                     SettlementTaskRunResult::Completed(result) => {
@@ -401,14 +357,10 @@ impl<
                                 "Failed to send settlement job result to watchers"
                             );
                         }
-                        result_watchers.lock().await.remove(&job_id);
-                        cleanup_guard.disarm();
                         break;
                     }
                     SettlementTaskRunResult::Cancelled => {
                         info!(?job_id, "Settlement task cancelled");
-                        result_watchers.lock().await.remove(&job_id);
-                        cleanup_guard.disarm();
                         break;
                     }
                     SettlementTaskRunResult::ReloadAndRestart => {
@@ -440,7 +392,6 @@ impl<
                                         "Failed to send settlement job result to watchers"
                                     );
                                 }
-                                cleanup_guard.disarm();
                                 break;
                             }
                             Err(error) => {
@@ -450,8 +401,6 @@ impl<
                                     "Failed to reload settlement task; dropping in-memory task \
                                      state"
                                 );
-                                result_watchers.lock().await.remove(&job_id);
-                                cleanup_guard.disarm();
                                 break;
                             }
                         }
@@ -586,7 +535,10 @@ impl<
         // No replacement registration is created until loading succeeds, so
         // clearing it here also leaves a load failure with no stale control or
         // watcher for this job.
-        self.result_watchers.lock().await.remove(&job_id);
+        self.result_watchers
+            .lock()
+            .expect("settlement result_watchers lock poisoned")
+            .remove(&job_id);
 
         let (task_control_handle, task_control) = TaskControlHandle::new(&self.cancellation_token);
         let stored_job = self
@@ -867,7 +819,10 @@ impl<
 
         // Drop the in-memory watcher that still broadcasts the removed
         // result, then bring the job back to life.
-        self.result_watchers.lock().await.remove(&job_id);
+        self.result_watchers
+            .lock()
+            .expect("settlement result_watchers lock poisoned")
+            .remove(&job_id);
 
         let (task_control_handle, task_control) = TaskControlHandle::new(&self.cancellation_token);
         // Nothing stale is registered at this point: the watcher was removed,
@@ -932,13 +887,20 @@ impl<
         &self,
         job_id: SettlementJobId,
     ) -> eyre::Result<RetrievedSettlementResult> {
-        if let Some(watcher) = self.result_watchers.lock().await.get(&job_id) {
-            return match watcher.borrow().as_ref() {
+        let watcher = self
+            .result_watchers
+            .lock()
+            .expect("settlement result_watchers lock poisoned")
+            .get(&job_id)
+            .cloned();
+        if let Some(watcher) = watcher {
+            let current = watcher.borrow().clone();
+            return match current {
                 None => Ok(RetrievedSettlementResult::Pending(SettlementJobWatcher {
                     job_id,
-                    watcher: watcher.clone(),
+                    watcher,
                 })),
-                Some(result) => Ok(RetrievedSettlementResult::Completed(result.clone())),
+                Some(result) => Ok(RetrievedSettlementResult::Completed(result)),
             };
         }
 

--- a/crates/agglayer-settlement-service/src/settlement_service.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service.rs
@@ -25,6 +25,65 @@ use crate::{
     wallet_nonce_locks::WalletNonceLocks,
 };
 
+type ResultWatchersMap =
+    Arc<Mutex<HashMap<SettlementJobId, watch::Receiver<Option<SettlementJobResult>>>>>;
+type TaskControlsMap = Arc<std::sync::Mutex<HashMap<SettlementJobId, TaskControlHandle>>>;
+
+async fn remove_job_from_active_tracking(
+    job_id: SettlementJobId,
+    result_watchers: &ResultWatchersMap,
+    task_controls: &TaskControlsMap,
+) {
+    result_watchers.lock().await.remove(&job_id);
+    task_controls
+        .lock()
+        .expect("settlement task_controls lock poisoned")
+        .remove(&job_id);
+}
+
+/// Ensures in-memory job tracking is removed when a spawned settlement task
+/// ends abnormally (e.g. panics) before explicit cleanup can run.
+struct JobTrackingGuard {
+    job_id: SettlementJobId,
+    result_watchers: ResultWatchersMap,
+    task_controls: TaskControlsMap,
+    armed: bool,
+}
+
+impl JobTrackingGuard {
+    fn new(
+        job_id: SettlementJobId,
+        result_watchers: ResultWatchersMap,
+        task_controls: TaskControlsMap,
+    ) -> Self {
+        Self {
+            job_id,
+            result_watchers,
+            task_controls,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for JobTrackingGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let job_id = self.job_id;
+        let result_watchers = self.result_watchers.clone();
+        let task_controls = self.task_controls.clone();
+        tokio::spawn(async move {
+            remove_job_from_active_tracking(job_id, &result_watchers, &task_controls).await;
+        });
+    }
+}
+
 /// How the live task for a job (if any) was told about an admin mutation.
 ///
 /// Admin mutations are declarative edits of stored state; a running task only
@@ -96,6 +155,7 @@ fn tag_admin_storage_error(error: agglayer_storage::error::Error) -> eyre::Repor
     };
     eyre::Report::new(error).wrap_err(code)
 }
+
 
 /// The Settlement Service is responsible for managing settlement jobs and
 /// answering settlement result requests.
@@ -329,6 +389,8 @@ impl<
                 job_id,
                 task_controls: task_controls.clone(),
             };
+            let mut cleanup_guard =
+                JobTrackingGuard::new(job_id, result_watchers.clone(), task_controls.clone());
             loop {
                 match task.run().await {
                     SettlementTaskRunResult::Completed(result) => {
@@ -339,11 +401,14 @@ impl<
                                 "Failed to send settlement job result to watchers"
                             );
                         }
+                        result_watchers.lock().await.remove(&job_id);
+                        cleanup_guard.disarm();
                         break;
                     }
                     SettlementTaskRunResult::Cancelled => {
                         info!(?job_id, "Settlement task cancelled");
                         result_watchers.lock().await.remove(&job_id);
+                        cleanup_guard.disarm();
                         break;
                     }
                     SettlementTaskRunResult::ReloadAndRestart => {
@@ -375,6 +440,7 @@ impl<
                                         "Failed to send settlement job result to watchers"
                                     );
                                 }
+                                cleanup_guard.disarm();
                                 break;
                             }
                             Err(error) => {
@@ -385,6 +451,7 @@ impl<
                                      state"
                                 );
                                 result_watchers.lock().await.remove(&job_id);
+                                cleanup_guard.disarm();
                                 break;
                             }
                         }

--- a/crates/agglayer-settlement-service/src/settlement_service/tests.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service/tests.rs
@@ -2654,3 +2654,4 @@ async fn live_job_count_tracks_the_task_registry() {
 }
 
 mod same_wallet_nonce_race;
+mod spawn_to_completed;

--- a/crates/agglayer-settlement-service/src/settlement_service/tests.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service/tests.rs
@@ -209,11 +209,26 @@ async fn insert_active_job_tracking(
         .lock()
         .expect("settlement task_controls lock poisoned")
         .insert(job_id, handle);
-    service.result_watchers.lock().await.insert(job_id, watcher);
+    service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .insert(job_id, watcher);
+}
+
+fn drop_job_registrations(
+    service: &SettlementService<impl Provider + WalletProvider + 'static, MockStateStore>,
+    job_id: SettlementJobId,
+) {
+    drop(TaskRegistrationGuard {
+        job_id,
+        result_watchers: service.result_watchers.clone(),
+        task_controls: service.task_controls.clone(),
+    });
 }
 
 #[tokio::test]
-async fn remove_job_from_active_tracking_clears_both_maps() {
+async fn task_registration_guard_clears_watcher_then_control_on_drop() {
     let mut store = MockStateStore::new();
     expect_empty_startup_recovery(&mut store);
     let service = mk_service(Arc::new(store)).await;
@@ -221,18 +236,18 @@ async fn remove_job_from_active_tracking_clears_both_maps() {
     let (_sender, watcher) = watch::channel(None);
 
     insert_active_job_tracking(&service, job_id, watcher).await;
+    drop_job_registrations(&service, job_id);
 
-    remove_job_from_active_tracking(job_id, &service.result_watchers, &service.task_controls)
-        .await;
-
-    assert!(service.result_watchers.lock().await.is_empty());
-    assert!(
-        service
-            .task_controls
-            .lock()
-            .expect("settlement task_controls lock poisoned")
-            .is_empty()
-    );
+    assert!(service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .is_empty());
+    assert!(service
+        .task_controls
+        .lock()
+        .expect("settlement task_controls lock poisoned")
+        .is_empty());
 }
 
 #[tokio::test]
@@ -252,9 +267,7 @@ async fn retrieve_uses_storage_after_active_tracking_cleanup() {
     let service = mk_service(Arc::new(store)).await;
     let (_sender, watcher) = watch::channel(Some(stored_result.clone()));
     insert_active_job_tracking(&service, job_id, watcher).await;
-
-    remove_job_from_active_tracking(job_id, &service.result_watchers, &service.task_controls)
-        .await;
+    drop_job_registrations(&service, job_id);
 
     let retrieved = service
         .retrieve_settlement_result(job_id)
@@ -282,42 +295,12 @@ async fn caller_watcher_retains_result_after_active_tracking_cleanup() {
         .send(Some(result.clone()))
         .expect("result should be sent to watcher");
     insert_active_job_tracking(&service, job_id, caller_watcher.clone()).await;
-
-    remove_job_from_active_tracking(job_id, &service.result_watchers, &service.task_controls)
-        .await;
+    drop_job_registrations(&service, job_id);
 
     assert_eq!(
         caller_watcher.borrow().as_ref(),
         Some(&result),
         "caller watcher should retain the result after service map cleanup"
-    );
-}
-
-#[tokio::test]
-async fn job_tracking_guard_cleans_up_on_drop_without_disarm() {
-    let mut store = MockStateStore::new();
-    expect_empty_startup_recovery(&mut store);
-    let service = mk_service(Arc::new(store)).await;
-    let job_id = mk_job_id(13);
-    let (_sender, watcher) = watch::channel(None);
-    insert_active_job_tracking(&service, job_id, watcher).await;
-
-    let guard = JobTrackingGuard::new(
-        job_id,
-        service.result_watchers.clone(),
-        service.task_controls.clone(),
-    );
-    drop(guard);
-
-    tokio::time::sleep(Duration::from_millis(10)).await;
-
-    assert!(service.result_watchers.lock().await.is_empty());
-    assert!(
-        service
-            .task_controls
-            .lock()
-            .expect("settlement task_controls lock poisoned")
-            .is_empty()
     );
 }
 
@@ -426,7 +409,11 @@ async fn start_scans_jobs_and_skips_completed_ones() {
         .lock()
         .expect("settlement task_controls lock poisoned")
         .is_empty());
-    assert!(service.result_watchers.lock().await.is_empty());
+    assert!(service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .is_empty());
 }
 
 #[tokio::test]
@@ -468,7 +455,11 @@ async fn start_resumes_pending_job_with_task_controls_tied_to_service_cancellati
         .lock()
         .expect("settlement task_controls lock poisoned")
         .contains_key(&job_id));
-    assert!(service.result_watchers.lock().await.contains_key(&job_id));
+    assert!(service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .contains_key(&job_id));
 
     cancellation_token.cancel();
 
@@ -532,7 +523,11 @@ async fn start_skips_unloadable_jobs_and_keeps_scanning() {
         .lock()
         .expect("settlement task_controls lock poisoned")
         .is_empty());
-    assert!(service.result_watchers.lock().await.is_empty());
+    assert!(service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .is_empty());
 }
 
 #[tokio::test]
@@ -577,7 +572,11 @@ async fn retrieve_uses_in_memory_watcher_before_storage() {
     let in_memory_result = mk_result(2, ContractCallOutcome::Revert);
 
     let (_sender, watcher) = watch::channel(Some(in_memory_result.clone()));
-    service.result_watchers.lock().await.insert(job_id, watcher);
+    service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .insert(job_id, watcher);
 
     let retrieved = service
         .retrieve_settlement_result(job_id)
@@ -681,7 +680,7 @@ async fn retrieve_fails_when_pending_job_has_no_running_task() {
 }
 
 #[tokio::test]
-async fn reload_and_restart_preserves_watcher_when_reload_finds_completed_job() {
+async fn reload_and_restart_clears_registrations_when_reload_finds_completed_job() {
     let mut store = MockStateStore::new();
     let job_id = mk_job_id(6);
     let job = mk_job(6);
@@ -756,12 +755,24 @@ async fn reload_and_restart_preserves_watcher_when_reload_finds_completed_job() 
         .expect("reload should publish the stored terminal result");
 
     assert_eq!(result_receiver.borrow().as_ref(), Some(&completed_result));
-    assert!(service
-        .task_controls
-        .lock()
-        .expect("settlement task_controls lock poisoned")
-        .is_empty());
-    assert!(service.result_watchers.lock().await.contains_key(&job_id));
+    wait_until(|| {
+        service
+            .task_controls
+            .lock()
+            .expect("settlement task_controls lock poisoned")
+            .is_empty()
+            && service
+                .result_watchers
+                .lock()
+                .expect("settlement result_watchers lock poisoned")
+                .is_empty()
+    })
+    .await;
+    assert_eq!(
+        result_receiver.borrow().as_ref(),
+        Some(&completed_result),
+        "caller watcher should retain the result after service map cleanup"
+    );
 }
 
 #[tokio::test]
@@ -836,7 +847,7 @@ async fn reload_and_restart_replaces_live_task_when_reload_finds_pending_job() {
     let registered_watcher = service
         .result_watchers
         .lock()
-        .await
+        .expect("settlement result_watchers lock poisoned")
         .get(&job_id)
         .cloned()
         .expect("the reloaded task must retain a result watcher");
@@ -924,7 +935,11 @@ async fn reload_and_restart_load_failure_cleans_up_live_registrations() {
 
     assert!(closed.is_err(), "the watcher sender should be dropped");
     wait_until(|| !service.has_live_task(job_id)).await;
-    assert!(!service.result_watchers.lock().await.contains_key(&job_id));
+    assert!(!service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .contains_key(&job_id));
 }
 
 #[tokio::test]
@@ -1022,7 +1037,11 @@ async fn request_new_settlement_persistence_failure_leaves_no_registrations() {
         .lock()
         .expect("settlement task_controls lock poisoned")
         .is_empty());
-    assert!(service.result_watchers.lock().await.is_empty());
+    assert!(service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .is_empty());
 }
 
 #[tokio::test]
@@ -1149,6 +1168,14 @@ async fn panicked_task_deregisters_control_and_abort_reports_no_live_task() {
     // first L1 query fails non-recoverably and deliberately panics.
     let service = mk_service(Arc::new(store)).await;
     wait_until(|| !service.has_live_task(job_id)).await;
+    assert!(
+        service
+            .result_watchers
+            .lock()
+            .expect("settlement result_watchers lock poisoned")
+            .is_empty(),
+        "panic teardown must clear in-memory registrations"
+    );
 
     let error = service
         .admin_abort_task(job_id)
@@ -1159,6 +1186,136 @@ async fn panicked_task_deregisters_control_and_abort_reports_no_live_task() {
         error.downcast_ref::<RpcErrorCode>(),
         Some(&RpcErrorCode::NoLiveTask)
     );
+}
+
+#[tokio::test]
+async fn panicked_task_reload_respawns_task_without_stale_teardown() {
+    use alloy::providers::mock::MockTransport;
+
+    #[derive(Clone, Debug)]
+    struct PanicOnceThenParkTransport {
+        mock: MockTransport,
+        // Counts at least one RPC call from each task spawn.
+        request_count: Arc<AtomicUsize>,
+    }
+
+    impl tower::Service<RequestPacket> for PanicOnceThenParkTransport {
+        type Response = alloy::rpc::json_rpc::ResponsePacket;
+        type Error = TransportError;
+        type Future = TransportFut<'static>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: RequestPacket) -> Self::Future {
+            self.request_count.fetch_add(1, Ordering::SeqCst);
+            if self.mock.read_q().is_empty() {
+                return Box::pin(pending());
+            }
+            self.mock.call(req)
+        }
+    }
+
+    let mut store = MockStateStore::new();
+    let job_id = mk_job_id(29);
+    let job = mk_job(29);
+    let attempt = mk_resolved_attempt(29, SettlementTxHash::new(Digest::from([30; 32])));
+
+    store
+        .expect_list_settlement_job_ids()
+        .once()
+        .return_once(move || Ok(vec![job_id]));
+    store
+        .expect_get_settlement_job()
+        .times(3)
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .returning(move |_| Ok(Some(job.clone())));
+    store
+        .expect_get_settlement_job_result()
+        .times(3)
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .returning(|_| Ok(None));
+    store
+        .expect_list_settlement_attempt_results()
+        .times(2)
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .returning(|_| Ok(Vec::new()));
+    store
+        .expect_list_settlement_attempts()
+        .times(2)
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .returning(move |_| Ok(vec![(0, attempt.clone())]));
+
+    // First L1 RPC call returns a "Method not found" error (non-recoverable),
+    // subsequent calls park to avoid a second panic.
+    let asserter = Asserter::new();
+    asserter.push_failure(alloy::rpc::json_rpc::ErrorPayload {
+        code: -32601,
+        message: "Method not found".into(),
+        data: None,
+    });
+    let mock = MockTransport::new(asserter);
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let transport = PanicOnceThenParkTransport {
+        mock,
+        request_count: request_count.clone(),
+    };
+    let client = RpcClient::new(transport, true);
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(
+            PrivateKeySigner::from_slice(&[0x11; 32]).expect("valid test signing key"),
+        ))
+        .connect_client(client);
+
+    let cancellation_token = CancellationToken::new();
+    let service = SettlementService::start(
+        SettlementServiceConfig::default(),
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(provider),
+        Arc::new(store),
+        cancellation_token.clone(),
+    )
+    .await
+    .expect("settlement service should start")
+    .0;
+
+    // Panic should tear down the stale registrations.
+    wait_until(|| !service.has_live_task(job_id)).await;
+    assert!(!service
+        .task_controls
+        .lock()
+        .expect("settlement task_controls lock poisoned")
+        .contains_key(&job_id));
+    assert!(!service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .contains_key(&job_id));
+
+    // Reload should respawn a task that stays registered (no stale teardown).
+    service
+        .admin_reload_and_restart_task(job_id)
+        .await
+        .expect("reload should respawn after panic");
+    wait_until(|| service.has_live_task(job_id)).await;
+
+    assert!(service
+        .task_controls
+        .lock()
+        .expect("settlement task_controls lock poisoned")
+        .contains_key(&job_id));
+    assert!(service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .contains_key(&job_id));
+
+    cancellation_token.cancel();
+    let _ = request_count;
 }
 
 #[tokio::test]
@@ -1268,7 +1425,7 @@ async fn abort_then_reload_respawns_pending_job() {
     let old_watcher = service
         .result_watchers
         .lock()
-        .await
+        .expect("settlement result_watchers lock poisoned")
         .get(&job_id)
         .cloned()
         .expect("the parked task must have a watcher");
@@ -1278,7 +1435,11 @@ async fn abort_then_reload_respawns_pending_job() {
         .await
         .expect("the parked task should accept an abort");
     wait_until(|| !service.has_live_task(job_id)).await;
-    assert!(!service.result_watchers.lock().await.contains_key(&job_id));
+    assert!(!service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .contains_key(&job_id));
 
     service
         .admin_reload_and_restart_task(job_id)
@@ -1290,7 +1451,7 @@ async fn abort_then_reload_respawns_pending_job() {
     let fresh_watcher = service
         .result_watchers
         .lock()
-        .await
+        .expect("settlement result_watchers lock poisoned")
         .get(&job_id)
         .cloned()
         .expect("the respawned task must have a watcher");
@@ -1469,7 +1630,7 @@ async fn reload_retries_after_closed_handle_teardown() {
     service
         .result_watchers
         .lock()
-        .await
+        .expect("settlement result_watchers lock poisoned")
         .insert(job_id, stale_watcher.clone());
 
     let error = service
@@ -1503,7 +1664,7 @@ async fn reload_retries_after_closed_handle_teardown() {
     let fresh_watcher = service
         .result_watchers
         .lock()
-        .await
+        .expect("settlement result_watchers lock poisoned")
         .get(&job_id)
         .cloned()
         .expect("respawn should register a fresh watcher");
@@ -1548,7 +1709,7 @@ async fn reload_load_failure_leaves_no_registrations() {
     service
         .result_watchers
         .lock()
-        .await
+        .expect("settlement result_watchers lock poisoned")
         .insert(job_id, stale_watcher);
 
     let error = service
@@ -1561,7 +1722,11 @@ async fn reload_load_failure_leaves_no_registrations() {
         Some(&RpcErrorCode::Unavailable)
     );
     assert!(!service.has_live_task(job_id));
-    assert!(!service.result_watchers.lock().await.contains_key(&job_id));
+    assert!(!service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .contains_key(&job_id));
 }
 
 #[tokio::test]
@@ -1604,7 +1769,11 @@ async fn reload_completed_during_load_is_tagged_already_completed() {
         Some(&RpcErrorCode::AlreadyCompleted)
     );
     assert!(!service.has_live_task(job_id));
-    assert!(!service.result_watchers.lock().await.contains_key(&job_id));
+    assert!(!service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .contains_key(&job_id));
 }
 
 #[tokio::test]
@@ -1687,7 +1856,7 @@ async fn admin_force_remove_job_result_respawns_task() {
     service
         .result_watchers
         .lock()
-        .await
+        .expect("settlement result_watchers lock poisoned")
         .insert(job_id, old_watcher.clone());
 
     service
@@ -1701,7 +1870,10 @@ async fn admin_force_remove_job_result_respawns_task() {
         .lock()
         .expect("settlement task_controls lock poisoned")
         .contains_key(&job_id));
-    let result_watchers = service.result_watchers.lock().await;
+    let result_watchers = service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned");
     let fresh_watcher = result_watchers
         .get(&job_id)
         .expect("the respawned task must have a watcher");
@@ -1790,7 +1962,7 @@ async fn force_remove_load_failure_leaves_clean_aborted_state() {
     service
         .result_watchers
         .lock()
-        .await
+        .expect("settlement result_watchers lock poisoned")
         .insert(job_id, old_watcher);
 
     let error = service
@@ -1807,7 +1979,11 @@ async fn force_remove_load_failure_leaves_clean_aborted_state() {
         .lock()
         .expect("settlement task_controls lock poisoned")
         .contains_key(&job_id));
-    assert!(!service.result_watchers.lock().await.contains_key(&job_id));
+    assert!(!service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .contains_key(&job_id));
 }
 
 /// A fully specified admin attempt.

--- a/crates/agglayer-settlement-service/src/settlement_service/tests.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service/tests.rs
@@ -198,6 +198,129 @@ fn mk_result(seed: u8, outcome: ContractCallOutcome) -> SettlementJobResult {
     }
 }
 
+async fn insert_active_job_tracking(
+    service: &SettlementService<impl Provider + WalletProvider + 'static, MockStateStore>,
+    job_id: SettlementJobId,
+    watcher: watch::Receiver<Option<SettlementJobResult>>,
+) {
+    let (handle, _control) = TaskControlHandle::new(&CancellationToken::new());
+    service
+        .task_controls
+        .lock()
+        .expect("settlement task_controls lock poisoned")
+        .insert(job_id, handle);
+    service.result_watchers.lock().await.insert(job_id, watcher);
+}
+
+#[tokio::test]
+async fn remove_job_from_active_tracking_clears_both_maps() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let service = mk_service(Arc::new(store)).await;
+    let job_id = mk_job_id(10);
+    let (_sender, watcher) = watch::channel(None);
+
+    insert_active_job_tracking(&service, job_id, watcher).await;
+
+    remove_job_from_active_tracking(job_id, &service.result_watchers, &service.task_controls)
+        .await;
+
+    assert!(service.result_watchers.lock().await.is_empty());
+    assert!(
+        service
+            .task_controls
+            .lock()
+            .expect("settlement task_controls lock poisoned")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn retrieve_uses_storage_after_active_tracking_cleanup() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(11);
+    let stored_result = mk_result(11, ContractCallOutcome::Success);
+    let stored_result_for_store = stored_result.clone();
+
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(stored_result_for_store)));
+
+    let service = mk_service(Arc::new(store)).await;
+    let (_sender, watcher) = watch::channel(Some(stored_result.clone()));
+    insert_active_job_tracking(&service, job_id, watcher).await;
+
+    remove_job_from_active_tracking(job_id, &service.result_watchers, &service.task_controls)
+        .await;
+
+    let retrieved = service
+        .retrieve_settlement_result(job_id)
+        .await
+        .expect("retrieval should succeed");
+
+    match retrieved {
+        RetrievedSettlementResult::Completed(result) => assert_eq!(result, stored_result),
+        RetrievedSettlementResult::Pending(_) => {
+            panic!("expected completed result from storage after map cleanup")
+        }
+    }
+}
+
+#[tokio::test]
+async fn caller_watcher_retains_result_after_active_tracking_cleanup() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let service = mk_service(Arc::new(store)).await;
+    let job_id = mk_job_id(12);
+    let result = mk_result(12, ContractCallOutcome::Success);
+
+    let (sender, caller_watcher) = watch::channel(None);
+    sender
+        .send(Some(result.clone()))
+        .expect("result should be sent to watcher");
+    insert_active_job_tracking(&service, job_id, caller_watcher.clone()).await;
+
+    remove_job_from_active_tracking(job_id, &service.result_watchers, &service.task_controls)
+        .await;
+
+    assert_eq!(
+        caller_watcher.borrow().as_ref(),
+        Some(&result),
+        "caller watcher should retain the result after service map cleanup"
+    );
+}
+
+#[tokio::test]
+async fn job_tracking_guard_cleans_up_on_drop_without_disarm() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let service = mk_service(Arc::new(store)).await;
+    let job_id = mk_job_id(13);
+    let (_sender, watcher) = watch::channel(None);
+    insert_active_job_tracking(&service, job_id, watcher).await;
+
+    let guard = JobTrackingGuard::new(
+        job_id,
+        service.result_watchers.clone(),
+        service.task_controls.clone(),
+    );
+    drop(guard);
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    assert!(service.result_watchers.lock().await.is_empty());
+    assert!(
+        service
+            .task_controls
+            .lock()
+            .expect("settlement task_controls lock poisoned")
+            .is_empty()
+    );
+}
+
 #[tokio::test]
 async fn watcher_returns_result_that_arrived_before_waiting() {
     let job_id = mk_job_id(6);

--- a/crates/agglayer-settlement-service/src/settlement_service/tests/spawn_to_completed.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service/tests/spawn_to_completed.rs
@@ -1,0 +1,273 @@
+use std::{sync::Arc, time::{Duration, SystemTime}};
+
+use agglayer_types::{
+    ContractCallOutcome, ContractCallResult, Digest, Nonce, SettlementAttempt,
+    SettlementAttemptNumber, SettlementAttemptResult, SettlementJobResult, SettlementTxHash, B256,
+};
+use alloy::{
+    consensus::{Signed, TxEip1559, TxEnvelope},
+    network::EthereumWallet,
+    primitives::{Address, Signature, TxKind, U256},
+    providers::{mock::Asserter, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+};
+
+use super::*;
+use crate::settlement_task::{SettlementTask, StoredSettlementJob, TaskControlHandle};
+
+fn test_signer() -> PrivateKeySigner {
+    PrivateKeySigner::from_slice(&[0x11; 32]).expect("valid test signing key")
+}
+
+fn mk_tx_hash(seed: u8) -> SettlementTxHash {
+    SettlementTxHash::new(Digest::from([seed; 32]))
+}
+
+fn mk_tx(hash_seed: u8) -> TxEnvelope {
+    TxEnvelope::Eip1559(Signed::new_unchecked(
+        TxEip1559 {
+            chain_id: 1,
+            nonce: 2,
+            gas_limit: 100_000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 10,
+            to: TxKind::Call(Address::from([6; 20])),
+            value: U256::from(7_u64),
+            input: vec![8].into(),
+            access_list: Default::default(),
+        },
+        Signature::test_signature(),
+        B256::from([hash_seed; 32]),
+    ))
+}
+
+fn mk_rpc_block(number: u64, hash: B256) -> alloy::rpc::types::Block {
+    let mut block: alloy::rpc::types::Block = Default::default();
+    block.header.hash = hash;
+    block.header.inner.number = number;
+    block
+}
+
+fn mk_rpc_receipt(
+    tx_hash: SettlementTxHash,
+    block_hash: B256,
+    block_number: u64,
+) -> alloy::rpc::types::TransactionReceipt {
+    alloy::rpc::types::TransactionReceipt {
+        inner: alloy::consensus::ReceiptEnvelope::Eip1559(alloy::consensus::ReceiptWithBloom {
+            receipt: alloy::consensus::Receipt {
+                status: true.into(),
+                cumulative_gas_used: 0,
+                logs: vec![],
+            },
+            logs_bloom: Default::default(),
+        }),
+        transaction_hash: tx_hash.into(),
+        transaction_index: Some(0),
+        block_hash: Some(block_hash),
+        block_number: Some(block_number),
+        gas_used: 0,
+        effective_gas_price: 0,
+        blob_gas_used: None,
+        blob_gas_price: None,
+        from: Address::from([9; 20]),
+        to: None,
+        contract_address: None,
+    }
+}
+
+fn mk_rpc_transaction(
+    tx: TxEnvelope,
+    from: Address,
+    block_number: u64,
+) -> alloy::rpc::types::Transaction {
+    alloy::rpc::types::Transaction {
+        inner: alloy::consensus::transaction::Recovered::new_unchecked(tx, from),
+        block_hash: Some(B256::from([2; 32])),
+        block_number: Some(block_number),
+        transaction_index: Some(0),
+        effective_gas_price: Some(0),
+    }
+}
+
+fn mk_completion_provider(
+    wallet: Address,
+    block_hash: B256,
+    block_number: u64,
+    stored_result: &ContractCallResult,
+) -> impl Provider + WalletProvider + 'static {
+    let asserter = Asserter::new();
+    // The other wallet's nonce is scanned first and is not on L1.
+    asserter.push_failure(alloy::rpc::json_rpc::ErrorPayload {
+        code: -32001,
+        message: "not found".into(),
+        data: None,
+    });
+    // The winning nonce replays settlement checks against L1.
+    asserter.push_success(&mk_rpc_transaction(mk_tx(60), wallet, block_number));
+    asserter.push_success(&mk_rpc_receipt(
+        stored_result.tx_hash,
+        block_hash,
+        block_number,
+    ));
+    asserter.push_success(&mk_rpc_block(1_000, B256::from([1; 32])));
+    asserter.push_success(&mk_rpc_receipt(
+        stored_result.tx_hash,
+        block_hash,
+        block_number,
+    ));
+    asserter.push_success(&mk_rpc_block(block_number, block_hash));
+    ProviderBuilder::new()
+        .wallet(EthereumWallet::from(test_signer()))
+        .connect_mocked_client(asserter)
+}
+
+/// End-to-end guard for #1480: a spawned task that reaches `Completed` must
+/// drop its service-level watcher registration once the run loop exits.
+#[tokio::test]
+async fn spawn_clears_result_watchers_after_task_completes() {
+    let job_id = mk_job_id(14);
+    let job = mk_job(14);
+    let wallet = Address::from([4; 20]);
+    let other_wallet = Address::from([3; 20]);
+    let nonce = Nonce(11);
+    let other_nonce = Nonce(12);
+    let block_hash = B256::from([7; 32]);
+    let block_number = 10;
+    let stored_result = ContractCallResult {
+        outcome: ContractCallOutcome::Success,
+        metadata: Default::default(),
+        block_hash,
+        block_number,
+        tx_hash: mk_tx_hash(60),
+    };
+    let winning_attempt = SettlementAttempt {
+        sender_wallet: wallet.into(),
+        nonce,
+        hash: stored_result.tx_hash,
+        submission_time: SystemTime::UNIX_EPOCH,
+        max_fee_per_gas: 0,
+        max_priority_fee_per_gas: 0,
+    };
+    let sibling_attempt = SettlementAttempt {
+        sender_wallet: wallet.into(),
+        nonce,
+        hash: mk_tx_hash(70),
+        submission_time: SystemTime::UNIX_EPOCH,
+        max_fee_per_gas: 0,
+        max_priority_fee_per_gas: 0,
+    };
+    let other_attempt = SettlementAttempt {
+        sender_wallet: other_wallet.into(),
+        nonce: other_nonce,
+        hash: mk_tx_hash(80),
+        submission_time: SystemTime::UNIX_EPOCH,
+        max_fee_per_gas: 0,
+        max_priority_fee_per_gas: 0,
+    };
+    let attempt_result = SettlementAttemptResult::ContractCall(stored_result.clone());
+
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job)));
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(|_| Ok(None));
+    store
+        .expect_list_settlement_attempt_results()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once({
+            let attempt_result = attempt_result.clone();
+            move |_| Ok(vec![(1, attempt_result.clone())])
+        });
+    store
+        .expect_list_settlement_attempts()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| {
+            Ok(vec![
+                (1, winning_attempt.clone()),
+                (2, sibling_attempt.clone()),
+                (3, other_attempt.clone()),
+            ])
+        });
+    store
+        .expect_record_settlement_attempt_result()
+        .times(2)
+        .returning(|_, _, _| Ok(()));
+    store
+        .expect_insert_settlement_job_result()
+        .once()
+        .returning(|_, _| Ok(()));
+
+    let store = Arc::new(store);
+    let provider = mk_completion_provider(wallet, block_hash, block_number, &stored_result);
+    let service = SettlementService::start(
+        SettlementServiceConfig::default(),
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(provider),
+        store.clone(),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("settlement service should start")
+    .0;
+
+    let (task_control_handle, task_control) = TaskControlHandle::new(&service.cancellation_token);
+    let task = match SettlementTask::load(
+        job_id,
+        service.tx_config.clone(),
+        service.provider.clone(),
+        service.store.clone(),
+        service.wallet_nonce_locks.clone(),
+        task_control,
+    )
+    .await
+    .expect("settlement task should load")
+    {
+        StoredSettlementJob::Pending(task) => task,
+        StoredSettlementJob::Completed(_) => panic!("initial load should be pending"),
+    };
+
+    assert!(service.result_watchers.lock().await.is_empty());
+    let mut result_receiver = service
+        .spawn_settlement_task(job_id, task, task_control_handle)
+        .await;
+    assert!(service.result_watchers.lock().await.contains_key(&job_id));
+
+    result_receiver
+        .changed()
+        .await
+        .expect("spawned task should publish a terminal result");
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while !service.result_watchers.lock().await.is_empty() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("result_watchers should be cleared after task completion");
+    assert!(
+        service
+            .task_controls
+            .lock()
+            .expect("settlement task_controls lock poisoned")
+            .is_empty()
+    );
+    assert_eq!(
+        result_receiver.borrow().as_ref(),
+        Some(&SettlementJobResult {
+            wallet: wallet.into(),
+            nonce,
+            attempt_number: SettlementAttemptNumber(1),
+            contract_call_result: stored_result,
+        })
+    );
+}

--- a/crates/agglayer-settlement-service/src/settlement_service/tests/spawn_to_completed.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service/tests/spawn_to_completed.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::{Duration, SystemTime}};
+use std::{sync::Arc, time::SystemTime};
 
 use agglayer_types::{
     ContractCallOutcome, ContractCallResult, Digest, Nonce, SettlementAttempt,
@@ -122,8 +122,8 @@ fn mk_completion_provider(
         .connect_mocked_client(asserter)
 }
 
-/// End-to-end guard for #1480: a spawned task that reaches `Completed` must
-/// drop its service-level watcher registration once the run loop exits.
+/// Regression test for issue 1480: a spawned task that reaches `Completed`
+/// must drop both in-memory registrations once the run loop exits.
 #[tokio::test]
 async fn spawn_clears_result_watchers_after_task_completes() {
     let job_id = mk_job_id(14);
@@ -236,31 +236,38 @@ async fn spawn_clears_result_watchers_after_task_completes() {
         StoredSettlementJob::Completed(_) => panic!("initial load should be pending"),
     };
 
-    assert!(service.result_watchers.lock().await.is_empty());
+    assert!(service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .is_empty());
     let mut result_receiver = service
         .spawn_settlement_task(job_id, task, task_control_handle)
         .await;
-    assert!(service.result_watchers.lock().await.contains_key(&job_id));
+    assert!(service
+        .result_watchers
+        .lock()
+        .expect("settlement result_watchers lock poisoned")
+        .contains_key(&job_id));
 
     result_receiver
         .changed()
         .await
         .expect("spawned task should publish a terminal result");
 
-    tokio::time::timeout(Duration::from_secs(10), async {
-        while !service.result_watchers.lock().await.is_empty() {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("result_watchers should be cleared after task completion");
-    assert!(
+    wait_until(|| {
         service
-            .task_controls
+            .result_watchers
             .lock()
-            .expect("settlement task_controls lock poisoned")
+            .expect("settlement result_watchers lock poisoned")
             .is_empty()
-    );
+    })
+    .await;
+    assert!(service
+        .task_controls
+        .lock()
+        .expect("settlement task_controls lock poisoned")
+        .is_empty());
     assert_eq!(
         result_receiver.borrow().as_ref(),
         Some(&SettlementJobResult {


### PR DESCRIPTION
Fixes #1480

## Summary

- Remove `result_watchers` entries when a spawned settlement task exits (Completed, Cancelled, reload-error, reload-to-completed, panic), fixing unbounded in-memory growth on the normal completion path.
- Use a unified **`TaskRegistrationGuard`** for synchronous RAII teardown of both `result_watchers` and `task_controls` when the spawn loop exits — no async cleanup from `Drop`.
- Drop order is **watcher first, then control**, so `admin_reloadSettlementTask` cannot respawn while a control entry still exists; this eliminates the stale-teardown race where delayed cleanup could delete a respawned task after panic (per review feedback).
- Callers are notified via their cloned `watch::Receiver` before cleanup; `retrieve_settlement_result` falls back to RocksDB once the in-memory entry is gone.

## Tests

- `cargo nextest run -p agglayer-settlement-service settlement_service::tests`
- `cargo clippy -p agglayer-settlement-service --tests -- -D warnings`
- `cargo +nightly fmt --all --check`

Added coverage:
- `task_registration_guard_clears_watcher_then_control_on_drop` — sync RAII teardown
- `retrieve_uses_storage_after_active_tracking_cleanup` — storage fallback after map cleanup
- `caller_watcher_retains_result_after_active_tracking_cleanup` — cloned receiver contract
- `spawn_clears_result_watchers_after_task_completes` — spawn → Completed → both maps empty
- `reload_and_restart_clears_registrations_when_reload_finds_completed_job` — reload-to-completed also clears maps
- `panicked_task_reload_respawns_task_without_stale_teardown` — panic → admin reload → respawned task stays live