### PR TITLE
ci: skip merge queue docker cache export

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -86,7 +86,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           outputs: ${{ inputs.push == true && 'type=image' || format('type=docker,dest={0}/{1}.tar', inputs.local-artifact-dir, inputs.local-artifact-name) }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Keep merge queue/local artifact builds cache-read-only; cache export is
+          # expensive and blocks the E2E required check.
+          cache-to: ${{ inputs.push == true && 'type=gha,mode=max' || '' }}
 
       - name: Upload artifact
         if: inputs.push == false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,14 +101,14 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: agglayer/e2e/.github/workflows/agglayer-node-e2e.yml@a2a90439583b62a7dcabcda915c72193e57ec6e7 # 2026-03-20
+    uses: agglayer/e2e/.github/workflows/agglayer-node-e2e.yml@8763263b4c6bf61fd83d205a6fc0080c6e82b1e4 # 2026-03-20
     secrets: inherit
     with:
       docker-image-override: agglayer_image
       docker-tag: ${{ needs.docker-build-local.outputs.tags }}
       kurtosis-cdk-ref: 6f5c0f0cd2cce5cf11a025aade73b13664df8007 # 2026-03-18
       docker-artifact-name: ${{ github.event_name == 'merge_group' && 'docker-image' || '' }}
-      agglayer-e2e-ref: a2a90439583b62a7dcabcda915c72193e57ec6e7 # 2026-03-20
+      agglayer-e2e-ref: 8763263b4c6bf61fd83d205a6fc0080c6e82b1e4 # 2026-04-27
       kurtosis-cdk-args: |
         {
           "deployment_stages": {


### PR DESCRIPTION
Keep merge-queue Docker artifact builds cache-read-only.

This avoids exporting Buildx cache while the required E2E path is
blocking the merge queue.

Push and image-publishing builds still write cache for future runs.

Verified with:
- cargo make blast-radius
- cargo check --workspace --tests --all-features
- git diff --check