### PR TITLE
revert: remove per-epoch certificate rate limiting

### DIFF
--- a/crates/agglayer-certificate-orchestrator/src/network_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task.rs
@@ -11,11 +11,11 @@ use agglayer_storage::{
 };
 use agglayer_types::{
     primitives::{Digest, Hashable as _},
-    CertificateId, CertificateStatus, CertificateStatusError, EpochNumber, ExecutionMode, Height,
+    CertificateId, CertificateStatus, CertificateStatusError, ExecutionMode, Height,
     LocalNetworkStateData, NetworkId,
 };
 use arc_swap::ArcSwap;
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -92,14 +92,11 @@ pub(crate) struct NetworkTask<
     certifier_client: Arc<CertifierClient>,
     /// The local network state of the network task.
     local_state: Box<LocalNetworkStateData>,
-
     /// The clock reference to subscribe to the epoch events and check for
     /// current epoch.
     clock_ref: ClockRef,
     /// The stream of new certificates to certify.
     certificate_stream: mpsc::Receiver<NewCertificate>,
-    /// Flag to indicate if the network is at capacity for the current epoch.
-    at_capacity_for_epoch: bool,
     /// latest certificate settled
     latest_settled: Option<SettledCertificate>,
     /// The settlement service for submitting settlement jobs
@@ -154,7 +151,6 @@ where
             local_state,
             clock_ref,
             certificate_stream,
-            at_capacity_for_epoch: false,
             latest_settled,
             settlement_service,
             current_epoch,
@@ -174,8 +170,6 @@ where
     ) -> Result<NetworkId, Error> {
         info!("Starting the network task for network {}", self.network_id);
 
-        let mut stream_epoch = self.clock_ref.subscribe()?;
-
         let current_epoch = self.clock_ref.current_epoch();
 
         // Start from the latest settled certificate to define the next expected height
@@ -189,7 +183,6 @@ where
                 debug!("Current network height is {}", current_height);
                 if epoch == current_epoch {
                     debug!("Already settled for the epoch {current_epoch}");
-                    self.at_capacity_for_epoch = true;
                 }
 
                 current_height.next()
@@ -208,7 +201,7 @@ where
                     return Ok(self.network_id);
                 }
 
-                result = self.make_progress(&mut stream_epoch, &mut next_expected_height, &mut first_run, &cancellation_token) => {
+                result = self.make_progress(&mut next_expected_height, &mut first_run, &cancellation_token) => {
                     if let Err(error)= result {
                         error!("Error during the certification process: {}", error);
 
@@ -222,10 +215,9 @@ where
         }
     }
 
-    #[instrument(skip(self, stream_epoch, cancellation_token), fields(certificate_id))]
+    #[instrument(skip(self, cancellation_token), fields(certificate_id))]
     async fn make_progress(
         &mut self,
-        stream_epoch: &mut tokio::sync::broadcast::Receiver<agglayer_clock::Event>,
         next_expected_height: &mut Height,
         first_run: &mut bool,
         cancellation_token: &CancellationToken,
@@ -234,39 +226,7 @@ where
             *first_run = false;
         } else {
             tokio::select! {
-                event = stream_epoch.recv() => {
-                    let network_id = self.network_id;
-                    match event {
-                        Ok(agglayer_clock::Event::EpochEnded(epoch)) => {
-                            info!("Received an epoch event: {}", epoch);
-
-                            let current_epoch = self.clock_ref.current_epoch();
-                            if epoch != EpochNumber::ZERO && epoch.next() < current_epoch {
-                                warn!("Received an epoch event for epoch {epoch} which is outdated, current epoch is {current_epoch}");
-
-                                return Ok(());
-                            }
-                            match self.latest_settled {
-                                Some(SettledCertificate(_, _, epoch, _)) if epoch == current_epoch => {
-                                    warn!("Network {network_id} is at capacity for the epoch {current_epoch}");
-                                    return Ok(());
-                                },
-                                _ => {
-                                    self.at_capacity_for_epoch = false;
-                                }
-                            }
-                        }
-                        Err(broadcast::error::RecvError::Lagged(num_skipped)) => {
-                            warn!("Network {network_id} skipped {num_skipped} epoch ticks");
-                            return Ok(());
-                        }
-                        Err(broadcast::error::RecvError::Closed) => {
-                            error!("Epoch channel closed for network {network_id}");
-                            return Err(Error::InternalError("epoch channel closed".into()));
-                        }
-                    }
-                }
-                Some(NewCertificate { certificate_id, height, .. }) = self.certificate_stream.recv(), if !self.at_capacity_for_epoch => {
+                Some(NewCertificate { certificate_id, height, .. }) = self.certificate_stream.recv() => {
                     info!(
                         hash = certificate_id.to_string(),
                         "Received a certificate event for {certificate_id} at height {height}"
@@ -367,9 +327,6 @@ where
                         continue;
                     }
                     Some(NetworkTaskMessage::CertificateSettled { height, certificate_id }) => {
-                        // One certificate settles per network per epoch: stop
-                        // accepting new certificates until the next epoch event.
-                        self.at_capacity_for_epoch = true;
                         next_expected_height.increment();
                         debug!("Certification process completed");
 
@@ -459,7 +416,6 @@ where
                     }
                     Some(NetworkTaskMessage::CertificateErrored { .. }) => {
                         // The certificate task already logged everything that should be logged.
-                        self.at_capacity_for_epoch = false;
                         break;
                     }
                 }

--- a/crates/agglayer-certificate-orchestrator/src/network_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task.rs
@@ -215,7 +215,7 @@ where
         }
     }
 
-    #[instrument(skip(self, cancellation_token), fields(certificate_id))]
+    #[instrument(skip(self, cancellation_token))]
     async fn make_progress(
         &mut self,
         next_expected_height: &mut Height,
@@ -243,12 +243,36 @@ where
                         warn!(
                             hash = certificate_id.to_string(),
                             "Received a certificate event for the wrong height");
-
-                        return Ok(());
                     }
                 }
             }
         }
+
+        // Drain every certificate already queued in the pending store: this
+        // wake may be the only one for a while (e.g. when recovering a
+        // backlog after a restart), so make as much progress as possible
+        // before waiting again. A certificate that does not settle leaves
+        // the height unchanged and ends the drain, so a failing certificate
+        // cannot cause a busy loop.
+        while self
+            .process_next_pending_certificate(next_expected_height, cancellation_token)
+            .await?
+        {}
+
+        Ok(())
+    }
+
+    /// Process the pending certificate at the next expected height, if any.
+    ///
+    /// Returns `true` when the certificate settled and the height advanced,
+    /// meaning another pending certificate may already be queued behind it.
+    #[instrument(skip(self, cancellation_token), fields(certificate_id))]
+    async fn process_next_pending_certificate(
+        &mut self,
+        next_expected_height: &mut Height,
+        cancellation_token: &CancellationToken,
+    ) -> Result<bool, Error> {
+        let height_before = *next_expected_height;
 
         // Get the certificate the pending certificate for the network at the height
         let certificate = if let Some(certificate) = self
@@ -267,7 +291,7 @@ where
                 self.network_id, *next_expected_height
             );
             // There is no certificate to certify at this height for now
-            return Ok(());
+            return Ok(false);
         };
 
         let certificate_id = certificate.hash();
@@ -425,6 +449,6 @@ where
         task.await
             .map_err(|e| Error::InternalError(format!("Certificate task panicked: {e}")))?;
 
-        Ok(())
+        Ok(*next_expected_height != height_before)
     }
 }

--- a/crates/agglayer-certificate-orchestrator/src/network_task/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task/tests.rs
@@ -158,6 +158,14 @@ async fn start_from_zero() {
             Ok(Some(certificate))
         });
 
+    // After settling height 0 the task drains the queue and looks for a
+    // pending certificate at height 1.
+    pending
+        .expect_get_certificate()
+        .once()
+        .with(eq(network_id), eq(Height::new(1)))
+        .returning(|_, _| Ok(None));
+
     state
         .expect_get_latest_settled_certificate_per_network()
         .once()
@@ -468,6 +476,13 @@ async fn retries() {
             let cert = certs.lock().unwrap().pop_front().unwrap();
             Ok(Some(cert))
         });
+
+    // Once the retried certificate settles, the drain checks height 1.
+    pending
+        .expect_get_certificate()
+        .once()
+        .with(eq(network_id), eq(Height::new(1)))
+        .returning(|_, _| Ok(None));
 
     pending
         .expect_get_certificate()
@@ -953,18 +968,7 @@ async fn process_next_certificate() {
         .await
         .expect("Failed to send second certificate");
 
-    // Process first certificate
-    task.make_progress(
-        &mut next_expected_height,
-        &mut first_run,
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
-
-    assert_eq!(next_expected_height, Height::new(1));
-
-    // Process second certificate
+    // The first wake drains both queued certificates back-to-back.
     task.make_progress(
         &mut next_expected_height,
         &mut first_run,
@@ -974,4 +978,245 @@ async fn process_next_certificate() {
     .unwrap();
 
     assert_eq!(next_expected_height, Height::new(2));
+
+    // The queued event for the already-settled second certificate is a no-op.
+    task.make_progress(
+        &mut next_expected_height,
+        &mut first_run,
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(next_expected_height, Height::new(2));
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+#[timeout(Duration::from_secs(30))]
+async fn settles_pending_backlog_on_startup() {
+    let tmp = TempDBDir::new();
+    let storage = new_storage(&tmp.path);
+    let mut certifier = MockCertifier::new();
+    expect_settlement_l1_context(&mut certifier);
+    let clock_ref = clock();
+    let network_id = 1.into();
+    // No certificate events are ever sent: the pending store alone must be
+    // enough to catch up, as when recovering a backlog after a restart.
+    let (_sender, certificate_stream) = mpsc::channel(100);
+
+    let mut forest = Forest::default();
+
+    let certificate = forest.apply_events(
+        &[(USDC, 10.try_into().unwrap())],
+        &[(USDC, 1.try_into().unwrap())],
+    );
+    storage
+        .pending
+        .insert_pending_certificate(network_id, Height::ZERO, &certificate)
+        .expect("unable to insert certificate in pending");
+    storage
+        .state
+        .insert_certificate_header(&certificate, CertificateStatus::Pending)
+        .expect("Failed to insert certificate header");
+
+    let certificate2 = {
+        let mut c = forest.apply_events(&[], &[(USDC, 1.try_into().unwrap())]);
+        c.height = Height::new(1);
+        c
+    };
+    storage
+        .pending
+        .insert_pending_certificate(network_id, Height::new(1), &certificate2)
+        .expect("unable to insert certificate in pending");
+    storage
+        .state
+        .insert_certificate_header(&certificate2, CertificateStatus::Pending)
+        .expect("Failed to insert certificate header");
+
+    certifier
+        .expect_certify()
+        .times(2)
+        .with(always(), eq(network_id), always())
+        .returning({
+            let pending_store = Arc::clone(&storage.pending);
+            move |mut new_state, network, height| {
+                let certificate = pending_store
+                    .get_certificate(network, height)
+                    .expect("Failed to get certificate")
+                    .expect("Certificate not found");
+                pending_store
+                    .insert_generated_proof(&certificate.hash(), &settlement_proof())
+                    .ok();
+
+                let signer = agglayer_types::Address::new([0; 20]);
+                let ctx_from_l1 = L1WitnessCtx {
+                    l1_info_root: certificate
+                        .l1_info_root()
+                        .expect("Failed to get L1 info root")
+                        .unwrap_or_default(),
+                    prev_pessimistic_root: PessimisticRootInput::Computed(
+                        PessimisticRootCommitmentVersion::V2,
+                    ),
+                    aggchain_data_ctx: CertificateAggchainDataCtx::LegacyEcdsa { signer },
+                };
+
+                let _ = new_state
+                    .apply_certificate(&certificate, ctx_from_l1)
+                    .expect("Failed to apply certificate");
+
+                Ok(CertifierOutput {
+                    certificate,
+                    height,
+                    new_state,
+                    network,
+                    new_pp_root: Digest::ZERO,
+                })
+            }
+        });
+
+    let mut settlement_service = MockSettlementServiceTrait::new();
+    mock_settlement_persisting(
+        &mut settlement_service,
+        Arc::clone(&storage.state),
+        SETTLEMENT_TX_HASH_1,
+        ContractCallOutcome::Success,
+    );
+    let mut task = NetworkTask::new(
+        Arc::clone(&storage.pending),
+        Arc::clone(&storage.state),
+        Arc::new(certifier),
+        clock_ref.clone(),
+        network_id,
+        certificate_stream,
+        Arc::new(settlement_service),
+        mock_current_epoch(),
+    )
+    .expect("Failed to create a new network task");
+
+    let mut next_expected_height = Height::ZERO;
+    let mut first_run = true;
+
+    // A single first-run pass settles the whole backlog.
+    task.make_progress(
+        &mut next_expected_height,
+        &mut first_run,
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(next_expected_height, Height::new(2));
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+#[timeout(Duration::from_secs(30))]
+async fn wrong_height_event_still_drains_pending() {
+    let tmp = TempDBDir::new();
+    let storage = new_storage(&tmp.path);
+    let mut certifier = MockCertifier::new();
+    expect_settlement_l1_context(&mut certifier);
+    let clock_ref = clock();
+    let network_id = 1.into();
+    let (sender, certificate_stream) = mpsc::channel(100);
+
+    let mut forest = Forest::default();
+
+    let certificate = forest.apply_events(
+        &[(USDC, 10.try_into().unwrap())],
+        &[(USDC, 1.try_into().unwrap())],
+    );
+    let certificate_id = certificate.hash();
+    storage
+        .pending
+        .insert_pending_certificate(network_id, Height::ZERO, &certificate)
+        .expect("unable to insert certificate in pending");
+    storage
+        .state
+        .insert_certificate_header(&certificate, CertificateStatus::Pending)
+        .expect("Failed to insert certificate header");
+
+    certifier
+        .expect_certify()
+        .once()
+        .with(always(), eq(network_id), eq(Height::ZERO))
+        .returning({
+            let pending_store = Arc::clone(&storage.pending);
+            move |mut new_state, network, height| {
+                let certificate = pending_store
+                    .get_certificate(network, height)
+                    .expect("Failed to get certificate")
+                    .expect("Certificate not found");
+                pending_store
+                    .insert_generated_proof(&certificate.hash(), &settlement_proof())
+                    .ok();
+
+                let signer = agglayer_types::Address::new([0; 20]);
+                let ctx_from_l1 = L1WitnessCtx {
+                    l1_info_root: certificate
+                        .l1_info_root()
+                        .expect("Failed to get L1 info root")
+                        .unwrap_or_default(),
+                    prev_pessimistic_root: PessimisticRootInput::Computed(
+                        PessimisticRootCommitmentVersion::V2,
+                    ),
+                    aggchain_data_ctx: CertificateAggchainDataCtx::LegacyEcdsa { signer },
+                };
+
+                let _ = new_state
+                    .apply_certificate(&certificate, ctx_from_l1)
+                    .expect("Failed to apply certificate");
+
+                Ok(CertifierOutput {
+                    certificate,
+                    height,
+                    new_state,
+                    network,
+                    new_pp_root: Digest::ZERO,
+                })
+            }
+        });
+
+    let mut settlement_service = MockSettlementServiceTrait::new();
+    mock_settlement_persisting(
+        &mut settlement_service,
+        Arc::clone(&storage.state),
+        SETTLEMENT_TX_HASH_1,
+        ContractCallOutcome::Success,
+    );
+    let mut task = NetworkTask::new(
+        Arc::clone(&storage.pending),
+        Arc::clone(&storage.state),
+        Arc::new(certifier),
+        clock_ref.clone(),
+        network_id,
+        certificate_stream,
+        Arc::new(settlement_service),
+        mock_current_epoch(),
+    )
+    .expect("Failed to create a new network task");
+
+    let mut next_expected_height = Height::ZERO;
+    let mut first_run = false;
+
+    // An event for a later height still wakes the task, which then finds and
+    // settles the certificate pending at the expected height.
+    sender
+        .send(NewCertificate {
+            certificate_id,
+            height: Height::new(5),
+        })
+        .await
+        .expect("Failed to send the certificate");
+
+    task.make_progress(
+        &mut next_expected_height,
+        &mut first_run,
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(next_expected_height, Height::new(1));
 }

--- a/crates/agglayer-certificate-orchestrator/src/network_task/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task/tests.rs
@@ -278,7 +278,6 @@ async fn start_from_zero() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
 
     let _ = sender
@@ -290,7 +289,6 @@ async fn start_from_zero() {
 
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -414,7 +412,6 @@ async fn repeated_unreadable_proof_errors_certificate() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
 
     let _ = sender
@@ -426,7 +423,6 @@ async fn repeated_unreadable_proof_errors_certificate() {
 
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -435,249 +431,6 @@ async fn repeated_unreadable_proof_errors_certificate() {
     .unwrap();
 
     assert_eq!(next_expected_height, Height::ZERO);
-}
-
-#[rstest]
-#[tokio::test]
-#[timeout(Duration::from_secs(1))]
-async fn one_per_epoch() {
-    let mut pending = MockPendingStore::new();
-    pending
-        .expect_get_proof()
-        .returning(|_| Ok(Some(settlement_proof())));
-    let mut state = MockStateStore::new();
-    let mut certifier = MockCertifier::new();
-    expect_settlement_l1_context(&mut certifier);
-    let clock_ref = clock();
-    let network_id = 1.into();
-    let (sender, certificate_stream) = mpsc::channel(100);
-
-    let certificate = Certificate::new_for_test(network_id, Height::ZERO);
-    let certificate2 = Certificate::new_for_test(network_id, Height::new(1));
-    let certificate_id = certificate.hash();
-    let certificate_id2 = certificate2.hash();
-
-    pending
-        .expect_get_certificate()
-        .once()
-        .with(eq(network_id), eq(Height::ZERO))
-        .returning(|network_id, height| {
-            let c = Certificate::new_for_test(network_id, height);
-
-            Ok(Some(c))
-        });
-
-    pending
-        .expect_get_certificate()
-        .never()
-        .with(eq(network_id), eq(Height::new(1)))
-        .returning(|network_id, height| {
-            let c = Certificate::new_for_test(network_id, height);
-
-            Ok(Some(c))
-        });
-
-    state
-        .expect_get_latest_settled_certificate_per_network()
-        .once()
-        .with(eq(network_id))
-        .returning(|_| Ok(None));
-
-    state
-        .expect_get_certificate_header()
-        .once()
-        .with(eq(certificate_id))
-        .returning(|certificate_id| {
-            Ok(Some(agglayer_types::CertificateHeader {
-                network_id: 1.into(),
-                height: Height::ZERO,
-                epoch_number: None,
-                certificate_index: None,
-                certificate_id: *certificate_id,
-                prev_local_exit_root: [1; 32].into(),
-                new_local_exit_root: [0; 32].into(),
-                metadata: Metadata::ZERO,
-                status: CertificateStatus::Pending,
-                settlement_tx_hash: None,
-            }))
-        });
-
-    state
-        .expect_get_certificate_header()
-        .never()
-        .with(eq(certificate_id2))
-        .returning(|certificate_id| {
-            Ok(Some(agglayer_types::CertificateHeader {
-                network_id: 1.into(),
-                height: Height::new(1),
-                epoch_number: None,
-                certificate_index: None,
-                certificate_id: *certificate_id,
-                prev_local_exit_root: [1; 32].into(),
-                new_local_exit_root: [0; 32].into(),
-                metadata: Metadata::ZERO,
-                status: CertificateStatus::Pending,
-                settlement_tx_hash: None,
-            }))
-        });
-    certifier
-        .expect_certify()
-        .once()
-        .with(always(), eq(network_id), eq(Height::ZERO))
-        .return_once(move |new_state, network_id, _height| {
-            let result = crate::CertifierOutput {
-                certificate,
-                height: Height::ZERO,
-                new_state,
-                network: network_id,
-                new_pp_root: Digest::ZERO,
-            };
-
-            Ok(result)
-        });
-
-    state
-        .expect_read_local_network_state()
-        .returning(|_| Ok(Default::default()));
-
-    state
-        .expect_write_local_network_state()
-        .returning(|_, _, _| Ok(()));
-
-    certifier
-        .expect_certify()
-        .never()
-        .with(always(), eq(network_id), eq(Height::new(1)))
-        .return_once(move |new_state, network_id, _height| {
-            let result = crate::CertifierOutput {
-                certificate: certificate2,
-                height: Height::new(1),
-                new_state,
-                network: network_id,
-                new_pp_root: Digest::ZERO,
-            };
-
-            Ok(result)
-        });
-
-    pending
-        .expect_set_latest_proven_certificate_per_network()
-        .once()
-        .with(eq(network_id), eq(Height::ZERO), eq(certificate_id))
-        .returning(|_, _, _| Ok(()));
-
-    state
-        .expect_update_certificate_header_status()
-        .once()
-        .with(eq(certificate_id), eq(CertificateStatus::Proven))
-        .returning(|_, _| Ok(()));
-
-    state
-        .expect_insert_certificate_settlement_job_id()
-        .returning(|_, _| Ok(()));
-    state
-        .expect_get_certificate_settlement_job_id()
-        .returning(|_| Ok(Some(job_id(1))));
-    state
-        .expect_update_certificate_header_status()
-        .once()
-        .with(eq(certificate_id), eq(CertificateStatus::Candidate))
-        .returning(|_, _| Ok(()));
-
-    state
-        .expect_update_settlement_tx_hash()
-        .once()
-        .withf(move |i, t, _f, _| *i == certificate_id && *t == SETTLEMENT_TX_HASH_1)
-        .returning(|_, _, _, _| Ok(()));
-
-    state
-        .expect_update_certificate_header_status()
-        .once()
-        .with(eq(certificate_id), eq(CertificateStatus::Settled))
-        .returning(|_, _| Ok(()));
-
-    state
-        .expect_set_latest_settled_certificate_for_network()
-        .once()
-        .with(
-            eq(network_id),
-            eq(Height::ZERO),
-            eq(certificate_id),
-            eq(EpochNumber::ZERO),
-            eq(CertificateIndex::ZERO),
-        )
-        .returning(|_, _, _, _, _| Ok(()));
-
-    let mut settlement_service = MockSettlementServiceTrait::new();
-    settlement_service
-        .expect_submit_settlement_job()
-        .once()
-        .returning(|_, _| Ok(job_id(1)));
-    settlement_service
-        .expect_wait_for_settlement()
-        .once()
-        .returning(move |_| {
-            Ok(settlement_result(
-                SETTLEMENT_TX_HASH_1,
-                ContractCallOutcome::Success,
-            ))
-        });
-
-    let mut task = NetworkTask::new(
-        Arc::new(pending),
-        Arc::new(state),
-        Arc::new(certifier),
-        clock_ref,
-        network_id,
-        certificate_stream,
-        Arc::new(settlement_service),
-        mock_current_epoch(),
-    )
-    .expect("Failed to create a new network task");
-
-    let mut epochs = task.clock_ref.subscribe().unwrap();
-    let mut next_expected_height = Height::ZERO;
-
-    sender
-        .send(NewCertificate {
-            certificate_id,
-            height: Height::ZERO,
-        })
-        .await
-        .expect("Failed to send the certificate");
-
-    sender
-        .send(NewCertificate {
-            certificate_id: certificate_id2,
-            height: Height::new(1),
-        })
-        .await
-        .expect("Failed to send the certificate");
-
-    let mut first_run = true;
-    task.make_progress(
-        &mut epochs,
-        &mut next_expected_height,
-        &mut first_run,
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
-
-    assert_eq!(next_expected_height, Height::new(1));
-    tokio::time::timeout(
-        Duration::from_millis(100),
-        task.make_progress(
-            &mut epochs,
-            &mut next_expected_height,
-            &mut first_run,
-            &CancellationToken::new(),
-        ),
-    )
-    .await
-    .expect_err("Should have timed out");
-
-    assert_eq!(next_expected_height, Height::new(1));
 }
 
 #[rstest]
@@ -919,7 +672,6 @@ async fn retries() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
 
     sender
@@ -940,7 +692,6 @@ async fn retries() {
 
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -952,7 +703,6 @@ async fn retries() {
     assert_eq!(next_expected_height, Height::ZERO);
 
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -962,307 +712,6 @@ async fn retries() {
 
     // Second certificate should succeed - height advances
     assert_eq!(next_expected_height, Height::new(1));
-}
-
-#[rstest]
-#[test_log::test(tokio::test)]
-#[timeout(Duration::from_secs(1))]
-async fn changing_epoch_triggers_certify() {
-    let mut pending = MockPendingStore::new();
-    pending
-        .expect_get_proof()
-        .returning(|_| Ok(Some(settlement_proof())));
-    let mut state = MockStateStore::new();
-    let mut certifier = MockCertifier::new();
-    expect_settlement_l1_context(&mut certifier);
-    let clock_ref = clock();
-    let network_id = 1.into();
-    let (sender, certificate_stream) = mpsc::channel(100);
-
-    let certificate = Certificate::new_for_test(network_id, Height::ZERO);
-    let certificate2 = Certificate::new_for_test(network_id, Height::new(1));
-    let certificate_id = certificate.hash();
-    let certificate_id2 = certificate2.hash();
-
-    pending
-        .expect_get_certificate()
-        .once()
-        .with(eq(network_id), eq(Height::ZERO))
-        .returning(|network_id, height| Ok(Some(Certificate::new_for_test(network_id, height))));
-
-    pending
-        .expect_get_certificate()
-        .once()
-        .with(eq(network_id), eq(Height::new(1)))
-        .returning(|network_id, height| Ok(Some(Certificate::new_for_test(network_id, height))));
-
-    state
-        .expect_read_local_network_state()
-        .returning(|_| Ok(Default::default()));
-
-    state
-        .expect_write_local_network_state()
-        .returning(|_, _, _| Ok(()));
-
-    state
-        .expect_get_latest_settled_certificate_per_network()
-        .once()
-        .with(eq(network_id))
-        .returning(|_| Ok(None));
-
-    state
-        .expect_get_certificate_header()
-        .once()
-        .with(eq(certificate_id))
-        .returning(|certificate_id| {
-            Ok(Some(agglayer_types::CertificateHeader {
-                network_id: 1.into(),
-                height: Height::ZERO,
-                epoch_number: None,
-                certificate_index: None,
-                certificate_id: *certificate_id,
-                new_local_exit_root: [0; 32].into(),
-                prev_local_exit_root: [1; 32].into(),
-                metadata: Metadata::ZERO,
-                status: CertificateStatus::Pending,
-                settlement_tx_hash: None,
-            }))
-        });
-
-    state
-        .expect_get_certificate_header()
-        .once()
-        .with(eq(certificate_id2))
-        .returning(|certificate_id| {
-            Ok(Some(agglayer_types::CertificateHeader {
-                network_id: 1.into(),
-                height: Height::new(1),
-                epoch_number: None,
-                certificate_index: None,
-                certificate_id: *certificate_id,
-                prev_local_exit_root: [1; 32].into(),
-                new_local_exit_root: [0; 32].into(),
-                metadata: Metadata::ZERO,
-                status: CertificateStatus::Pending,
-                settlement_tx_hash: None,
-            }))
-        });
-
-    certifier
-        .expect_certify()
-        .once()
-        .with(always(), eq(network_id), eq(Height::ZERO))
-        .return_once(move |new_state, network_id, _height| {
-            let result = crate::CertifierOutput {
-                certificate,
-                height: Height::ZERO,
-                new_state,
-                network: network_id,
-                new_pp_root: Digest::ZERO,
-            };
-
-            Ok(result)
-        });
-
-    certifier
-        .expect_certify()
-        .once()
-        .with(always(), eq(network_id), eq(Height::new(1)))
-        .return_once(move |new_state, network_id, _height| {
-            let result = crate::CertifierOutput {
-                certificate: certificate2,
-                height: Height::new(1),
-                new_state,
-                network: network_id,
-                new_pp_root: Digest::ZERO,
-            };
-
-            Ok(result)
-        });
-
-    pending
-        .expect_set_latest_proven_certificate_per_network()
-        .once()
-        .with(eq(network_id), eq(Height::ZERO), eq(certificate_id))
-        .returning(|_, _, _| Ok(()));
-
-    pending
-        .expect_set_latest_proven_certificate_per_network()
-        .once()
-        .with(eq(network_id), eq(Height::new(1)), eq(certificate_id2))
-        .returning(|_, _, _| Ok(()));
-
-    state
-        .expect_update_certificate_header_status()
-        .once()
-        .with(eq(certificate_id), eq(CertificateStatus::Proven))
-        .returning(|_, _| Ok(()));
-
-    state
-        .expect_update_certificate_header_status()
-        .once()
-        .with(eq(certificate_id2), eq(CertificateStatus::Proven))
-        .returning(|_, _| Ok(()));
-
-    // Both certificates transition through Candidate before settlement.
-    state
-        .expect_update_certificate_header_status()
-        .times(2)
-        .withf(|_, status| matches!(status, CertificateStatus::Candidate))
-        .returning(|_, _| Ok(()));
-
-    state
-        .expect_insert_certificate_settlement_job_id()
-        .returning(|_, _| Ok(()));
-    state
-        .expect_get_certificate_settlement_job_id()
-        .returning(|_| Ok(Some(job_id(1))));
-
-    state
-        .expect_update_settlement_tx_hash()
-        .once()
-        .withf(move |i, t, _f, _| *i == certificate_id && *t == SETTLEMENT_TX_HASH_1)
-        .returning(|_, _, _, _| Ok(()));
-
-    state
-        .expect_update_settlement_tx_hash()
-        .once()
-        .withf(move |i, t, _f, _| *i == certificate_id2 && *t == SETTLEMENT_TX_HASH_2)
-        .returning(|_, _, _, _| Ok(()));
-
-    state
-        .expect_update_certificate_header_status()
-        .once()
-        .with(eq(certificate_id), eq(CertificateStatus::Settled))
-        .returning(|_, _| Ok(()));
-
-    state
-        .expect_set_latest_settled_certificate_for_network()
-        .once()
-        .with(
-            eq(network_id),
-            eq(Height::ZERO),
-            eq(certificate_id),
-            eq(EpochNumber::ZERO),
-            eq(CertificateIndex::ZERO),
-        )
-        .returning(|_, _, _, _, _| Ok(()));
-
-    state
-        .expect_update_certificate_header_status()
-        .once()
-        .with(eq(certificate_id2), eq(CertificateStatus::Settled))
-        .returning(|_, _| Ok(()));
-
-    state
-        .expect_set_latest_settled_certificate_for_network()
-        .once()
-        .with(
-            eq(network_id),
-            eq(Height::new(1)),
-            eq(certificate_id2),
-            eq(EpochNumber::ZERO),
-            eq(CertificateIndex::ZERO),
-        )
-        .returning(|_, _, _, _, _| Ok(()));
-
-    let mut settlement_service = MockSettlementServiceTrait::new();
-    settlement_service
-        .expect_submit_settlement_job()
-        .times(2)
-        .returning(|_, _| Ok(job_id(1)));
-    settlement_service
-        .expect_wait_for_settlement()
-        .times(1)
-        .return_once(move |_| {
-            Ok(settlement_result(
-                SETTLEMENT_TX_HASH_1,
-                ContractCallOutcome::Success,
-            ))
-        });
-    settlement_service
-        .expect_wait_for_settlement()
-        .times(1)
-        .return_once(move |_| {
-            Ok(settlement_result(
-                SETTLEMENT_TX_HASH_2,
-                ContractCallOutcome::Success,
-            ))
-        });
-
-    let mut task = NetworkTask::new(
-        Arc::new(pending),
-        Arc::new(state),
-        Arc::new(certifier),
-        clock_ref.clone(),
-        network_id,
-        certificate_stream,
-        Arc::new(settlement_service),
-        mock_current_epoch(),
-    )
-    .expect("Failed to create a new network task");
-
-    let mut epochs = task.clock_ref.subscribe().unwrap();
-    let mut next_expected_height = Height::ZERO;
-
-    sender
-        .send(NewCertificate {
-            certificate_id,
-            height: Height::ZERO,
-        })
-        .await
-        .expect("Failed to send the certificate");
-
-    sender
-        .send(NewCertificate {
-            certificate_id: certificate_id2,
-            height: Height::new(1),
-        })
-        .await
-        .expect("Failed to send the certificate");
-    let mut first_run = true;
-    task.make_progress(
-        &mut epochs,
-        &mut next_expected_height,
-        &mut first_run,
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
-
-    assert_eq!(next_expected_height, Height::new(1));
-
-    tokio::time::timeout(
-        Duration::from_millis(100),
-        task.make_progress(
-            &mut epochs,
-            &mut next_expected_height,
-            &mut first_run,
-            &CancellationToken::new(),
-        ),
-    )
-    .await
-    .expect_err("Should have timed out");
-
-    assert_eq!(next_expected_height, Height::new(1));
-
-    clock_ref.update_block_height(2);
-
-    clock_ref
-        .get_sender()
-        .send(agglayer_clock::Event::EpochEnded(EpochNumber::ZERO))
-        .expect("Failed to send");
-    let mut first_run = true;
-    task.make_progress(
-        &mut epochs,
-        &mut next_expected_height,
-        &mut first_run,
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
-
-    assert_eq!(next_expected_height, Height::new(2));
 }
 
 #[rstest]
@@ -1358,7 +807,6 @@ async fn timeout_certifier() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
 
     sender
@@ -1370,7 +818,6 @@ async fn timeout_certifier() {
         .expect("Failed to send the certificate");
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -1486,7 +933,6 @@ async fn process_next_certificate() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
     let mut first_run = false; // Set to false since we're testing certificate processing, not initialization
 
@@ -1509,7 +955,6 @@ async fn process_next_certificate() {
 
     // Process first certificate
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -1519,17 +964,8 @@ async fn process_next_certificate() {
 
     assert_eq!(next_expected_height, Height::new(1));
 
-    // Advance the epoch and signal it so the per-epoch settlement backpressure
-    // releases before the second certificate.
-    clock_ref.update_block_height(2);
-    clock_ref
-        .get_sender()
-        .send(agglayer_clock::Event::EpochEnded(EpochNumber::new(1)))
-        .unwrap();
-
     // Process second certificate
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -1538,78 +974,4 @@ async fn process_next_certificate() {
     .unwrap();
 
     assert_eq!(next_expected_height, Height::new(2));
-}
-
-#[rstest]
-#[test_log::test(tokio::test)]
-#[timeout(Duration::from_secs(1))]
-async fn epoch_jammed(#[values(false, true)] at_capacity: bool) {
-    let mut pending = MockPendingStore::new();
-    let mut state = MockStateStore::new();
-    let certifier = MockCertifier::new();
-    let settlement_service = MockSettlementServiceTrait::new();
-    let clock_ref = clock();
-    let epoch_sender = clock_ref.get_sender();
-    let network_id = 1.into();
-    let (_sender, certificate_stream) = mpsc::channel(1);
-
-    state
-        .expect_read_local_network_state()
-        .returning(|_| Ok(Default::default()));
-
-    state
-        .expect_get_latest_settled_certificate_per_network()
-        .once()
-        .with(eq(network_id))
-        .returning(|_| Ok(None));
-
-    pending.expect_get_certificate().returning(|_, _| Ok(None));
-
-    let mut task = NetworkTask::new(
-        Arc::new(pending),
-        Arc::new(state),
-        Arc::new(certifier),
-        clock_ref.clone(),
-        network_id,
-        certificate_stream,
-        Arc::new(settlement_service),
-        mock_current_epoch(),
-    )
-    .expect("Failed to create a new network task");
-
-    let mut epochs = task.clock_ref.subscribe().unwrap();
-    let mut next_expected_height = Height::ZERO;
-
-    // Jam the epoch channel with a bunch of epoch events.
-    for epoch_no in 1..=105 {
-        epoch_sender
-            .send(agglayer_clock::Event::EpochEnded(EpochNumber::new(
-                epoch_no,
-            )))
-            .unwrap();
-    }
-
-    // Just make sure it does not panic or time out when epoch events are skipped.
-    let mut first_run = false;
-    task.at_capacity_for_epoch = at_capacity;
-    task.make_progress(
-        &mut epochs,
-        &mut next_expected_height,
-        &mut first_run,
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(task.at_capacity_for_epoch, at_capacity);
-
-    // Taking the next item from the channel should advance the epoch.
-    task.make_progress(
-        &mut epochs,
-        &mut next_expected_height,
-        &mut first_run,
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
-    assert!(!task.at_capacity_for_epoch);
 }

--- a/crates/agglayer-certificate-orchestrator/src/network_task/tests/status.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task/tests/status.rs
@@ -132,11 +132,9 @@ async fn from_pending_to_settled() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -267,11 +265,9 @@ async fn from_proven_to_settled() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -380,11 +376,9 @@ async fn from_candidate_to_settled() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -492,11 +486,9 @@ async fn from_candidate_to_settle_via_pending() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -555,11 +547,9 @@ async fn from_settled_to_settled() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::new(1);
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),
@@ -690,11 +680,9 @@ async fn from_proven_settlement_revert_goes_to_error() {
     )
     .expect("Failed to create a new network task");
 
-    let mut epochs = task.clock_ref.subscribe().unwrap();
     let mut next_expected_height = Height::ZERO;
     let mut first_run = true;
     task.make_progress(
-        &mut epochs,
         &mut next_expected_height,
         &mut first_run,
         &CancellationToken::new(),

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -38,8 +38,6 @@ pub(crate) mod cf_definitions;
 #[cfg(test)]
 mod tests;
 
-const MAX_CERTIFICATE_PER_EPOCH: u64 = 1;
-
 /// A logical store for an Epoch.
 pub struct PerEpochStore<PendingStore, StateStore> {
     pub epoch_number: Arc<EpochNumber>,
@@ -356,8 +354,6 @@ where
                 );
                 // Adding the network to the end checkpoint.
                 end_checkpoint_entry_assignment = Some(Height::ZERO);
-
-                // Adding the certificate to the DB
             }
             // If the network is not found in the end checkpoint and the height is not 0,
             // this is an invalid certificate candidate and the operation should fail.
@@ -369,18 +365,23 @@ where
             (Some(_start_height), Entry::Occupied(ref current_height))
                 if height == Height::ZERO =>
             {
+                debug!(
+                    "{}Failed certificate candidate for network {}: height is {} but network is \
+                     already present in the end checkpoint with height {}",
+                    mode.prefix(),
+                    network_id,
+                    height,
+                    current_height.get()
+                );
                 return Err(CertificateCandidateError::UnexpectedHeight(
                     network_id,
                     height,
                     *current_height.get(),
-                ))?
+                ))?;
             }
             // If the network is found in the end checkpoint and the height minus one is equal to
             // the current network height. We can add the certificate.
-            (Some(start_height), Entry::Occupied(current_height))
-                if current_height.get().next() == height
-                    && height.distance_since(start_height) <= MAX_CERTIFICATE_PER_EPOCH =>
-            {
+            (_, Entry::Occupied(current_height)) if current_height.get().next() == height => {
                 debug!(
                     "{}Certificate candidate for network {} at height {} accepted",
                     mode.prefix(),
@@ -392,11 +393,19 @@ where
             }
 
             (_, Entry::Occupied(current_height)) => {
+                debug!(
+                    "{}Failed certificate candidate for network {}: current height is {} \
+                     submitted certificate height is {}",
+                    mode.prefix(),
+                    network_id,
+                    current_height.get(),
+                    height,
+                );
                 return Err(CertificateCandidateError::UnexpectedHeight(
                     network_id,
                     height,
                     *current_height.get(),
-                ))?
+                ))?;
             }
         }
 

--- a/crates/agglayer-storage/src/stores/per_epoch/tests.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/tests.rs
@@ -387,7 +387,7 @@ fn adding_a_certificate(
 #[case::when_state_are_empty(
     StartCheckpointState::Empty,
     EndCheckpointState::Empty,
-    VecDeque::from([|result: Result<_, Error>| result.is_ok(), |result: Result<_, Error>| result.is_err()]),
+    VecDeque::from([|result: Result<_, Error>| result.is_ok(), |result: Result<_, Error>| result.is_ok()]),
     Height::ZERO)]
 #[case::when_state_are_empty_and_starting_at_wrong_height(
     StartCheckpointState::Empty,
@@ -397,7 +397,7 @@ fn adding_a_certificate(
 #[case::when_state_is_already_full(
     StartCheckpointState::Empty,
     EndCheckpointState::WithCheckpoint(vec![(NetworkId::new(0), Height::ZERO)]),
-    VecDeque::from([|result: Result<_, Error>| result.is_err()]),
+    VecDeque::from([|result: Result<_, Error>| result.is_ok()]),
     Height::new(1))]
 #[case::when_state_contains_other_network(
     StartCheckpointState::Empty,
@@ -625,4 +625,219 @@ fn can_retrieve_proof_at_index() {
         non_existent_proof.is_none(),
         "Should return None for non-existent index"
     );
+}
+
+#[rstest]
+#[case::five_certificates(5)]
+#[case::ten_certificates(10)]
+#[case::fifty_certificates(50)]
+fn can_add_multiple_certificates_per_epoch(
+    store: PerEpochStore<PendingStore, StateStore>,
+    #[case] num_certificates: u64,
+) {
+    let pending_store = store.pending_store.clone();
+    let state_store = store.state_store.clone();
+    let network = NetworkId::new(0);
+
+    // Add multiple certificates sequentially
+    for i in 0..num_certificates {
+        let height = Height::new(i);
+        let certificate = Certificate::new_for_test(network, height);
+        let certificate_id = certificate.hash();
+
+        state_store
+            .insert_certificate_header(&certificate, CertificateStatus::Proven)
+            .unwrap();
+
+        pending_store
+            .insert_pending_certificate(network, height, &certificate)
+            .unwrap();
+
+        pending_store
+            .insert_generated_proof(&certificate_id, &Proof::dummy())
+            .unwrap();
+
+        let result = store.add_certificate(certificate_id, agglayer_types::ExecutionMode::Default);
+        assert!(
+            result.is_ok(),
+            "Failed to add certificate at height {}: {:?}",
+            i,
+            result
+        );
+
+        let (epoch_number, certificate_index) = result.unwrap();
+        assert_eq!(epoch_number, EpochNumber::ZERO);
+        assert_eq!(certificate_index, CertificateIndex::new(i));
+    }
+
+    // Verify all certificates can be retrieved
+    for i in 0..num_certificates {
+        let certificate = store
+            .get_certificate_at_index(CertificateIndex::new(i))
+            .unwrap();
+        assert!(
+            certificate.is_some(),
+            "Certificate at index {} should exist",
+            i
+        );
+
+        let cert = certificate.unwrap();
+        assert_eq!(cert.network_id, network);
+        assert_eq!(cert.height, Height::new(i));
+    }
+
+    // Verify end checkpoint is updated correctly
+    let end_checkpoint = store.get_end_checkpoint();
+    assert_eq!(
+        end_checkpoint.get(&network),
+        Some(&Height::new(num_certificates - 1))
+    );
+}
+
+#[rstest]
+fn multiple_networks_multiple_certificates_per_epoch(
+    store: PerEpochStore<PendingStore, StateStore>,
+) {
+    let pending_store = store.pending_store.clone();
+    let state_store = store.state_store.clone();
+
+    // Add 10 certificates for 3 different networks
+    let networks = [NetworkId::new(0), NetworkId::new(1), NetworkId::new(2)];
+    let certificates_per_network = 10;
+
+    for network in networks.iter() {
+        for i in 0..certificates_per_network {
+            let height = Height::new(i);
+            let certificate = Certificate::new_for_test(*network, height);
+            let certificate_id = certificate.hash();
+
+            state_store
+                .insert_certificate_header(&certificate, CertificateStatus::Proven)
+                .unwrap();
+
+            pending_store
+                .insert_pending_certificate(*network, height, &certificate)
+                .unwrap();
+
+            pending_store
+                .insert_generated_proof(&certificate_id, &Proof::dummy())
+                .unwrap();
+
+            let result =
+                store.add_certificate(certificate_id, agglayer_types::ExecutionMode::Default);
+            assert!(
+                result.is_ok(),
+                "Failed to add certificate for network {} at height {}: {:?}",
+                network,
+                i,
+                result
+            );
+        }
+    }
+
+    // Verify end checkpoints for all networks
+    let end_checkpoint = store.get_end_checkpoint();
+    for network in networks.iter() {
+        assert_eq!(
+            end_checkpoint.get(network),
+            Some(&Height::new(certificates_per_network - 1)),
+            "Network {} should have end checkpoint at height {}",
+            network,
+            certificates_per_network - 1
+        );
+    }
+
+    // Verify total number of certificates
+    let mut count = 0;
+    for i in 0..(networks.len() as u64 * certificates_per_network) {
+        if store
+            .get_certificate_at_index(CertificateIndex::new(i))
+            .unwrap()
+            .is_some()
+        {
+            count += 1;
+        }
+    }
+    assert_eq!(
+        count,
+        networks.len() as u64 * certificates_per_network,
+        "Should have {} total certificates",
+        networks.len() * certificates_per_network as usize
+    );
+}
+
+#[rstest]
+fn sequential_validation_still_enforced(store: PerEpochStore<PendingStore, StateStore>) {
+    let pending_store = store.pending_store.clone();
+    let state_store = store.state_store.clone();
+    let network = NetworkId::new(0);
+
+    // Add first certificate at height 0
+    let height0 = Height::ZERO;
+    let certificate0 = Certificate::new_for_test(network, height0);
+    let certificate_id0 = certificate0.hash();
+
+    pending_store
+        .insert_pending_certificate(network, height0, &certificate0)
+        .unwrap();
+
+    let height1 = Height::new(1);
+    let certificate1 = Certificate::new_for_test(network, height1);
+    let certificate_id1 = certificate1.hash();
+
+    pending_store
+        .insert_pending_certificate(network, height1, &certificate1)
+        .unwrap();
+
+    let height2 = Height::new(2);
+    let certificate2 = Certificate::new_for_test(network, height2);
+    let certificate_id2 = certificate2.hash();
+
+    pending_store
+        .insert_pending_certificate(network, height2, &certificate2)
+        .unwrap();
+
+    state_store
+        .insert_certificate_header(&certificate0, CertificateStatus::Proven)
+        .unwrap();
+
+    pending_store
+        .insert_generated_proof(&certificate_id0, &Proof::dummy())
+        .unwrap();
+
+    assert!(store
+        .add_certificate(certificate_id0, agglayer_types::ExecutionMode::Default)
+        .is_ok());
+
+    state_store
+        .insert_certificate_header(&certificate2, CertificateStatus::Proven)
+        .unwrap();
+
+    pending_store
+        .insert_generated_proof(&certificate_id2, &Proof::dummy())
+        .unwrap();
+
+    let result = store.add_certificate(certificate_id2, agglayer_types::ExecutionMode::Default);
+    assert!(
+        result.is_err(),
+        "Should reject certificate with gap in heights"
+    );
+    assert!(matches!(
+        result,
+        Err(Error::CertificateCandidateError(
+            crate::error::CertificateCandidateError::UnexpectedHeight(_, _, _)
+        ))
+    ));
+
+    state_store
+        .insert_certificate_header(&certificate1, CertificateStatus::Proven)
+        .unwrap();
+
+    pending_store
+        .insert_generated_proof(&certificate_id1, &Proof::dummy())
+        .unwrap();
+
+    assert!(store
+        .add_certificate(certificate_id1, agglayer_types::ExecutionMode::Default)
+        .is_ok());
 }


### PR DESCRIPTION
Applies the first commit of #1536 (6aad8350, the revert of #1514) on
top of the settlement-service network task rework from #1393,
preserving the multi-certificate-per-epoch behavior needed for the
SP1 v6 release. #1393 merged while this was being prepared, so the
base is main (which now contains it); this supersedes #1536.

Adapted to the reworked network task from #1393: the epoch stream
subscription and at_capacity_for_epoch gating are removed from
NetworkTask, its epoch-gating tests (one_per_epoch,
changing_epoch_triggers_certify, epoch_jammed) are deleted, and
per-epoch storage validation accepts multiple certificates per epoch
again.