### PR TITLE
fix(settlement): assign nonces from local queue

### DIFF
--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -82,6 +82,8 @@ fn bump_fee(
 enum BuildAttemptError {
     #[error("L1 RPC error while building settlement attempt: {0}")]
     Transport(#[from] TransportError),
+    #[error("failed to assign settlement nonce: {0}")]
+    NonceAssignment(eyre::Error),
     #[error("failed to build or sign settlement transaction: {0}")]
     Build(#[from] TransactionBuilderError<Ethereum>),
 }
@@ -126,6 +128,7 @@ impl BuildRetryPolicy {
                 self.signer_failures += 1;
                 self.signer_failures <= Self::MAX_SIGNER_BUILD_RETRIES
             }
+            BuildAttemptError::NonceAssignment(_) => false,
             BuildAttemptError::Build(_) => false,
         }
     }
@@ -881,6 +884,37 @@ impl<
         .await
     }
 
+    async fn assign_next_nonce_for_wallet(
+        &self,
+        wallet: Address,
+    ) -> Result<Nonce, BuildAttemptError> {
+        let l1_nonce = Nonce(
+            self.provider
+                .get_transaction_count(wallet)
+                .pending()
+                .await?,
+        );
+
+        let Some(max_local_nonce) = self
+            .store
+            .max_settlement_nonce_for_wallet(wallet.into())
+            .wrap_err_with(|| {
+                format!("Failed to inspect recorded settlement attempts for wallet {wallet}")
+            })
+            .map_err(BuildAttemptError::NonceAssignment)?
+        else {
+            return Ok(l1_nonce);
+        };
+
+        let next_local_nonce = Nonce(max_local_nonce.0.checked_add(1).ok_or_else(|| {
+            BuildAttemptError::NonceAssignment(eyre::eyre!(
+                "Unable to assign settlement nonce for wallet {wallet}: nonce overflow"
+            ))
+        })?);
+
+        Ok(l1_nonce.max(next_local_nonce))
+    }
+
     /// Polls an L1 settlement check until it yields a terminal answer, retrying
     /// transient "not ready yet" signals with the not-included backoff. The
     /// inner check returns `Ok(None)` to report a reorg, which the caller turns
@@ -1318,18 +1352,23 @@ impl<
                 // These three L1 reads are independent, so fetch them
                 // concurrently to keep each (retried) build to one round-trip.
                 let (nonce, chain_id, estimate) = tokio::try_join!(
-                    self.provider
-                        .get_transaction_count(wallet)
-                        .pending()
-                        .into_future(),
-                    self.provider.get_chain_id().into_future(),
-                    self.provider.estimate_eip1559_fees().into_future(),
+                    self.assign_next_nonce_for_wallet(wallet),
+                    async {
+                        self.provider
+                            .get_chain_id()
+                            .await
+                            .map_err(BuildAttemptError::from)
+                    },
+                    async {
+                        self.provider
+                            .estimate_eip1559_fees()
+                            .await
+                            .map_err(BuildAttemptError::from)
+                    },
                 )?;
                 let gas = self.resolve_base_gas_params(&estimate);
-                let tx = self
-                    .build_attempt(wallet, Nonce(nonce), chain_id, gas)
-                    .await?;
-                Ok((wallet, Nonce(nonce), attempt_number, tx))
+                let tx = self.build_attempt(wallet, nonce, chain_id, gas).await?;
+                Ok((wallet, nonce, attempt_number, tx))
             },
             |error| retry_policy.should_retry(error),
         )
@@ -1646,8 +1685,8 @@ mod tests {
         consensus::{Signed, TxEip1559},
         network::EthereumWallet,
         node_bindings::Anvil,
-        primitives::{Signature, TxKind},
-        providers::ProviderBuilder,
+        primitives::{Signature, TxKind, U64},
+        providers::{mock::Asserter, ProviderBuilder},
         rpc::types::TransactionRequest,
         signers::local::PrivateKeySigner,
         transports::TransportErrorKind,
@@ -1779,18 +1818,35 @@ mod tests {
         store: Arc<MockStateStore>,
         attempts: ActiveSettlementAttempts,
     ) -> SettlementTask<impl Provider + WalletProvider + 'static, MockStateStore> {
+        mk_task_with_id_and_provider(job_id, mk_provider(), store, attempts)
+    }
+
+    fn mk_task_with_provider<L1Provider: Provider + WalletProvider + 'static>(
+        provider: L1Provider,
+        store: Arc<MockStateStore>,
+        attempts: ActiveSettlementAttempts,
+    ) -> SettlementTask<L1Provider, MockStateStore> {
+        mk_task_with_id_and_provider(SettlementJobId::from(1u128), provider, store, attempts)
+    }
+
+    fn mk_task_with_id_and_provider<L1Provider: Provider + WalletProvider + 'static>(
+        job_id: SettlementJobId,
+        provider: L1Provider,
+        store: Arc<MockStateStore>,
+        attempts: ActiveSettlementAttempts,
+    ) -> SettlementTask<L1Provider, MockStateStore> {
         SettlementTask {
             id: job_id,
             job: mk_job(),
             tx_config: Arc::new(SettlementTransactionConfig::default()),
-            provider: Arc::new(mk_provider()),
+            provider: Arc::new(provider),
             store,
             control: mk_control(),
             attempts,
         }
     }
 
-    fn mk_task_with_provider<P: Provider + WalletProvider + 'static>(
+    fn mk_task_with_tx_config<P: Provider + WalletProvider + 'static>(
         provider: P,
         tx_config: SettlementTransactionConfig,
     ) -> SettlementTask<P, MockStateStore> {
@@ -1829,6 +1885,14 @@ mod tests {
         )]);
         let task = mk_task(store, attempts);
         assert_eq!(task.next_attempt_number(), SettlementAttemptNumber(6));
+    }
+
+    fn mk_mock_provider_with_pending_nonce(nonce: u64) -> impl Provider + WalletProvider + 'static {
+        let asserter = Asserter::new();
+        asserter.push_success(&U64::from(nonce));
+        ProviderBuilder::new()
+            .wallet(EthereumWallet::from(test_signer()))
+            .connect_mocked_client(asserter)
     }
 
     async fn load_job_from_store<L1Provider: Provider + WalletProvider + 'static>(
@@ -2120,6 +2184,81 @@ mod tests {
                 panic!("completed settlement job should not reload as pending")
             }
         }
+    }
+
+    #[tokio::test]
+    async fn assign_next_nonce_for_wallet_uses_l1_pending_nonce_when_queue_is_empty() {
+        let wallet = Address::from([9; 20]);
+        let expected_wallet: agglayer_types::Address = wallet.into();
+        let mut store = MockStateStore::new();
+        store
+            .expect_max_settlement_nonce_for_wallet()
+            .once()
+            .withf(move |recorded_wallet| *recorded_wallet == expected_wallet)
+            .return_once(|_| Ok(None));
+
+        let task = mk_task_with_provider(
+            mk_mock_provider_with_pending_nonce(5),
+            Arc::new(store),
+            BTreeMap::new(),
+        );
+
+        let nonce = task
+            .assign_next_nonce_for_wallet(wallet)
+            .await
+            .expect("nonce assignment should succeed");
+
+        assert_eq!(nonce, Nonce(5));
+    }
+
+    #[tokio::test]
+    async fn assign_next_nonce_for_wallet_uses_next_local_nonce_when_queue_is_ahead_of_l1() {
+        let wallet = Address::from([10; 20]);
+        let expected_wallet: agglayer_types::Address = wallet.into();
+        let mut store = MockStateStore::new();
+        store
+            .expect_max_settlement_nonce_for_wallet()
+            .once()
+            .withf(move |recorded_wallet| *recorded_wallet == expected_wallet)
+            .return_once(|_| Ok(Some(Nonce(6))));
+
+        let task = mk_task_with_provider(
+            mk_mock_provider_with_pending_nonce(5),
+            Arc::new(store),
+            BTreeMap::new(),
+        );
+
+        let nonce = task
+            .assign_next_nonce_for_wallet(wallet)
+            .await
+            .expect("nonce assignment should succeed");
+
+        assert_eq!(nonce, Nonce(7));
+    }
+
+    #[tokio::test]
+    async fn assign_next_nonce_for_wallet_uses_l1_pending_nonce_when_l1_is_ahead_of_queue() {
+        let wallet = Address::from([11; 20]);
+        let expected_wallet: agglayer_types::Address = wallet.into();
+        let mut store = MockStateStore::new();
+        store
+            .expect_max_settlement_nonce_for_wallet()
+            .once()
+            .withf(move |recorded_wallet| *recorded_wallet == expected_wallet)
+            .return_once(|_| Ok(Some(Nonce(6))));
+
+        let task = mk_task_with_provider(
+            mk_mock_provider_with_pending_nonce(9),
+            Arc::new(store),
+            BTreeMap::new(),
+        );
+
+        let nonce = task
+            .assign_next_nonce_for_wallet(wallet)
+            .await
+            .expect("nonce assignment should succeed");
+
+        assert_eq!(nonce, Nonce(9));
     }
 
     #[tokio::test]
@@ -2522,7 +2661,7 @@ mod tests {
         // The zero address sorts first and is never mined, so the wait must skip it
         // and still resolve on the mined (sender, Nonce(0)).
         let pending = BTreeSet::from([(Address::ZERO, Nonce(0)), (sender, Nonce(0))]);
-        let task = mk_task_with_provider(provider, SettlementTransactionConfig::default());
+        let task = mk_task_with_tx_config(provider, SettlementTransactionConfig::default());
 
         tokio::time::timeout(
             Duration::from_secs(5),
@@ -2545,7 +2684,7 @@ mod tests {
         tx_config.retry_on_not_included_on_l1.initial_interval = Duration::from_secs(3600);
 
         let pending = BTreeSet::from([(sender, Nonce(5))]);
-        let task = mk_task_with_provider(provider, tx_config);
+        let task = mk_task_with_tx_config(provider, tx_config);
 
         assert!(tokio::time::timeout(
             Duration::from_millis(300),
@@ -2569,7 +2708,7 @@ mod tests {
             .expect("get receipt");
         let tx_hash = SettlementTxHash::from(receipt.transaction_hash);
 
-        let task = mk_task_with_provider(provider, SettlementTransactionConfig::default());
+        let task = mk_task_with_tx_config(provider, SettlementTransactionConfig::default());
         let result = task
             .current_result_once(sender, Nonce(0), tx_hash)
             .await
@@ -2597,7 +2736,7 @@ mod tests {
             .expect("send transaction");
         let tx_hash = SettlementTxHash::from(*pending.tx_hash());
 
-        let task = mk_task_with_provider(provider, SettlementTransactionConfig::default());
+        let task = mk_task_with_tx_config(provider, SettlementTransactionConfig::default());
         let result = task
             .current_result_once(sender, Nonce(0), tx_hash)
             .await
@@ -2960,7 +3099,7 @@ mod tests {
         // `Error::message` produces an opaque `Error::Other`, mirroring how a
         // remote signer backend (e.g. GCP KMS) surfaces a signing failure.
         let signer_failure = || {
-            BuildAttemptError::Build(TransactionBuilderError::Signer(
+            BuildAttemptError::from(TransactionBuilderError::Signer(
                 alloy::signers::Error::message("remote signer failure"),
             ))
         };
@@ -2975,7 +3114,7 @@ mod tests {
 
         // A structural build error is never recoverable by retrying.
         let mut policy = BuildRetryPolicy::new();
-        assert!(!policy.should_retry(&BuildAttemptError::Build(
+        assert!(!policy.should_retry(&BuildAttemptError::from(
             TransactionBuilderError::UnsupportedSignatureType
         )));
     }
@@ -3011,7 +3150,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_next_attempt_with_new_nonce_uses_pending_nonce_and_default_wallet() {
+    async fn build_next_attempt_with_new_nonce_uses_assigned_nonce_and_default_wallet() {
         use alloy::{
             consensus::Transaction as _, node_bindings::Anvil, providers::ProviderBuilder,
             rpc::types::TransactionRequest,
@@ -3038,12 +3177,20 @@ mod tests {
                 .unwrap();
         }
 
+        let expected_wallet: agglayer_types::Address = wallet_address.into();
+        let mut store = MockStateStore::new();
+        store
+            .expect_max_settlement_nonce_for_wallet()
+            .once()
+            .withf(move |recorded_wallet| *recorded_wallet == expected_wallet)
+            .return_once(|_| Ok(Some(Nonce(6))));
+
         let task = SettlementTask {
             id: mk_job_id(1),
             job: mk_job(),
             tx_config: Arc::new(SettlementTransactionConfig::default()),
             provider: Arc::new(provider),
-            store: Arc::new(MockStateStore::new()),
+            store: Arc::new(store),
             control: mk_control(),
             attempts: BTreeMap::new(),
         };
@@ -3054,9 +3201,9 @@ mod tests {
             .expect("attempt should build");
 
         assert_eq!(used_wallet, wallet_address);
-        assert_eq!(nonce, Nonce(2));
+        assert_eq!(nonce, Nonce(7));
         assert_eq!(attempt_number, SettlementAttemptNumber(0));
-        assert_eq!(envelope.nonce(), 2);
+        assert_eq!(envelope.nonce(), 7);
         assert_eq!(envelope.to(), Some(mk_job().contract_address.into_alloy()));
         assert_eq!(envelope.chain_id(), Some(anvil.chain_id()));
         // Fees are within the configured bounds (defaults: floor 0, ceiling 100 gwei).

--- a/crates/agglayer-storage/src/columns/mod.rs
+++ b/crates/agglayer-storage/src/columns/mod.rs
@@ -53,7 +53,7 @@ pub const SETTLEMENT_ATTEMPT_RESULTS_COLUMN_OPTIONS: ColumnOptions = ColumnOptio
 pub const SETTLEMENT_ATTEMPT_PER_WALLET_COLUMN_OPTIONS: ColumnOptions = ColumnOptions {
     compression: crate::schema::options::ColumnCompressionType::Lz4,
     prefix_extractor: crate::schema::options::PrefixExtractor::Fixed {
-        size: crate::types::settlement::attempt_per_wallet::Key::PREFIX_LEN,
+        size: crate::types::settlement::attempt_per_wallet::Key::WALLET_PREFIX_LEN,
     },
 };
 

--- a/crates/agglayer-storage/src/schema/codec.rs
+++ b/crates/agglayer-storage/src/schema/codec.rs
@@ -51,6 +51,18 @@ pub trait Codec: Sized {
     fn decode(buf: &[u8]) -> Result<Self, CodecError>;
 }
 
+impl<const N: usize> Codec for [u8; N] {
+    fn encode_into<W: io::Write>(&self, mut writer: W) -> Result<(), CodecError> {
+        writer.write_all(self)?;
+
+        Ok(())
+    }
+
+    fn decode(buf: &[u8]) -> Result<Self, CodecError> {
+        crate::schema::fixed_bytes::<N>(buf, "fixed byte array")
+    }
+}
+
 macro_rules! impl_codec_using_bincode_for {
     ($($type:ty),* $(,)?) => {
         $(

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -2,8 +2,9 @@ use std::path::Path;
 
 use iterators::{ColumnIterator, KeysIterator};
 use rocksdb::{
-    ColumnFamily, ColumnFamilyDescriptor, DBCompressionType, DBPinnableSlice, Direction, Options,
-    ReadOptions, SliceTransform, WriteBatch, WriteOptions,
+    ColumnFamily, ColumnFamilyDescriptor, DBCompressionType, DBPinnableSlice, Direction,
+    IterateBounds as _, IteratorMode, Options, PrefixRange, ReadOptions, SliceTransform,
+    WriteBatch, WriteOptions,
 };
 
 use crate::schema::{
@@ -241,6 +242,29 @@ impl DB {
         let iterator = self.rocksdb.prefix_iterator_cf(&cf, prefix).into();
 
         Ok(ColumnIterator::new(iterator, Direction::Forward))
+    }
+
+    pub(crate) fn prefix_iterator_with_direction<C: ColumnSchema, P: Codec>(
+        &self,
+        prefix: &P,
+        direction: Direction,
+    ) -> Result<ColumnIterator<'_, C>, DBError> {
+        let cf = self.cf::<C>()?;
+        let prefix = prefix.encode()?;
+        let (_lower_bound, upper_bound) = PrefixRange(prefix.clone()).into_bounds();
+        let mode = match (direction, upper_bound.as_deref()) {
+            (Direction::Forward, _) => IteratorMode::From(&prefix, Direction::Forward),
+            (Direction::Reverse, Some(upper_bound)) => {
+                IteratorMode::From(upper_bound, Direction::Reverse)
+            }
+            (Direction::Reverse, None) => IteratorMode::End,
+        };
+
+        let mut read_options = ReadOptions::default();
+        read_options.set_iterate_range(PrefixRange(prefix.clone()));
+        let iterator = self.rocksdb.iterator_cf_opt(&cf, read_options, mode).into();
+
+        Ok(ColumnIterator::new(iterator, direction))
     }
 
     pub(crate) fn delete<C: ColumnSchema>(&self, key: &C::Key) -> Result<(), DBError> {

--- a/crates/agglayer-storage/src/stores/interfaces/reader/settlement_reader.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/reader/settlement_reader.rs
@@ -1,5 +1,6 @@
 use agglayer_types::{
-    SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobId, SettlementJobResult,
+    Address, Nonce, SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobId,
+    SettlementJobResult,
 };
 
 use crate::error::Error;
@@ -35,4 +36,7 @@ pub trait SettlementReader: Send + Sync {
         &self,
         settlement_job_id: &SettlementJobId,
     ) -> Result<Vec<(u64, SettlementAttemptResult)>, Error>;
+
+    /// Returns the highest settlement attempt nonce recorded for `wallet`.
+    fn max_settlement_nonce_for_wallet(&self, wallet: Address) -> Result<Option<Nonce>, Error>;
 }

--- a/crates/agglayer-storage/src/stores/state/settlement/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/settlement/mod.rs
@@ -1,7 +1,8 @@
 use agglayer_types::{
-    SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobId, SettlementJobResult,
+    Address, Nonce, SettlementAttempt, SettlementAttemptResult, SettlementJob, SettlementJobId,
+    SettlementJobResult,
 };
-use rocksdb::WriteBatch;
+use rocksdb::{Direction, WriteBatch};
 
 use super::StateStore;
 use crate::{
@@ -108,6 +109,19 @@ impl SettlementReader for StateStore {
                 ))
             })
             .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn max_settlement_nonce_for_wallet(&self, wallet: Address) -> Result<Option<Nonce>, Error> {
+        let prefix = wallet.into_array();
+        Ok(self
+            .db
+            .prefix_iterator_with_direction::<SettlementAttemptPerWalletColumn, _>(
+                &prefix,
+                Direction::Reverse,
+            )?
+            .next()
+            .transpose()?
+            .map(|(key, _)| Nonce(key.nonce)))
     }
 }
 

--- a/crates/agglayer-storage/src/stores/state/tests/settlement.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/settlement.rs
@@ -416,6 +416,73 @@ fn insert_settlement_attempt_indexes_by_wallet_and_nonce() {
 }
 
 #[test]
+fn max_settlement_nonce_for_wallet_returns_highest_indexed_nonce() {
+    let (_tmp, _db, store) = setup_store();
+    let job_id = mk_job_id(407);
+    let other_job_id = mk_job_id(408);
+    let wallet = Address::from([10; 20]);
+    let max_wallet = Address::from([0xff; 20]);
+    let other_wallet = Address::from([11; 20]);
+    let mut lower_nonce_attempt = mk_settlement_attempt(1);
+    let mut higher_nonce_attempt = mk_settlement_attempt(2);
+    let mut other_wallet_attempt = mk_settlement_attempt(3);
+    let mut max_wallet_lower_nonce_attempt = mk_settlement_attempt(4);
+    let mut max_wallet_higher_nonce_attempt = mk_settlement_attempt(5);
+
+    lower_nonce_attempt.sender_wallet = wallet;
+    lower_nonce_attempt.nonce = Nonce(12);
+    higher_nonce_attempt.sender_wallet = wallet;
+    higher_nonce_attempt.nonce = Nonce(14);
+    other_wallet_attempt.sender_wallet = other_wallet;
+    other_wallet_attempt.nonce = Nonce(99);
+    max_wallet_lower_nonce_attempt.sender_wallet = max_wallet;
+    max_wallet_lower_nonce_attempt.nonce = Nonce(7);
+    max_wallet_higher_nonce_attempt.sender_wallet = max_wallet;
+    max_wallet_higher_nonce_attempt.nonce = Nonce(8);
+
+    store
+        .insert_settlement_job(&job_id, &mk_settlement_job(42))
+        .expect("first job insert must succeed");
+    store
+        .insert_settlement_job(&other_job_id, &mk_settlement_job(43))
+        .expect("second job insert must succeed");
+    store
+        .insert_settlement_attempt(&job_id, 1, &lower_nonce_attempt)
+        .expect("lower nonce attempt insert must succeed");
+    store
+        .insert_settlement_attempt(&job_id, 2, &higher_nonce_attempt)
+        .expect("higher nonce attempt insert must succeed");
+    store
+        .insert_settlement_attempt(&other_job_id, 1, &other_wallet_attempt)
+        .expect("other-wallet attempt insert must succeed");
+    store
+        .insert_settlement_attempt(&job_id, 3, &max_wallet_lower_nonce_attempt)
+        .expect("max-wallet lower nonce attempt insert must succeed");
+    store
+        .insert_settlement_attempt(&job_id, 4, &max_wallet_higher_nonce_attempt)
+        .expect("max-wallet higher nonce attempt insert must succeed");
+
+    assert_eq!(
+        store
+            .max_settlement_nonce_for_wallet(wallet)
+            .expect("max nonce lookup must succeed"),
+        Some(Nonce(14))
+    );
+    assert_eq!(
+        store
+            .max_settlement_nonce_for_wallet(max_wallet)
+            .expect("max wallet lookup must succeed"),
+        Some(Nonce(8))
+    );
+    assert_eq!(
+        store
+            .max_settlement_nonce_for_wallet(Address::from([12; 20]))
+            .expect("missing wallet lookup must succeed"),
+        None
+    );
+}
+
+#[test]
 fn get_settlement_job_returns_none_when_missing() {
     let (_tmp, _db, store) = setup_store();
     assert_eq!(

--- a/crates/agglayer-storage/src/tests/mocks/state_store.rs
+++ b/crates/agglayer-storage/src/tests/mocks/state_store.rs
@@ -1,6 +1,6 @@
 use agglayer_types::{
-    primitives::Digest, Certificate, CertificateHeader, CertificateId, CertificateStatus,
-    EpochNumber, Height, LocalNetworkStateData, NetworkId, SettlementAttempt,
+    primitives::Digest, Address, Certificate, CertificateHeader, CertificateId, CertificateStatus,
+    EpochNumber, Height, LocalNetworkStateData, NetworkId, Nonce, SettlementAttempt,
     SettlementAttemptResult, SettlementJob, SettlementJobId, SettlementJobResult, SettlementTxHash,
 };
 use mockall::mock;
@@ -152,6 +152,11 @@ mock! {
             &self,
             settlement_job_id: &SettlementJobId,
         ) -> Result<Vec<(u64, SettlementAttemptResult)>, Error>;
+
+        fn max_settlement_nonce_for_wallet(
+            &self,
+            wallet: Address,
+        ) -> Result<Option<Nonce>, Error>;
     }
 
     impl SettlementWriter for StateStore {

--- a/crates/agglayer-storage/src/types/settlement/attempt_per_wallet.rs
+++ b/crates/agglayer-storage/src/types/settlement/attempt_per_wallet.rs
@@ -17,9 +17,11 @@ pub struct Key {
 
 impl Key {
     pub(crate) const ADDRESS_LEN: usize = ADDRESS_LEN;
-    pub(crate) const PREFIX_LEN: usize = Self::ADDRESS_LEN + crate::schema::U64_LEN;
-    pub(crate) const LEN: usize =
-        Self::PREFIX_LEN + SettlementJobId::BYTE_LEN + crate::schema::U64_LEN;
+    pub(crate) const WALLET_PREFIX_LEN: usize = Self::ADDRESS_LEN;
+    pub(crate) const LEN: usize = Self::ADDRESS_LEN
+        + crate::schema::U64_LEN
+        + SettlementJobId::BYTE_LEN
+        + crate::schema::U64_LEN;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Use the highest locally queued settlement nonce for a wallet when building a fresh attempt, so recovery and restart paths do not reuse a nonce that is already reserved in storage.

Store the wallet nonce index with a wallet-only prefix to support reverse prefix scans for the local maximum.

Fixes #1231