### PR TITLE
fix: prevent panic-loop on conflicting attempt results

### DIFF
--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -1704,9 +1704,22 @@ impl<
             }
 
             if !current_result.can_be_replaced_by(&result) {
+                // A "settled elsewhere" note can reach an attempt that already has a real
+                // result. Keep the real result. Panicking here would repeat on every restart
+                // and wedge the job forever.
+                if result.is_resolved_elsewhere() {
+                    warn!(
+                        "Settlement task {} kept result {current_result:?} for attempt \
+                         {attempt_number}, dropped conflicting write {result:?}",
+                        self.id
+                    );
+                    return;
+                }
+
                 panic!(
-                    "Settlement task {} tried to replace conflicting result for attempt {}",
-                    self.id, attempt_number
+                    "Settlement task {} tried to replace conflicting result for attempt \
+                     {attempt_number}: {current_result:?} -> {result:?}",
+                    self.id
                 );
             }
         }
@@ -2433,6 +2446,42 @@ mod tests {
             existing_hash
         );
         assert!(!task.attempts.contains_key(&(new_wallet, new_nonce)));
+    }
+
+    #[tokio::test]
+    async fn record_attempt_result_keeps_revert_over_conflicting_write() {
+        // Regression (#1607): a stored revert must survive a later "settled elsewhere"
+        // write instead of panicking (which used to repeat on every restart).
+        let wallet = Address::from([2; 20]);
+        let nonce = Nonce(7);
+        let attempt_number = SettlementAttemptNumber(3);
+        let revert = SettlementAttemptResult::ContractCall(mk_contract_call_result(
+            1,
+            ContractCallOutcome::Revert,
+        ));
+
+        let attempts = BTreeMap::from([(
+            (wallet, nonce),
+            BTreeMap::from([(
+                attempt_number,
+                mk_active_attempt(wallet, nonce, mk_tx_hash(1), Some(revert.clone())),
+            )]),
+        )]);
+
+        // The conflicting write is dropped, so the store is never called.
+        let mut task = mk_task(Arc::new(MockStateStore::new()), attempts);
+
+        task.record_attempt_result_to_db(
+            attempt_number,
+            SettlementAttemptResult::ClientError(ClientError::settlement_succeeded_elsewhere(
+                mk_tx_hash(9),
+            )),
+        );
+
+        assert_eq!(
+            task.attempts[&(wallet, nonce)][&attempt_number].result,
+            Some(revert)
+        );
     }
 
     #[tokio::test]

--- a/crates/agglayer-types/src/settlement.rs
+++ b/crates/agglayer-types/src/settlement.rs
@@ -140,6 +140,8 @@ impl ClientError {
 }
 
 impl SettlementAttemptResult {
+    /// May `replacement` overwrite `self`? Only a stronger result replaces a
+    /// weaker one.
     pub fn can_be_replaced_by(&self, replacement: &Self) -> bool {
         match (self, replacement) {
             (Self::ClientError(_), Self::ContractCall(_)) => true,
@@ -153,6 +155,20 @@ impl SettlementAttemptResult {
             }
             _ => false,
         }
+    }
+
+    /// True for "nonce used elsewhere" / "settled elsewhere" results: notes
+    /// that another tx handled the attempt. They never overwrite a real
+    /// result.
+    pub fn is_resolved_elsewhere(&self) -> bool {
+        matches!(
+            self,
+            Self::ClientError(ClientError {
+                kind: ClientErrorType::NonceAlreadyUsed
+                    | ClientErrorType::SettlementSucceededElsewhere,
+                ..
+            })
+        )
     }
 }
 
@@ -183,4 +199,23 @@ pub struct SettlementAttempt {
     /// `max_priority_fee_per_gas` (wei) of the signed attempt; the baseline a
     /// retry bumps from.
     pub max_priority_fee_per_gas: u128,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client_error(kind: ClientErrorType) -> SettlementAttemptResult {
+        SettlementAttemptResult::ClientError(ClientError {
+            kind,
+            message: String::new(),
+        })
+    }
+
+    #[test]
+    fn is_resolved_elsewhere_matches_used_and_settled_kinds() {
+        assert!(client_error(ClientErrorType::NonceAlreadyUsed).is_resolved_elsewhere());
+        assert!(client_error(ClientErrorType::SettlementSucceededElsewhere).is_resolved_elsewhere());
+        assert!(!client_error(ClientErrorType::Unknown).is_resolved_elsewhere());
+    }
 }


### PR DESCRIPTION
Closes #1607 

## What breaks today

A settlement job can use more than one nonce. When one nonce **reverts** and another
nonce **later succeeds**, the job can panic — and because the conflicting state is written
to disk, it **re-panics on every restart**. End result: settlement actually succeeded on
L1, but the certificate is stuck `InError` forever, with no way to recover.

Normally a revert finalizes the job right away, so a later success never happens. The
trigger here is a **shallow reorg** during the finalization wait: it lets the job keep
running with a revert already recorded, and a later success then tries to overwrite it.

## Step by step

Wallet `W`, two nonces — nonce `5` reverts, nonce `6` later succeeds:

| step | event | `attempts[(W,5)] #0` | `attempts[(W,6)]` | job result |
|------|-------|----------------------|-------------------|------------|
| 1 | nonce 5 tx reverts, nonce 6 tx seen → enter finalization block | `None` | pending | – |
| 2 | loop hits nonce 5 → `write_nonce_revert_to_db` | **`ContractCall(Revert)`** (saved to disk) | pending | – |
| 3 | loop hits nonce 6 → `wait_for_settlement_of` returns `None` (block reorged) → `continue 'start` | `ContractCall(Revert)` | pending | still none |
| 4 | back at `'start`, a fresh nonce-6 attempt succeeds → `write_job_result_to_db(W, 6, Success)` | `ContractCall(Revert)` | `ContractCall(Success)` | writing… |
| 5 | the success marks every **other** attempt "settled elsewhere" → `record_attempt_result_to_db(#0, ClientError(succeeded_elsewhere))` | `ContractCall(Revert)` vs incoming `ClientError` | | |
| 6 | `can_be_replaced_by(ContractCall(Revert), ClientError(…))` → `false` | 💥 **panic** | | never written |

The key moment is **step 5**: a success marks all the *other* attempts as "settled
elsewhere" (bookkeeping). One of those others — nonce 5 — already holds a **real revert**,
and a real on-chain result must never be overwritten by a bookkeeping note, so it panics
(**step 6**). The revert is on disk, so on restart the job replays these exact steps and
panics again — forever.

## The fix

A "settled elsewhere" note is best-effort. When it lands on an attempt that already has a
real result, **keep the real result and skip the note** instead of panicking. The job then
finalizes with the real outcome (`Success`) and the certificate settles.

Genuine impossible conflicts (two different on-chain verdicts for the same attempt) still
panic, so real bugs stay loud.