### PR TITLE
fix(settlement): map Tenderly's -32001 "not found" to an absent tx

### DIFF
--- a/crates/agglayer-settlement-service/src/utils.rs
+++ b/crates/agglayer-settlement-service/src/utils.rs
@@ -128,11 +128,23 @@ pub(crate) async fn tx_hash_on_l1_for_nonce(
     wallet: Address,
     nonce: Nonce,
 ) -> TransportResult<Option<SettlementTxHash>> {
-    let result = provider
+    let tx = match provider
         .get_transaction_by_sender_nonce(wallet, nonce.0)
-        .await?;
-    let Some(tx) = result else {
-        return Ok(None);
+        .await
+    {
+        Ok(Some(tx)) => tx,
+        Ok(None) => return Ok(None),
+        // Tenderly Gateway (the L1 RPC of current deployments) answers
+        // `-32001 "not found"` instead of the `null` other nodes return when
+        // no transaction matches the sender and nonce. Only this exact
+        // dialect maps to `None`; any other error response keeps failing
+        // loudly rather than being silently read as "not included yet".
+        Err(TransportError::ErrorResp(error))
+            if error.code == -32001 && error.message == "not found" =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
     };
     Ok(tx
         .block_number()
@@ -734,6 +746,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tx_hash_on_l1_for_nonce_maps_tenderly_not_found_to_none() {
+        // Tenderly Gateway answers `-32001 "not found"` instead of the `null`
+        // other nodes return when no transaction matches the sender and nonce.
+        let asserter = alloy::providers::mock::Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        asserter.push_failure(alloy::rpc::json_rpc::ErrorPayload {
+            code: -32001,
+            message: Cow::Borrowed("not found"),
+            data: None,
+        });
+
+        let result = tx_hash_on_l1_for_nonce(&provider, Address::ZERO, Nonce(0))
+            .await
+            .unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn tx_hash_on_l1_for_nonce_propagates_other_error_responses() {
+        let asserter = alloy::providers::mock::Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        asserter.push_failure(alloy::rpc::json_rpc::ErrorPayload {
+            code: -32001,
+            message: Cow::Borrowed("header not found"),
+            data: None,
+        });
+
+        let error = tx_hash_on_l1_for_nonce(&provider, Address::ZERO, Nonce(0))
+            .await
+            .unwrap_err();
+        assert!(matches!(&error, RpcError::ErrorResp(error) if error.code == -32001));
+    }
+
+    #[tokio::test]
     async fn contract_call_result_from_receipt_maps_revert() {
         let anvil = Anvil::new().spawn();
         let provider = build_provider(&anvil);
@@ -807,6 +853,26 @@ mod tests {
             Some(expected_hash),
             "Unexpected tx hash when querying by wallet + nonce through {}",
             L1_RPC_ENV,
+        );
+
+        println!("Querying an absent (wallet, nonce) pair via wallet + nonce RPC");
+
+        // A nonce far beyond anything the sampled wallet has used, so no
+        // transaction can match. Providers signal absence either with `null`
+        // or with an error dialect like Tenderly's `-32001 "not found"`; both
+        // must map to `None`.
+        let absent_nonce = Nonce(nonce.saturating_add(1_000_000));
+        let result = match tx_hash_on_l1_for_nonce(&provider, sender, absent_nonce).await {
+            Ok(result) => result,
+            Err(error) => panic!(
+                "{L1_RPC_ENV} rejected eth_getTransactionBySenderAndNonce for absent nonce \
+                 {absent_nonce}: {error:?}"
+            ),
+        };
+        assert_eq!(
+            result, None,
+            "Expected no tx hash for absent nonce {} through {}",
+            absent_nonce, L1_RPC_ENV,
         );
 
         println!("External L1 RPC sender+nonce lookup validated");


### PR DESCRIPTION
## Problem

On spec (0.6.0-rc.1), a settlement task panicked at `settlement_task.rs:529`:

```
assumed non-recoverable in settlement task 01KWW4KKFRFHEW4D5V3MZSA4B4 …:
querying nonce inclusion on L1 for wallet 0xb671…Cd3 / nonce 7527
ErrorResp(ErrorPayload { code: -32001, message: "not found", data: None })
```

`utils::tx_hash_on_l1_for_nonce` only maps a JSON `null` result of `eth_getTransactionBySenderAndNonce` to `None`. The L1 RPC of our deployments is Tenderly Gateway (`web3_clientVersion` → `Tenderly/1.0`), whose dialect answers the error `-32001 "not found"` *instead of* `null` when no transaction matches the (sender, nonce) — reproduced live against the spec gateway. Alloy's `RateLimitRetryPolicy` rightly does not classify that error as transient, so the `retry!` wrapper escalated it to the deliberate "assumed non-recoverable" panic.

The trigger is a race: the run loop polls inclusion ~100 ms after broadcasting its own transaction, before Tenderly's mempool indexing makes the fresh tx visible. Normally the pending tx is returned as an object (Tenderly does serve mempool txs on this method), so the panic only strikes when the poll wins that race. When it does, the settlement task dies while the settlement tx still mines, and the certificate gets stuck re-submitting (observed on spec: cert `0x20f82083…`, rollup 18 height 50, tx mined in block `0xab26d0`).

## Fix

Map exactly `ErrorResp { code: -32001, message: "not found" }` to `Ok(None)` ("no such transaction") in `tx_hash_on_l1_for_nonce`. Any other error response — including `-32001` with a different message such as reth's "header not found" — still propagates, so unknown provider dialects keep failing loudly instead of being silently read as "not included yet". This helper is the single choke point used by the run-loop inclusion poll, `wait_for_any_nonce_on_l1`, and `current_result_once`, so all polling paths are covered.

## Tests

- `tx_hash_on_l1_for_nonce_maps_tenderly_not_found_to_none`: mocked `-32001 "not found"` response must yield `None` (regression test for the panic).
- `tx_hash_on_l1_for_nonce_propagates_other_error_responses`: `-32001` with a different message still errors, guarding the deliberately narrow match.
- The manual `L1_RPC_ENDPOINT` compatibility test now also queries an absent nonce, so provider vetting covers the absence dialect. Verified live against the spec Tenderly Sepolia gateway: the absent-nonce query (which Tenderly answers with `-32001`) returns `None`; before the fix it errored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)