### PR TITLE
feat(observability): instrument storage and runtime for stall detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,7 @@ dependencies = [
  "agglayer-interop-types 0.13.0",
  "agglayer-sp1",
  "agglayer-storage",
+ "agglayer-telemetry 0.1.0",
  "agglayer-tries 0.18.0",
  "agglayer-types",
  "alloy-primitives",

--- a/crates/agglayer-config/src/telemetry.rs
+++ b/crates/agglayer-config/src/telemetry.rs
@@ -1,9 +1,11 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use super::DEFAULT_IP;
 
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct TelemetryConfig {
@@ -13,16 +15,49 @@ pub struct TelemetryConfig {
         default = "default_metrics_api_addr"
     )]
     pub addr: SocketAddr,
+
+    /// Duration above which a synchronous RocksDB operation is recorded as slow
+    /// (and may be blocking a Tokio worker thread).
+    #[serde_as(as = "crate::with::HumanDuration")]
+    #[serde(default = "default_slow_storage_op_threshold")]
+    pub slow_storage_op_threshold: Duration,
+
+    /// Interval at which the runtime scheduler-lag probe samples its timer.
+    #[serde_as(as = "crate::with::HumanDuration")]
+    #[serde(default = "default_scheduler_lag_probe_interval")]
+    pub scheduler_lag_probe_interval: Duration,
+
+    /// Scheduler lag above which a WARN is emitted. On an otherwise idle node
+    /// this indicates worker threads were blocked long enough to delay
+    /// unrelated work.
+    #[serde_as(as = "crate::with::HumanDuration")]
+    #[serde(default = "default_scheduler_lag_warn_threshold")]
+    pub scheduler_lag_warn_threshold: Duration,
 }
 
 impl Default for TelemetryConfig {
     fn default() -> Self {
         Self {
             addr: default_metrics_api_addr(),
+            slow_storage_op_threshold: default_slow_storage_op_threshold(),
+            scheduler_lag_probe_interval: default_scheduler_lag_probe_interval(),
+            scheduler_lag_warn_threshold: default_scheduler_lag_warn_threshold(),
         }
     }
 }
 
 const fn default_metrics_api_addr() -> SocketAddr {
     SocketAddr::V4(std::net::SocketAddrV4::new(DEFAULT_IP, 3000))
+}
+
+const fn default_slow_storage_op_threshold() -> Duration {
+    Duration::from_millis(25)
+}
+
+const fn default_scheduler_lag_probe_interval() -> Duration {
+    Duration::from_millis(500)
+}
+
+const fn default_scheduler_lag_warn_threshold() -> Duration {
+    Duration::from_millis(100)
 }

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_distinct_pp_and_tx_settlement_keys_are_preserved.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_distinct_pp_and_tx_settlement_keys_are_preserved.snap
@@ -65,6 +65,9 @@ tx-settlement-key-version = 22
 
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
+slow-storage-op-threshold = "25ms"
+scheduler-lag-probe-interval = "500ms"
+scheduler-lag-warn-threshold = "100ms"
 
 [epoch.block-clock]
 epoch-duration = 6

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_legacy.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_legacy.snap
@@ -65,6 +65,9 @@ tx-settlement-key-version = 2
 
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
+slow-storage-op-threshold = "25ms"
+scheduler-lag-probe-interval = "500ms"
+scheduler-lag-warn-threshold = "100ms"
 
 [epoch.block-clock]
 epoch-duration = 6

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_transition.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_transition.snap
@@ -65,6 +65,9 @@ tx-settlement-key-version = 4
 
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
+slow-storage-op-threshold = "25ms"
+scheduler-lag-probe-interval = "500ms"
+scheduler-lag-warn-threshold = "100ms"
 
 [epoch.block-clock]
 epoch-duration = 6

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_update.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_update.snap
@@ -65,6 +65,9 @@ tx-settlement-key-version = 4
 
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
+slow-storage-op-threshold = "25ms"
+scheduler-lag-probe-interval = "500ms"
+scheduler-lag-warn-threshold = "100ms"
 
 [epoch.block-clock]
 epoch-duration = 6

--- a/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
+++ b/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
@@ -59,6 +59,9 @@ private-keys = []
 
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
+slow-storage-op-threshold = "25ms"
+scheduler-lag-probe-interval = "500ms"
+scheduler-lag-warn-threshold = "100ms"
 
 [epoch.block-clock]
 epoch-duration = 6

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -59,6 +59,9 @@ private-keys = []
 
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
+slow-storage-op-threshold = "25ms"
+scheduler-lag-probe-interval = "500ms"
+scheduler-lag-warn-threshold = "100ms"
 
 [epoch.block-clock]
 epoch-duration = 6

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
@@ -59,6 +59,9 @@ private-keys = []
 
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
+slow-storage-op-threshold = "25ms"
+scheduler-lag-probe-interval = "500ms"
+scheduler-lag-warn-threshold = "100ms"
 
 [epoch.block-clock]
 epoch-duration = 6

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
@@ -60,6 +60,9 @@ private-keys = []
 
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
+slow-storage-op-threshold = "25ms"
+scheduler-lag-probe-interval = "500ms"
+scheduler-lag-warn-threshold = "100ms"
 
 [epoch.block-clock]
 epoch-duration = 6

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -74,6 +74,11 @@ pub fn main(
 
     info!("Starting agglayer node version info: {}", version);
 
+    // Apply the configured storage slow-op threshold before any database is
+    // opened, so the instrumentation in `agglayer-storage` uses it from the
+    // first operation.
+    agglayer_telemetry::storage::set_slow_op_threshold(config.telemetry.slow_storage_op_threshold);
+
     let node_runtime = tokio::runtime::Builder::new_multi_thread()
         .thread_name("agglayer-node-runtime")
         .enable_all()

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -10,6 +10,7 @@ mod logging;
 mod epoch_synchronizer;
 mod l1_tracing;
 mod node;
+mod runtime_monitor;
 mod url_redact;
 
 use agglayer_telemetry::ServerBuilder as MetricsBuilder;

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -340,7 +340,11 @@ impl Node {
 
         // Probe the node runtime for scheduler stalls (e.g. blocking RocksDB
         // calls on async worker threads) and surface them as metrics/logs.
-        tokio::spawn(crate::runtime_monitor::run(cancellation_token.clone()));
+        tokio::spawn(crate::runtime_monitor::run(
+            config.telemetry.scheduler_lag_probe_interval,
+            config.telemetry.scheduler_lag_warn_threshold,
+            cancellation_token.clone(),
+        ));
 
         let readrpc_server = axum::serve(readrpc_listener, readrpc_router)
             .with_graceful_shutdown(cancellation_token.clone().cancelled_owned());

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -338,6 +338,10 @@ impl Node {
         info!(on = %config.public_grpc_addr(), "Public gRPC listening");
         info!(on = %config.admin_rpc_addr(), "AdminRPC listening");
 
+        // Probe the node runtime for scheduler stalls (e.g. blocking RocksDB
+        // calls on async worker threads) and surface them as metrics/logs.
+        tokio::spawn(crate::runtime_monitor::run(cancellation_token.clone()));
+
         let readrpc_server = axum::serve(readrpc_listener, readrpc_router)
             .with_graceful_shutdown(cancellation_token.clone().cancelled_owned());
 

--- a/crates/agglayer-node/src/runtime_monitor.rs
+++ b/crates/agglayer-node/src/runtime_monitor.rs
@@ -1,0 +1,95 @@
+//! Tokio runtime responsiveness probe.
+//!
+//! A blocked worker thread -- for example a synchronous RocksDB call running on
+//! an async thread (see `agglayer_storage`) -- prevents otherwise-ready tasks
+//! from being polled. Even a trivial handler such as `/health` then appears to
+//! "hang". This probe measures how late a fixed-interval timer fires; the
+//! overshoot approximates how long the scheduler was unable to make progress.
+//!
+//! It is intentionally cheap and requires no `tokio_unstable` build flags. For
+//! per-task attribution (which future blocked the worker) reach for
+//! `tokio-metrics`/`tokio-console`, which do require `tokio_unstable`.
+
+use std::time::Duration;
+
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+/// Interval between probe ticks.
+const PROBE_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Scheduler lag above this is logged at WARN. On an otherwise idle node, 100ms
+/// of lag means worker threads were blocked long enough to delay unrelated work
+/// and is worth investigating.
+const LAG_WARN_THRESHOLD: Duration = Duration::from_millis(100);
+
+/// Computes how much later than `interval` a tick actually fired.
+///
+/// Returns [`Duration::ZERO`] when the tick was on time or early, so a healthy
+/// scheduler reports approximately zero lag.
+fn overshoot(observed: Duration, interval: Duration) -> Duration {
+    observed.saturating_sub(interval)
+}
+
+/// Runs the scheduler-lag probe until `cancellation` is triggered.
+///
+/// Spawn this on the runtime you want to observe; it reads metrics from
+/// [`tokio::runtime::Handle::current`].
+pub(crate) async fn run(cancellation: CancellationToken) {
+    run_with(PROBE_INTERVAL, LAG_WARN_THRESHOLD, cancellation).await
+}
+
+async fn run_with(interval: Duration, warn_threshold: Duration, cancellation: CancellationToken) {
+    let handle = tokio::runtime::Handle::current();
+    let mut last = Instant::now();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => break,
+            _ = tokio::time::sleep(interval) => {}
+        }
+
+        let now = Instant::now();
+        let lag = overshoot(now.duration_since(last), interval);
+        last = now;
+
+        let lag_ms = lag.as_secs_f64() * 1_000.0;
+        agglayer_telemetry::runtime::SCHEDULER_LAG_MS.record(lag_ms, &[]);
+        agglayer_telemetry::runtime::GLOBAL_QUEUE_DEPTH
+            .record(handle.metrics().global_queue_depth() as u64, &[]);
+
+        if lag >= warn_threshold {
+            warn!(
+                lag_ms = lag_ms,
+                "Tokio scheduler lag spike; worker threads may be blocked (e.g. blocking I/O on \
+                 an async thread)"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overshoot_is_zero_when_on_time_or_early() {
+        let interval = Duration::from_millis(500);
+        assert_eq!(overshoot(interval, interval), Duration::ZERO);
+        assert_eq!(
+            overshoot(Duration::from_millis(450), interval),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn overshoot_reports_lateness() {
+        let interval = Duration::from_millis(500);
+        assert_eq!(
+            overshoot(Duration::from_millis(620), interval),
+            Duration::from_millis(120)
+        );
+    }
+}

--- a/crates/agglayer-node/src/runtime_monitor.rs
+++ b/crates/agglayer-node/src/runtime_monitor.rs
@@ -16,14 +16,6 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-/// Interval between probe ticks.
-const PROBE_INTERVAL: Duration = Duration::from_millis(500);
-
-/// Scheduler lag above this is logged at WARN. On an otherwise idle node, 100ms
-/// of lag means worker threads were blocked long enough to delay unrelated work
-/// and is worth investigating.
-const LAG_WARN_THRESHOLD: Duration = Duration::from_millis(100);
-
 /// Computes how much later than `interval` a tick actually fired.
 ///
 /// Returns [`Duration::ZERO`] when the tick was on time or early, so a healthy
@@ -35,12 +27,13 @@ fn overshoot(observed: Duration, interval: Duration) -> Duration {
 /// Runs the scheduler-lag probe until `cancellation` is triggered.
 ///
 /// Spawn this on the runtime you want to observe; it reads metrics from
-/// [`tokio::runtime::Handle::current`].
-pub(crate) async fn run(cancellation: CancellationToken) {
-    run_with(PROBE_INTERVAL, LAG_WARN_THRESHOLD, cancellation).await
-}
-
-async fn run_with(interval: Duration, warn_threshold: Duration, cancellation: CancellationToken) {
+/// [`tokio::runtime::Handle::current`]. `interval` and `warn_threshold` come
+/// from configuration (see `agglayer_config::TelemetryConfig`).
+pub(crate) async fn run(
+    interval: Duration,
+    warn_threshold: Duration,
+    cancellation: CancellationToken,
+) {
     let handle = tokio::runtime::Handle::current();
     let mut last = Instant::now();
 

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -28,6 +28,7 @@ tracing.workspace = true
 
 agglayer-config.workspace = true
 agglayer-sp1.workspace = true
+agglayer-telemetry.workspace = true
 agglayer-types.workspace = true
 agglayer-tries.workspace = true
 pessimistic-proof.workspace = true

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -1,4 +1,7 @@
-use std::path::Path;
+use std::{
+    path::Path,
+    time::{Duration, Instant},
+};
 
 use iterators::{ColumnIterator, KeysIterator};
 use rocksdb::{
@@ -29,6 +32,45 @@ pub enum DBError {
 
     #[error("Database was opened in read-only mode")]
     ReadOnlyMode,
+}
+
+/// RocksDB point operations are expected to complete in well under a
+/// millisecond. An operation exceeding this budget while running on an async
+/// runtime thread is a strong signal that it is blocking a Tokio worker (for
+/// example a disk stall or compaction back-pressure). Kept as a constant for
+/// now; promote to configuration if per-deployment tuning is needed.
+const SLOW_OP_THRESHOLD: Duration = Duration::from_millis(25);
+
+/// Times a synchronous RocksDB operation, recording its duration to
+/// [`agglayer_telemetry::storage::OP_DURATION_MS`] and flagging operations that
+/// exceed [`SLOW_OP_THRESHOLD`] (which may be blocking a Tokio worker thread).
+///
+/// Note: this covers discrete point/batch operations. Long range scans driven
+/// through [`iterators`] are not timed per item; the remediation for a scan that
+/// shows up as scheduler lag is to run it via `tokio::task::spawn_blocking`.
+fn timed<T>(op: &'static str, cf: &'static str, f: impl FnOnce() -> T) -> T {
+    let start = Instant::now();
+    let out = f();
+    let elapsed = start.elapsed();
+    let elapsed_ms = elapsed.as_secs_f64() * 1_000.0;
+
+    let attrs = [
+        agglayer_telemetry::KeyValue::new("op", op),
+        agglayer_telemetry::KeyValue::new("cf", cf),
+    ];
+    agglayer_telemetry::storage::OP_DURATION_MS.record(elapsed_ms, &attrs);
+
+    if elapsed >= SLOW_OP_THRESHOLD {
+        agglayer_telemetry::storage::SLOW_OP.add(1, &attrs);
+        tracing::warn!(
+            op = op,
+            cf = cf,
+            duration_ms = elapsed_ms,
+            "Slow RocksDB operation; may be blocking a Tokio worker thread"
+        );
+    }
+
+    out
 }
 
 /// A physical storage component with an active RocksDB.
@@ -94,12 +136,13 @@ impl DB {
         let key = key.encode()?;
         let cf = self.cf::<C>()?;
 
-        self.rocksdb
-            .get_cf(cf, &key)?
-            .map(|v| C::Value::decode(&v[..]).map_err(Into::into))
-            // If the value is not found, return None.
-            // If the value is found, decode it and wrap it in Some to propagate decode error.
-            .map_or(Ok(None), |v| v.map(Some))
+        timed("get", C::COLUMN_FAMILY_NAME, || {
+            self.rocksdb.get_cf(cf, &key)
+        })?
+        .map(|v| C::Value::decode(&v[..]).map_err(Into::into))
+        // If the value is not found, return None.
+        // If the value is found, decode it and wrap it in Some to propagate decode error.
+        .map_or(Ok(None), |v| v.map(Some))
     }
 
     pub fn atomic_multi_get<C: ColumnSchema>(
@@ -116,12 +159,14 @@ impl DB {
             .into_iter()
             .map(|k| k.encode().map(|key| (cf, key)))
             .collect();
+        let keys = keys?;
 
-        let results = snapshot
-            .multi_get_cf(keys?)
-            .into_iter()
-            .map(|r| r.map_err(DBError::from))
-            .collect::<Result<Vec<Option<_>>, _>>()?;
+        let results = timed("atomic_multi_get", C::COLUMN_FAMILY_NAME, || {
+            snapshot.multi_get_cf(keys)
+        })
+        .into_iter()
+        .map(|r| r.map_err(DBError::from))
+        .collect::<Result<Vec<Option<_>>, _>>()?;
 
         results
             .into_iter()
@@ -138,10 +183,12 @@ impl DB {
     ) -> Result<Vec<Option<C::Value>>, DBError> {
         let cf = self.cf::<C>()?;
         let keys: Result<Vec<_>, _> = keys.into_iter().map(|k| k.encode()).collect();
+        let keys = keys?;
 
-        let results: Result<Vec<Option<DBPinnableSlice>>, _> = self
-            .rocksdb
-            .batched_multi_get_cf(cf, &keys?, false)
+        let results: Result<Vec<Option<DBPinnableSlice>>, _> =
+            timed("multi_get", C::COLUMN_FAMILY_NAME, || {
+                self.rocksdb.batched_multi_get_cf(cf, &keys, false)
+            })
             .into_iter()
             .map(|r| r.map_err(DBError::from))
             .collect();
@@ -162,14 +209,19 @@ impl DB {
         let cf = self.cf::<C>()?;
 
         let write_options = self.write_options()?;
-        self.rocksdb.put_cf_opt(cf, key, value, write_options)?;
+        timed("put", C::COLUMN_FAMILY_NAME, || {
+            self.rocksdb.put_cf_opt(cf, key, value, write_options)
+        })?;
 
         Ok(())
     }
 
     pub fn write_batch(&self, batch: WriteBatch) -> Result<(), DBError> {
         let write_options = self.write_options()?;
-        self.rocksdb.write_opt(batch, write_options)?;
+        // A batch may span multiple column families, so it is tagged with `*`.
+        timed("write_batch", "*", || {
+            self.rocksdb.write_opt(batch, write_options)
+        })?;
 
         Ok(())
     }
@@ -248,7 +300,11 @@ impl DB {
         let key = key.encode()?;
 
         let write_options = self.write_options()?;
-        Ok(self.rocksdb.delete_cf_opt(&cf, key, write_options)?)
+        timed("delete", C::COLUMN_FAMILY_NAME, || {
+            self.rocksdb.delete_cf_opt(&cf, key, write_options)
+        })?;
+
+        Ok(())
     }
 
     pub(crate) fn raw_rocksdb(&self) -> &rocksdb::DB {

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -38,8 +38,9 @@ pub enum DBError {
 /// Tokio worker thread.
 ///
 /// Note: this covers discrete point/batch operations. Long range scans driven
-/// through [`iterators`] are not timed per item; the remediation for a scan that
-/// shows up as scheduler lag is to run it via `tokio::task::spawn_blocking`.
+/// through [`iterators`] are not timed per item; the remediation for a scan
+/// that shows up as scheduler lag is to run it via
+/// `tokio::task::spawn_blocking`.
 fn timed<T>(op: &'static str, cf: &'static str, f: impl FnOnce() -> T) -> T {
     let start = Instant::now();
     let out = f();

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::Path,
-    time::{Duration, Instant},
-};
+use std::{path::Path, time::Instant};
 
 use iterators::{ColumnIterator, KeysIterator};
 use rocksdb::{
@@ -34,16 +31,11 @@ pub enum DBError {
     ReadOnlyMode,
 }
 
-/// RocksDB point operations are expected to complete in well under a
-/// millisecond. An operation exceeding this budget while running on an async
-/// runtime thread is a strong signal that it is blocking a Tokio worker (for
-/// example a disk stall or compaction back-pressure). Kept as a constant for
-/// now; promote to configuration if per-deployment tuning is needed.
-const SLOW_OP_THRESHOLD: Duration = Duration::from_millis(25);
-
 /// Times a synchronous RocksDB operation, recording its duration to
 /// [`agglayer_telemetry::storage::OP_DURATION_MS`] and flagging operations that
-/// exceed [`SLOW_OP_THRESHOLD`] (which may be blocking a Tokio worker thread).
+/// exceed the configured slow-op threshold (see
+/// [`agglayer_telemetry::storage::slow_op_threshold`]), which may be blocking a
+/// Tokio worker thread.
 ///
 /// Note: this covers discrete point/batch operations. Long range scans driven
 /// through [`iterators`] are not timed per item; the remediation for a scan that
@@ -60,7 +52,7 @@ fn timed<T>(op: &'static str, cf: &'static str, f: impl FnOnce() -> T) -> T {
     ];
     agglayer_telemetry::storage::OP_DURATION_MS.record(elapsed_ms, &attrs);
 
-    if elapsed >= SLOW_OP_THRESHOLD {
+    if elapsed >= agglayer_telemetry::storage::slow_op_threshold() {
         agglayer_telemetry::storage::SLOW_OP.add(1, &attrs);
         tracing::warn!(
             op = op,

--- a/crates/agglayer-telemetry/src/lib.rs
+++ b/crates/agglayer-telemetry/src/lib.rs
@@ -20,6 +20,8 @@ use crate::constant::{AGGLAYER_KERNEL_OTEL_SCOPE_NAME, AGGLAYER_RPC_OTEL_SCOPE_N
 mod constant;
 
 pub mod clock;
+pub mod runtime;
+pub mod storage;
 
 pub use opentelemetry::KeyValue;
 

--- a/crates/agglayer-telemetry/src/runtime.rs
+++ b/crates/agglayer-telemetry/src/runtime.rs
@@ -1,0 +1,33 @@
+//! Tokio runtime responsiveness metrics.
+//!
+//! These instruments surface scheduler stalls: if a worker thread is blocked
+//! (for example by a synchronous RocksDB call on an async thread), ready tasks
+//! are not polled and even a trivial endpoint such as `/health` appears to hang.
+//! They are populated by a lightweight probe and require no `tokio_unstable`
+//! build flags.
+
+use lazy_static::lazy_static;
+use opentelemetry::{global, metrics::*};
+
+const AGGLAYER_RUNTIME_OTEL_SCOPE_NAME: &str = "agglayer_runtime";
+
+lazy_static! {
+    /// Scheduler lag in milliseconds: how late a fixed-interval probe tick
+    /// fired relative to its deadline. Sustained lag while CPU is idle indicates
+    /// worker threads were blocked and unable to make progress.
+    pub static ref SCHEDULER_LAG_MS: Histogram<f64> =
+        global::meter(AGGLAYER_RUNTIME_OTEL_SCOPE_NAME)
+            .f64_histogram("runtime_scheduler_lag_ms")
+            .with_description("Tokio scheduler lag (timer overshoot) in milliseconds")
+            .build();
+
+    /// Number of tasks waiting in the runtime's global (injector) run queue.
+    ///
+    /// A rising depth while CPU usage stays low means tasks are ready but not
+    /// being polled, i.e. the worker pool is starved.
+    pub static ref GLOBAL_QUEUE_DEPTH: Gauge<u64> =
+        global::meter(AGGLAYER_RUNTIME_OTEL_SCOPE_NAME)
+            .u64_gauge("runtime_global_queue_depth")
+            .with_description("Tasks waiting in the Tokio global run queue")
+            .build();
+}

--- a/crates/agglayer-telemetry/src/runtime.rs
+++ b/crates/agglayer-telemetry/src/runtime.rs
@@ -2,9 +2,9 @@
 //!
 //! These instruments surface scheduler stalls: if a worker thread is blocked
 //! (for example by a synchronous RocksDB call on an async thread), ready tasks
-//! are not polled and even a trivial endpoint such as `/health` appears to hang.
-//! They are populated by a lightweight probe and require no `tokio_unstable`
-//! build flags.
+//! are not polled and even a trivial endpoint such as `/health` appears to
+//! hang. They are populated by a lightweight probe and require no
+//! `tokio_unstable` build flags.
 
 use lazy_static::lazy_static;
 use opentelemetry::{global, metrics::*};

--- a/crates/agglayer-telemetry/src/storage.rs
+++ b/crates/agglayer-telemetry/src/storage.rs
@@ -1,0 +1,36 @@
+//! Storage layer metrics.
+//!
+//! These instruments make it possible to detect synchronous RocksDB calls that
+//! block Tokio worker threads. A slow operation recorded here, correlated with
+//! a [`crate::runtime`] scheduler-lag spike while CPU is idle, is the signature
+//! of blocking I/O running on the async runtime.
+
+use lazy_static::lazy_static;
+use opentelemetry::{global, metrics::*};
+
+const AGGLAYER_STORAGE_OTEL_SCOPE_NAME: &str = "agglayer_storage";
+
+lazy_static! {
+    /// Duration of synchronous RocksDB operations, in milliseconds.
+    ///
+    /// Milliseconds (rather than seconds) are recorded deliberately: values then
+    /// spread across the OpenTelemetry default histogram buckets
+    /// (`5, 10, 25, 50, 100, 250, 500, 1000, ...`) without configuring a custom
+    /// View. Healthy point operations land in the first bucket and stalls stand
+    /// out. Tagged with `op` (e.g. `get`, `put`) and `cf` (column family).
+    pub static ref OP_DURATION_MS: Histogram<f64> =
+        global::meter(AGGLAYER_STORAGE_OTEL_SCOPE_NAME)
+            .f64_histogram("storage_rocksdb_op_duration_ms")
+            .with_description("Duration of synchronous RocksDB operations in milliseconds")
+            .build();
+
+    /// Count of RocksDB operations exceeding the slow-op threshold.
+    ///
+    /// Tagged with `op` and `cf`, matching [`OP_DURATION_MS`], so a rising rate
+    /// can be attributed to a specific operation and column family.
+    pub static ref SLOW_OP: Counter<u64> =
+        global::meter(AGGLAYER_STORAGE_OTEL_SCOPE_NAME)
+            .u64_counter("storage_rocksdb_slow_op_total")
+            .with_description("RocksDB operations exceeding the slow-op threshold")
+            .build();
+}

--- a/crates/agglayer-telemetry/src/storage.rs
+++ b/crates/agglayer-telemetry/src/storage.rs
@@ -5,10 +5,40 @@
 //! a [`crate::runtime`] scheduler-lag spike while CPU is idle, is the signature
 //! of blocking I/O running on the async runtime.
 
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
 use lazy_static::lazy_static;
 use opentelemetry::{global, metrics::*};
 
 const AGGLAYER_STORAGE_OTEL_SCOPE_NAME: &str = "agglayer_storage";
+
+/// Slow-op threshold in milliseconds.
+///
+/// RocksDB point operations are expected to complete in well under a
+/// millisecond; an operation exceeding this budget while running on an async
+/// runtime thread is a strong signal that it is blocking a Tokio worker (for
+/// example a disk stall or compaction back-pressure).
+///
+/// Defaults to 25ms and is overridden once at startup from configuration via
+/// [`set_slow_op_threshold`]. A process-global is used (rather than threading
+/// the value through every `DB` constructor) to stay consistent with this
+/// crate's global instruments: it is written once during startup and only read
+/// afterwards.
+static SLOW_OP_THRESHOLD_MS: AtomicU64 = AtomicU64::new(25);
+
+/// Sets the storage slow-op threshold. Intended to be called once at startup,
+/// before databases are opened.
+pub fn set_slow_op_threshold(threshold: Duration) {
+    SLOW_OP_THRESHOLD_MS.store(threshold.as_millis() as u64, Ordering::Relaxed);
+}
+
+/// Returns the currently configured storage slow-op threshold.
+pub fn slow_op_threshold() -> Duration {
+    Duration::from_millis(SLOW_OP_THRESHOLD_MS.load(Ordering::Relaxed))
+}
 
 lazy_static! {
     /// Duration of synchronous RocksDB operations, in milliseconds.

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -59,6 +59,9 @@ private-keys = []
 
 [telemetry]
 prometheus-addr = "0.0.0.0:3000"
+slow-storage-op-threshold = "25ms"
+scheduler-lag-probe-interval = "500ms"
+scheduler-lag-warn-threshold = "100ms"
 
 [epoch.block-clock]
 epoch-duration = 6


### PR DESCRIPTION
Detect synchronous RocksDB calls that block Tokio worker threads, which
can stall unrelated futures (e.g. /health) even while CPU is idle. Adds
two correlated signals plus configurable thresholds.

agglayer-telemetry: new `storage` instruments (op-duration histogram and
slow-op counter, tagged by op/cf) and `runtime` instruments
(scheduler-lag histogram and global queue-depth gauge).

agglayer-storage: time the get/put/multi_get/delete/write_batch paths
via a `timed()` helper; warn past the configured slow-op threshold.

agglayer-node: spawn a lightweight scheduler-lag probe (timer overshoot)
on the node runtime; no tokio_unstable required.

Detection rule: a slow storage op together with scheduler lag while CPU
is idle indicates blocking RocksDB on an async worker. Pair
runtime_scheduler_lag_ms and storage_rocksdb_slow_op_total with
container CPU usage and the /health synthetic on one dashboard.

Thresholds are configurable via [telemetry] and default to the previous
hardcoded values, so existing deployments are unaffected.

CONFIG-CHANGE: new optional [telemetry] keys, all defaulting to prior
behaviour: slow-storage-op-threshold=25ms,
scheduler-lag-probe-interval=500ms, scheduler-lag-warn-threshold=100ms.
