### PR TITLE
fix: log expected settlement polling retries at debug level

### DIFF
--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -199,6 +199,18 @@ impl WaitForSettlementError {
             Self::Transport(error) => crate::utils::is_transient_alloy_error(error),
         }
     }
+
+    /// Whether the retry loop should log this transient error at warning
+    /// level. The "not yet" variants are the expected steady state while
+    /// polling for inclusion or settlement of a submitted transaction, so they
+    /// are only worth debug logs; transport errors are anomalies worth
+    /// surfacing.
+    fn needs_warning_log(&self) -> bool {
+        match self {
+            Self::NotSettledYet | Self::NotIncludedYet => false,
+            Self::Transport(_) => true,
+        }
+    }
 }
 
 impl From<TransportError> for WaitForSettlementError {
@@ -919,6 +931,7 @@ impl<
                 Err(WaitForSettlementError::NotIncludedYet)
             },
             WaitForSettlementError::is_transient,
+            WaitForSettlementError::needs_warning_log,
         )
         .await;
     }
@@ -992,6 +1005,7 @@ impl<
             &self.control.cancellation_token,
             check,
             WaitForSettlementError::is_transient,
+            WaitForSettlementError::needs_warning_log,
         )
         .await
         .map_err(|error| match error {
@@ -1383,6 +1397,7 @@ impl<
                 Ok(Some((attempt_number, tx)))
             },
             |error| retry_policy.should_retry(error),
+            |_| true,
         )
         .await
     }
@@ -1428,6 +1443,7 @@ impl<
                 Ok((wallet, nonce, attempt_number, tx))
             },
             |error| retry_policy.should_retry(error),
+            |_| true,
         )
         .await
     }
@@ -3326,6 +3342,16 @@ mod tests {
         assert_eq!(envelope.chain_id(), Some(anvil.chain_id()));
         // Fees are within the configured bounds (defaults: floor 0, ceiling 100 gwei).
         assert!(envelope.max_fee_per_gas() <= 100_000_000_000);
+    }
+
+    #[test]
+    fn polling_signals_skip_the_retry_warning_log() {
+        assert!(!WaitForSettlementError::NotIncludedYet.needs_warning_log());
+        assert!(!WaitForSettlementError::NotSettledYet.needs_warning_log());
+        assert!(
+            WaitForSettlementError::Transport(TransportErrorKind::custom_str("connection reset"))
+                .needs_warning_log()
+        );
     }
 
     #[test]

--- a/crates/agglayer-settlement-service/src/utils.rs
+++ b/crates/agglayer-settlement-service/src/utils.rs
@@ -13,7 +13,7 @@ use alloy::{
 };
 use rand::Rng as _;
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{debug, warn};
 
 #[derive(Debug)]
 pub(crate) enum RetryCallbackError<E> {
@@ -21,25 +21,41 @@ pub(crate) enum RetryCallbackError<E> {
     Cancelled,
 }
 
+/// Number of consecutive failed retries after which every further retry is
+/// logged at warning level even when `needs_warning_log` says debug, so a
+/// retry loop stuck on an expected "keep polling" signal still surfaces in the
+/// default logs. With the default non-inclusion policy (60s doubling up to
+/// 10min intervals) this only triggers roughly 10 hours into a stuck wait, far
+/// beyond any healthy inclusion or finality delay.
+const FORCE_WARNING_AFTER_RETRIES: u64 = 64;
+
 /// Calls `callback` until it succeeds.
 ///
 /// Transient errors are retried using the provided policy. Permanent errors are
 /// returned immediately.
 ///
+/// Each retried error is logged at warning level, unless `needs_warning_log`
+/// returns `false` for it — an expected "keep polling" signal rather than an
+/// anomaly — in which case it is only logged at debug level. Once
+/// [`FORCE_WARNING_AFTER_RETRIES`] consecutive retries have failed, every
+/// further retry is logged at warning level regardless.
+///
 /// Cancellation is observed both before and during each callback invocation, so
 /// an already-cancelled token never starts a new callback and a pending
 /// callback (for example a stalled request) is abandoned promptly.
-pub(crate) async fn retry_callback_until_success<T, E, F, Fut, I>(
+pub(crate) async fn retry_callback_until_success<T, E, F, Fut, I, W>(
     policy: &TxRetryPolicy,
     cancellation_token: &CancellationToken,
     mut callback: F,
     mut is_transient: I,
+    mut needs_warning_log: W,
 ) -> Result<T, RetryCallbackError<E>>
 where
     E: std::fmt::Debug,
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, E>>,
     I: FnMut(&E) -> bool,
+    W: FnMut(&E) -> bool,
 {
     let mut next_interval = policy.initial_interval;
     let mut retry_attempt = 0_u64;
@@ -62,12 +78,21 @@ where
 
                 retry_attempt = retry_attempt.saturating_add(1);
                 let sleep_duration = next_interval.saturating_add(random_jitter(policy.jitter));
-                warn!(
-                    ?error,
-                    retry_attempt,
-                    ?sleep_duration,
-                    "Transient error while executing retryable callback"
-                );
+                if needs_warning_log(&error) || retry_attempt >= FORCE_WARNING_AFTER_RETRIES {
+                    warn!(
+                        ?error,
+                        retry_attempt,
+                        ?sleep_duration,
+                        "Transient error while executing retryable callback"
+                    );
+                } else {
+                    debug!(
+                        ?error,
+                        retry_attempt,
+                        ?sleep_duration,
+                        "Transient error while executing retryable callback"
+                    );
+                }
 
                 tokio::select! {
                     biased;
@@ -102,6 +127,7 @@ where
         cancellation_token,
         callback,
         is_transient_alloy_error,
+        |_| true,
     )
     .await
 }
@@ -275,6 +301,7 @@ mod tests {
                 }
             },
             |_| false,
+            |_| true,
         )
         .await
         .unwrap_err();
@@ -304,12 +331,109 @@ mod tests {
                 }
             },
             |_| true,
+            |_| true,
         )
         .await
         .unwrap();
 
         assert_eq!(value, 42);
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    /// Counts emitted tracing events by level, to assert which level the retry
+    /// helper picks for a transient error.
+    struct LevelCountingSubscriber {
+        warn_events: Arc<AtomicUsize>,
+        debug_events: Arc<AtomicUsize>,
+    }
+
+    impl tracing::Subscriber for LevelCountingSubscriber {
+        fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+        fn event(&self, event: &tracing::Event<'_>) {
+            match *event.metadata().level() {
+                tracing::Level::WARN => self.warn_events.fetch_add(1, Ordering::SeqCst),
+                tracing::Level::DEBUG => self.debug_events.fetch_add(1, Ordering::SeqCst),
+                _ => 0,
+            };
+        }
+
+        fn enter(&self, _span: &tracing::span::Id) {}
+
+        fn exit(&self, _span: &tracing::span::Id) {}
+    }
+
+    /// Runs `retry_callback_until_success` through `failures` transient
+    /// failures with the given `needs_warning_log`, returning `(warn_events,
+    /// debug_events)`.
+    async fn count_retry_log_levels(
+        failures: usize,
+        needs_warning_log: fn(&TransientTestError) -> bool,
+    ) -> (usize, usize) {
+        let warn_events = Arc::new(AtomicUsize::new(0));
+        let debug_events = Arc::new(AtomicUsize::new(0));
+        // Thread-local default: `#[tokio::test]` runs on a current-thread
+        // runtime, so every retry log lands on this subscriber and parallel
+        // tests cannot pollute the counters.
+        let _guard = tracing::subscriber::set_default(LevelCountingSubscriber {
+            warn_events: warn_events.clone(),
+            debug_events: debug_events.clone(),
+        });
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let cancellation_token = CancellationToken::new();
+        let policy = retry_policy(Duration::ZERO, 1000, Duration::ZERO, Duration::ZERO);
+
+        retry_callback_until_success(
+            &policy,
+            &cancellation_token,
+            || {
+                let attempts = attempts.clone();
+                async move {
+                    if attempts.fetch_add(1, Ordering::SeqCst) < failures {
+                        Err::<(), _>(TransientTestError)
+                    } else {
+                        Ok(())
+                    }
+                }
+            },
+            |_| true,
+            needs_warning_log,
+        )
+        .await
+        .unwrap();
+
+        (
+            warn_events.load(Ordering::SeqCst),
+            debug_events.load(Ordering::SeqCst),
+        )
+    }
+
+    #[tokio::test]
+    async fn retry_callback_until_success_logs_retries_at_warning_by_default() {
+        assert_eq!(count_retry_log_levels(2, |_| true).await, (2, 0));
+    }
+
+    #[tokio::test]
+    async fn retry_callback_until_success_logs_quiet_retries_at_debug() {
+        assert_eq!(count_retry_log_levels(2, |_| false).await, (0, 2));
+    }
+
+    #[tokio::test]
+    async fn retry_callback_until_success_escalates_quiet_retries_to_warning_after_threshold() {
+        // 65 consecutive failures: retries 1..=63 stay at debug, 64 and 65 are
+        // escalated to warnings.
+        assert_eq!(count_retry_log_levels(65, |_| false).await, (2, 63));
     }
 
     #[tokio::test(start_paused = true)]
@@ -337,6 +461,7 @@ mod tests {
                             Err::<(), _>(TransientTestError)
                         }
                     },
+                    |_| true,
                     |_| true,
                 )
                 .await
@@ -379,6 +504,7 @@ mod tests {
                 }
             },
             |_| true,
+            |_| true,
         )
         .await;
 
@@ -406,6 +532,7 @@ mod tests {
                     &policy,
                     &cancellation_token,
                     std::future::pending::<Result<(), TransientTestError>>,
+                    |_| true,
                     |_| true,
                 )
                 .await
@@ -455,6 +582,7 @@ mod tests {
                             }
                         }
                     },
+                    |_| true,
                     |_| true,
                 )
                 .await


### PR DESCRIPTION
## Description

Settlement retry loops logged every transient error at warning level, so the expected `NotIncludedYet` / `NotSettledYet` polling signals flooded the logs with `Transient error while executing retryable callback` warnings while settlement transactions were simply waiting for L1 inclusion or finality.

- `retry_callback_until_success` now takes a `needs_warning_log` callback, akin to `is_transient`. Errors it marks as quiet log their retries at debug level instead of warning.
- `WaitForSettlementError::needs_warning_log` marks the two expected polling signals (`NotIncludedYet`, `NotSettledYet`) as quiet; transport errors and every other retry site keep their warning logs.
- Safety net: once 64 consecutive retries have failed, every further retry is logged at warning level even for the quiet signals, so an unexpectedly stuck wait still surfaces in the default logs. With the default non-inclusion policy (60s doubling up to 10-minute intervals) this only triggers roughly 10 hours into a stuck wait, and then emits at most one warning per poll.

## Testing

- New tests assert the level selection end-to-end through a counting `tracing` subscriber: warning by default, debug for quiet errors, and the escalation boundary (65 consecutive failures → 63 debug logs, then warnings at retries 64 and 65).
- `cargo check --workspace --tests --all-features`, `cargo make ci-all`, and `cargo nextest run -p agglayer-settlement-service` (83/83) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)