### PR TITLE
fix(rpc): refuse certificate replacement while its settlement job has not reverted

### DIFF
--- a/crates/agglayer-grpc-api/src/certificate_submission_service/mod.rs
+++ b/crates/agglayer-grpc-api/src/certificate_submission_service/mod.rs
@@ -8,7 +8,7 @@ use agglayer_grpc_types::node::v1::{
 use agglayer_rpc::AgglayerService;
 use agglayer_storage::stores::{
     DebugReader, DebugWriter, EpochStoreReader, PendingCertificateReader, PendingCertificateWriter,
-    StateReader, StateWriter,
+    SettlementReader, StateReader, StateWriter,
 };
 use error::CertificateSubmissionErrorWrapper;
 use tonic_types::{ErrorDetails, StatusExt};
@@ -29,7 +29,7 @@ impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore> CertificateSubmis
     for CertificateSubmissionServer<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
 where
     PendingStore: PendingCertificateReader + PendingCertificateWriter + 'static,
-    StateStore: StateReader + StateWriter + 'static,
+    StateStore: SettlementReader + StateReader + StateWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
     L1Rpc: RollupContract + AggchainContract + L1TransactionFetcher + Send + Sync + 'static,
     EpochsStore: EpochStoreReader + 'static,

--- a/crates/agglayer-grpc-api/src/lib.rs
+++ b/crates/agglayer-grpc-api/src/lib.rs
@@ -9,7 +9,7 @@ use agglayer_grpc_server::node::v1::{
 };
 use agglayer_storage::stores::{
     DebugReader, DebugWriter, EpochStoreReader, NetworkInfoReader, PendingCertificateReader,
-    PendingCertificateWriter, StateReader, StateWriter,
+    PendingCertificateWriter, SettlementReader, StateReader, StateWriter,
 };
 use certificate_submission_service::CertificateSubmissionServer;
 use configuration_service::ConfigurationServer;
@@ -100,7 +100,7 @@ impl Server {
     where
         L1Rpc: RollupContract + AggchainContract + L1TransactionFetcher + Send + Sync + 'static,
         PendingStore: PendingCertificateReader + PendingCertificateWriter + 'static,
-        StateStore: NetworkInfoReader + StateReader + StateWriter + 'static,
+        StateStore: NetworkInfoReader + SettlementReader + StateReader + StateWriter + 'static,
         DebugStore: DebugReader + DebugWriter + 'static,
         EpochsStore: EpochStoreReader + 'static,
     {

--- a/crates/agglayer-jsonrpc-api/src/lib.rs
+++ b/crates/agglayer-jsonrpc-api/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 use agglayer_contracts::{AggchainContract, L1TransactionFetcher, RollupContract};
 use agglayer_storage::stores::{
     DebugReader, DebugWriter, EpochStoreReader, NetworkInfoReader, PendingCertificateReader,
-    PendingCertificateWriter, StateReader, StateWriter,
+    PendingCertificateWriter, SettlementReader, StateReader, StateWriter,
 };
 use agglayer_types::{
     Certificate, CertificateHeader, CertificateId, EpochConfiguration, NetworkId, NetworkInfo,
@@ -122,7 +122,7 @@ where
     V0Rpc: Provider + Clone + 'static,
     Rpc: RollupContract + AggchainContract + L1TransactionFetcher + 'static + Send + Sync,
     PendingStore: PendingCertificateWriter + PendingCertificateReader + 'static,
-    StateStore: NetworkInfoReader + StateReader + StateWriter + 'static,
+    StateStore: NetworkInfoReader + SettlementReader + StateReader + StateWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
     EpochsStore: EpochStoreReader + 'static,
 {
@@ -198,7 +198,7 @@ where
     V0Rpc: Provider + Clone + 'static,
     Rpc: RollupContract + AggchainContract + L1TransactionFetcher + 'static + Send + Sync,
     PendingStore: PendingCertificateWriter + PendingCertificateReader + 'static,
-    StateStore: NetworkInfoReader + StateReader + StateWriter + 'static,
+    StateStore: NetworkInfoReader + SettlementReader + StateReader + StateWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
     EpochsStore: EpochStoreReader + 'static,
 {

--- a/crates/agglayer-rpc/src/lib.rs
+++ b/crates/agglayer-rpc/src/lib.rs
@@ -8,13 +8,13 @@ use agglayer_storage::{
     columns::latest_settled_certificate_per_network::SettledCertificate,
     stores::{
         DebugReader, DebugWriter, EpochStoreReader, NetworkInfoReader, PendingCertificateReader,
-        PendingCertificateWriter, StateReader, StateWriter,
+        PendingCertificateWriter, SettlementReader, StateReader, StateWriter,
     },
 };
 use agglayer_types::{
     aggchain_data::MultisigCtx, aggchain_proof::AggchainData, Certificate, CertificateHeader,
-    CertificateId, CertificateStatus, EpochConfiguration, Height, NetworkId, NetworkInfo,
-    NetworkStatus, NetworkType, SettledClaim, U256,
+    CertificateId, CertificateStatus, ContractCallOutcome, EpochConfiguration, Height, NetworkId,
+    NetworkInfo, NetworkStatus, NetworkType, SettledClaim, U256,
 };
 use error::SignatureVerificationError;
 use tokio::sync::mpsc;
@@ -672,8 +672,78 @@ where
 impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
     AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
 where
+    StateStore: StateReader + SettlementReader + 'static,
+{
+    /// Refuse replacing a certificate whose settlement job may still settle
+    /// (or already has settled) this height on L1.
+    ///
+    /// The settlement tx hash is only recorded on the header after a terminal
+    /// success, so an in-flight or spuriously-failed settlement leaves an
+    /// `InError` certificate with no hash while its transaction is still live
+    /// on L1 (and gets re-broadcast by settlement-service startup recovery).
+    /// Replacing the certificate then races the old transaction with the
+    /// replacement's: the old one settles first (lower nonce, same wallet) and
+    /// L1 diverges from the certificate we track at this height. Only a
+    /// terminally reverted settlement job makes replacement safe.
+    // The error type is the submission pipeline's; boxing it here just to
+    // shrink this one sync fn's Result would leak the lint into the caller.
+    #[allow(clippy::result_large_err)]
+    fn ensure_no_live_settlement_job(
+        &self,
+        certificate: &Certificate,
+        pre_existing_certificate_id: CertificateId,
+        replacement_certificate_id: CertificateId,
+    ) -> Result<(), CertificateSubmissionError> {
+        let Some(settlement_job_id) = self
+            .state
+            .get_certificate_settlement_job_id(&pre_existing_certificate_id)?
+        else {
+            return Ok(());
+        };
+
+        // Replacement is the risky operation here, so the allowing arm is the
+        // strict one: only an explicit terminal revert lets it through. Any
+        // outcome added to `ContractCallOutcome` in the future must take an
+        // explicit stance on replacement to make this match exhaustive again.
+        let result = self.state.get_settlement_job_result(&settlement_job_id)?;
+        let message = match result.as_ref().map(|r| &r.contract_call_result.outcome) {
+            Some(ContractCallOutcome::Revert) => {
+                info!(
+                    %pre_existing_certificate_id,
+                    %settlement_job_id,
+                    "Settlement job of the replaced certificate terminally reverted; replacement \
+                     allowed"
+                );
+                return Ok(());
+            }
+            None => {
+                "Unable to replace a certificate in error whose settlement job is still in flight"
+            }
+            Some(ContractCallOutcome::Success) => {
+                "Unable to replace a certificate in error whose settlement job has already \
+                 succeeded"
+            }
+        };
+
+        warn!(%pre_existing_certificate_id, %settlement_job_id, message);
+        Err(
+            CertificateSubmissionError::UnableToReplacePendingCertificate {
+                reason: message.to_string(),
+                height: certificate.height,
+                network_id: certificate.network_id,
+                stored_certificate_id: pre_existing_certificate_id,
+                replacement_certificate_id,
+                source: None,
+            },
+        )
+    }
+}
+
+impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+    AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+where
     PendingStore: PendingCertificateWriter + PendingCertificateReader + 'static,
-    StateStore: StateReader + StateWriter + 'static,
+    StateStore: StateReader + StateWriter + SettlementReader + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
     L1Rpc: RollupContract + AggchainContract + L1TransactionFetcher + 'static,
 {
@@ -718,6 +788,12 @@ where
                 .state
                 .get_certificate_header(&pre_existing_certificate_id)?
             {
+                self.ensure_no_live_settlement_job(
+                    certificate,
+                    pre_existing_certificate_id,
+                    new_certificate_id,
+                )?;
+
                 match settlement_tx_hash {
                     None => {
                         info!(

--- a/crates/agglayer-rpc/src/tests/certificate_replacement.rs
+++ b/crates/agglayer-rpc/src/tests/certificate_replacement.rs
@@ -1,0 +1,171 @@
+use std::sync::Arc;
+
+use agglayer_config::Config;
+use agglayer_storage::tests::mocks::{
+    MockDebugStore, MockEpochsStore, MockPendingStore, MockStateStore,
+};
+use agglayer_types::{
+    Address, Certificate, CertificateId, ContractCallOutcome, ContractCallResult, Digest,
+    NetworkId, Nonce, SettlementAttemptNumber, SettlementJobId, SettlementJobResult,
+    SettlementTxHash, B256,
+};
+use alloy::providers::{mock::Asserter, ProviderBuilder};
+use mockall::predicate::eq;
+
+use crate::CertificateSubmissionError;
+
+const NETWORK_1: NetworkId = NetworkId::new(1);
+
+fn settlement_job_id() -> SettlementJobId {
+    SettlementJobId::from(42u128)
+}
+
+fn job_result(outcome: ContractCallOutcome) -> SettlementJobResult {
+    SettlementJobResult {
+        wallet: Address::new([0u8; 20]),
+        nonce: Nonce(0),
+        attempt_number: SettlementAttemptNumber(0),
+        contract_call_result: ContractCallResult {
+            outcome,
+            metadata: Default::default(),
+            block_hash: B256::ZERO,
+            block_number: 0,
+            tx_hash: SettlementTxHash::new(Digest([9u8; 32])),
+        },
+    }
+}
+
+fn service_with_state(
+    state_store: MockStateStore,
+) -> crate::AgglayerService<
+    impl alloy::providers::Provider,
+    MockPendingStore,
+    MockStateStore,
+    MockDebugStore,
+    MockEpochsStore,
+> {
+    let certificate_sender = tokio::sync::mpsc::channel(1).0;
+    let asserter = Asserter::new();
+    let l1_rpc_provider = Arc::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+    crate::AgglayerService::new(
+        certificate_sender,
+        Arc::new(MockPendingStore::new()),
+        Arc::new(state_store),
+        Arc::new(MockDebugStore::new()),
+        Arc::new(MockEpochsStore::new()),
+        Arc::new(Config::default()),
+        l1_rpc_provider,
+    )
+}
+
+fn ids() -> (Certificate, CertificateId, CertificateId) {
+    let replacement = Certificate::new_for_test(NETWORK_1, 0.into());
+    let replacement_id = replacement.hash();
+    let pre_existing_id = CertificateId::new(Digest([1u8; 32]));
+    (replacement, pre_existing_id, replacement_id)
+}
+
+#[test]
+fn replacement_refused_while_settlement_job_is_pending() {
+    let (replacement, pre_existing_id, replacement_id) = ids();
+
+    let mut state_store = MockStateStore::new();
+    state_store
+        .expect_get_certificate_settlement_job_id()
+        .with(eq(pre_existing_id))
+        .once()
+        .returning(|_| Ok(Some(settlement_job_id())));
+    state_store
+        .expect_get_settlement_job_result()
+        .with(eq(settlement_job_id()))
+        .once()
+        .returning(|_| Ok(None));
+
+    let service = service_with_state(state_store);
+    let error = service
+        .ensure_no_live_settlement_job(&replacement, pre_existing_id, replacement_id)
+        .expect_err("a pending settlement job must block replacement");
+
+    match error {
+        CertificateSubmissionError::UnableToReplacePendingCertificate {
+            reason,
+            stored_certificate_id,
+            replacement_certificate_id,
+            ..
+        } => {
+            assert!(reason.contains("still in flight"), "reason: {reason}");
+            assert_eq!(stored_certificate_id, pre_existing_id);
+            assert_eq!(replacement_certificate_id, replacement_id);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn replacement_refused_after_settlement_job_success() {
+    let (replacement, pre_existing_id, replacement_id) = ids();
+
+    let mut state_store = MockStateStore::new();
+    state_store
+        .expect_get_certificate_settlement_job_id()
+        .with(eq(pre_existing_id))
+        .once()
+        .returning(|_| Ok(Some(settlement_job_id())));
+    state_store
+        .expect_get_settlement_job_result()
+        .with(eq(settlement_job_id()))
+        .once()
+        .returning(|_| Ok(Some(job_result(ContractCallOutcome::Success))));
+
+    let service = service_with_state(state_store);
+    let error = service
+        .ensure_no_live_settlement_job(&replacement, pre_existing_id, replacement_id)
+        .expect_err("a succeeded settlement job must block replacement");
+
+    match error {
+        CertificateSubmissionError::UnableToReplacePendingCertificate { reason, .. } => {
+            assert!(reason.contains("already succeeded"), "reason: {reason}");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn replacement_allowed_after_settlement_job_revert() {
+    let (replacement, pre_existing_id, replacement_id) = ids();
+
+    let mut state_store = MockStateStore::new();
+    state_store
+        .expect_get_certificate_settlement_job_id()
+        .with(eq(pre_existing_id))
+        .once()
+        .returning(|_| Ok(Some(settlement_job_id())));
+    state_store
+        .expect_get_settlement_job_result()
+        .with(eq(settlement_job_id()))
+        .once()
+        .returning(|_| Ok(Some(job_result(ContractCallOutcome::Revert))));
+
+    let service = service_with_state(state_store);
+    service
+        .ensure_no_live_settlement_job(&replacement, pre_existing_id, replacement_id)
+        .expect("a terminally reverted settlement job must allow replacement");
+}
+
+#[test]
+fn replacement_allowed_without_settlement_job() {
+    let (replacement, pre_existing_id, replacement_id) = ids();
+
+    let mut state_store = MockStateStore::new();
+    state_store
+        .expect_get_certificate_settlement_job_id()
+        .with(eq(pre_existing_id))
+        .once()
+        .returning(|_| Ok(None));
+
+    let service = service_with_state(state_store);
+    service
+        .ensure_no_live_settlement_job(&replacement, pre_existing_id, replacement_id)
+        .expect("a certificate without a settlement job keeps the legacy replacement behavior");
+}

--- a/crates/agglayer-rpc/src/tests/mod.rs
+++ b/crates/agglayer-rpc/src/tests/mod.rs
@@ -1,1 +1,2 @@
+pub mod certificate_replacement;
 pub mod network_info;


### PR DESCRIPTION
Fixes #1608

Follow-up to #1393 (found during its review).

## Problem

The settlement tx hash is only written to the certificate header after a terminal success, so any pre-success settlement failure leaves an `InError` certificate with `settlement_tx_hash: None` while its broadcast transaction is still live on L1 (and gets re-broadcast by settlement-service startup recovery). `validate_pre_existing_certificate` keyed only on the header hash, so its `None` branch accepted a replacement certificate during that window. The replacement's settlement job takes a higher nonce on the same wallet, so L1 must mine the orphaned transaction first: L1 settles the **old** certificate's state transition while agglayer's records at that height hold the replacement, whose own transaction then reverts against the advanced root — both certificates end `InError` and latest-settled freezes.

## Fix

`validate_pre_existing_certificate` now also consults the settlement service via a new `ensure_no_live_settlement_job` helper, which runs at the top of the `InError` arm (covering both the `None` and `Some` hash branches):

- cert→job link exists, no terminal result → **refused** ("settlement job is still in flight")
- link exists, job result `Success` → **refused** ("settlement job has already succeeded" — covers the job-succeeded-but-cert-`InError` window, where the height is already settled on L1)
- link exists, job result `Revert` → allowed
- no link → allowed (legacy behavior preserved)

Replacement being the risky operation, the allowing arm strictly matches `ContractCallOutcome::Revert` with no wildcard: any future outcome variant makes the match non-exhaustive, forcing an explicit replacement-policy decision at this site.

The `SettlementReader` bound propagates through the generic impls in `agglayer-jsonrpc-api` and `agglayer-grpc-api`; the production `StateStore` already implements it, so no wiring changes.

## Tests

Four unit tests in `agglayer-rpc` cover the matrix above (pending → refused, succeeded → refused, reverted → allowed, no link → allowed, with mockall verifying the result lookup is skipped when no link exists).

Verification: `cargo check --workspace --tests --all-features`, `cargo make ci-all`, and `cargo nextest run --workspace` (816/816) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)