### PR TITLE
feat: include software version in /health endpoint

### DIFF
--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -112,6 +112,7 @@ pub fn main(
         Node::builder()
             .config(config.clone())
             .cancellation_token(global_cancellation_token.clone())
+            .version(version.to_string())
             .start(),
     )?;
     let terminate_signal = async {

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -58,6 +58,7 @@ impl Node {
     ///    Node::builder()
     ///      .config(config)
     ///      .cancellation_token(CancellationToken::new())
+    ///      .version(env!("CARGO_PKG_VERSION").to_string())
     ///      .start()
     ///      .await?;
     ///
@@ -76,6 +77,7 @@ impl Node {
     pub(crate) async fn start(
         config: Arc<Config>,
         cancellation_token: CancellationToken,
+        version: String,
     ) -> eyre::Result<Self> {
         if config.mock_verifier {
             warn!(
@@ -330,7 +332,7 @@ impl Node {
                 .build()
                 .inspect_err(|err| error!(?err, "Failed to build public gRPC router"))?;
 
-        let health_router = api::rest::health_router();
+        let health_router = api::rest::health_router(version);
 
         let readrpc_router = axum::Router::new()
             .merge(health_router)

--- a/crates/agglayer-node/src/node/api/rest.rs
+++ b/crates/agglayer-node/src/node/api/rest.rs
@@ -1,12 +1,15 @@
 use hyper::StatusCode;
 
-pub(crate) fn health_router() -> axum::Router {
-    axum::Router::new().route("/health", axum::routing::get(health))
+pub(crate) fn health_router(version: String) -> axum::Router {
+    axum::Router::new().route(
+        "/health",
+        axum::routing::get(move || health(version.clone())),
+    )
 }
 
-pub(crate) async fn health() -> impl axum::response::IntoResponse {
+pub(crate) async fn health(version: String) -> impl axum::response::IntoResponse {
     (
         StatusCode::OK,
-        serde_json::json!({ "health": true }).to_string(),
+        serde_json::json!({ "health": true, "version": version }).to_string(),
     )
 }

--- a/crates/agglayer-node/src/node/api/tests/mod.rs
+++ b/crates/agglayer-node/src/node/api/tests/mod.rs
@@ -11,7 +11,7 @@ use crate::node::api;
 
 #[test_log::test(tokio::test)]
 async fn healthcheck_method_can_be_called() {
-    let router = api::rest::health_router();
+    let router = api::rest::health_router("test-version".to_string());
     let addr = TestContext::next_available_address();
     let listener = TcpListener::bind(addr).await.unwrap();
 
@@ -38,6 +38,6 @@ async fn healthcheck_method_can_be_called() {
         .await
         .unwrap();
     let out = String::from_utf8(bytes.to_bytes().to_vec()).unwrap();
-    assert_eq!(out.as_str(), "{\"health\":true}");
+    assert_eq!(out.as_str(), "{\"health\":true,\"version\":\"test-version\"}");
     token.cancel();
 }

--- a/crates/agglayer-node/src/node/api/tests/mod.rs
+++ b/crates/agglayer-node/src/node/api/tests/mod.rs
@@ -38,6 +38,9 @@ async fn healthcheck_method_can_be_called() {
         .await
         .unwrap();
     let out = String::from_utf8(bytes.to_bytes().to_vec()).unwrap();
-    assert_eq!(out.as_str(), "{\"health\":true,\"version\":\"test-version\"}");
+    assert_eq!(
+        out.as_str(),
+        "{\"health\":true,\"version\":\"test-version\"}"
+    );
     token.cancel();
 }


### PR DESCRIPTION
## Summary

The `/health` endpoint of the agglayer node now returns the running software version in addition to the existing health boolean.

Response body:

```json
{"health":true,"version":"agglayer (v0.x.x-...) [git commit timestamp: ...]"}
```

- `health` — unchanged boolean (`true`), same status code (`200 OK`)
- `version` — the running build version (already available in `agglayer_node::main`, previously only logged)

This makes it easy to check which build is deployed without shell access to the container.

## Test plan

- [x] `cargo build -p agglayer-node`
- [x] `cargo nextest run -p agglayer-node healthcheck_method_can_be_called`

Made with [Cursor](https://cursor.com)