### PR TITLE
fix(storage): apply declared column options when reopening the database

### DIFF
--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -307,6 +307,7 @@ fn hydrate_settlement_attempts(
     let mut results_by_attempt_number = BTreeMap::new();
     for (attempt_number, result) in results {
         let attempt_number = attempt_number.into();
+        debug!(%job_id, %attempt_number, ?result, "Loaded settlement attempt result from storage");
         if results_by_attempt_number
             .insert(attempt_number, result)
             .is_some()
@@ -319,6 +320,7 @@ fn hydrate_settlement_attempts(
     let mut loaded_attempts = ActiveSettlementAttempts::new();
     for (attempt_number, attempt) in attempts {
         let attempt_number = attempt_number.into();
+        debug!(%job_id, %attempt_number, ?attempt, "Loaded settlement attempt from storage");
         if !loaded_attempt_numbers.insert(attempt_number) {
             eyre::bail!("Duplicate settlement attempt {attempt_number} for job {job_id}",);
         }

--- a/crates/agglayer-storage/src/storage/migration/mod.rs
+++ b/crates/agglayer-storage/src/storage/migration/mod.rs
@@ -44,8 +44,19 @@ impl Builder {
     /// This method initializes or opens an existing database with the provided
     /// initial schema (v0). It automatically sets up migration tracking and
     /// validates the database schema.
-    pub fn open(path: &Path, cfs_v0: &[ColumnDescriptor]) -> Result<Self, DBOpenError> {
+    ///
+    /// `known_cfs` catalogs every column family this binary declares across
+    /// all schema versions. Column family options only apply when passed at
+    /// open time, so an existing database is opened with the declared options
+    /// looked up there (RocksDB defaults for on-disk column families it does
+    /// not list).
+    pub fn open(
+        path: &Path,
+        cfs_v0: &[ColumnDescriptor],
+        known_cfs: &[ColumnDescriptor],
+    ) -> Result<Self, DBOpenError> {
         debug!("Preparing database for initialization and migration");
+        debug!(?known_cfs, "Column families known to this binary");
         let desc_v0: Vec<_> = cfs_v0.iter().map(DB::descriptor).collect();
         let cfs_v0: BTreeSet<_> = desc_v0.iter().map(|d| d.name()).collect();
 
@@ -73,12 +84,12 @@ impl Builder {
             Self::open_rocksdb_fresh(path, cfs)?
         } else if cfs_db.contains(MigrationRecordColumn::COLUMN_FAMILY_NAME) {
             // Move on to migration as usual.
-            Self::open_rocksdb_existing(path, &cfs_db)?
+            Self::open_rocksdb_existing(path, &cfs_db, known_cfs)?
         } else if cfs_db.iter().eq(cfs_v0.iter()) {
             // Initialize migration record.
             let mut cfs = cfs_db;
             cfs.insert(MigrationRecordColumn::COLUMN_FAMILY_NAME.into());
-            Self::open_rocksdb_existing(path, &cfs)?
+            Self::open_rocksdb_existing(path, &cfs, known_cfs)?
         } else {
             // Unexpected schema.
             return Err(DBOpenError::UnexpectedSchema);
@@ -131,14 +142,28 @@ impl Builder {
         })
     }
 
-    fn open_rocksdb_existing(path: &Path, cfs: &BTreeSet<impl AsRef<str>>) -> Result<DB, DBError> {
+    fn open_rocksdb_existing(
+        path: &Path,
+        cfs: &BTreeSet<impl AsRef<str>>,
+        known_cfs: &[ColumnDescriptor],
+    ) -> Result<DB, DBError> {
         debug!("Opening existing database");
 
         let mut options = rocksdb::Options::default();
         options.create_missing_column_families(true);
 
+        let known_cfs: Vec<ColumnDescriptor> = known_cfs
+            .iter()
+            .cloned()
+            .chain([ColumnDescriptor::new::<MigrationRecordColumn>()])
+            .collect();
+        let descriptors: Vec<_> = cfs
+            .iter()
+            .map(|name| DB::descriptor_for_existing(name.as_ref(), &known_cfs))
+            .collect();
+
         Ok(DB {
-            rocksdb: rocksdb::DB::open_cf(&options, path, cfs.iter().map(AsRef::as_ref))?,
+            rocksdb: rocksdb::DB::open_cf_descriptors(&options, path, descriptors)?,
             default_write_options: Some(Self::writeopts()),
         })
     }
@@ -164,7 +189,7 @@ impl Builder {
                     db.db.rocksdb.drop_cf(cf).map_err(DBError::from)?;
                 }
 
-                debug!("Creating column family {cf:?}");
+                debug!(options = ?descriptor.options(), "Creating column family {cf:?}");
                 db.db.rocksdb.create_cf(cf, &opts).map_err(DBError::from)?;
             }
 
@@ -210,7 +235,10 @@ impl Builder {
                 let cf = descriptor.name();
 
                 let opts = DB::options(descriptor.options());
-                debug!("Creating missing column family {cf:?}");
+                debug!(
+                    options = ?descriptor.options(),
+                    "Creating missing column family {cf:?}"
+                );
                 db.db.rocksdb.create_cf(cf, &opts).map_err(DBError::from)?;
             }
 

--- a/crates/agglayer-storage/src/storage/migration/test/sample.rs
+++ b/crates/agglayer-storage/src/storage/migration/test/sample.rs
@@ -106,11 +106,11 @@ pub const CFS_V2: &[ColumnDescriptor] = &[
 impl Builder {
     pub fn open_sample(path: &Path) -> Result<Self, DBOpenError> {
         let cfs = [ColumnDescriptor::new::<NetworkInfoV0Column>()];
-        Self::open(path, &cfs)
+        Self::open(path, &cfs, &cfs)
     }
 
     pub fn open_sample_v1(path: &Path) -> Result<Self, DBOpenError> {
-        Self::open(path, CFS_V1)
+        Self::open(path, CFS_V1, CFS_V1)
     }
 
     pub fn sample_migrate_v0_v1(self) -> Result<Self, DBOpenError> {

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -6,6 +6,7 @@ use rocksdb::{
     IterateBounds as _, IteratorMode, Options, PrefixRange, ReadOptions, SliceTransform,
     WriteBatch, WriteOptions,
 };
+use tracing::debug;
 
 use crate::schema::{
     options::{ColumnCompressionType, ColumnOptions, PrefixExtractor},
@@ -41,13 +42,21 @@ pub struct DB {
 impl DB {
     /// Open a new RocksDB instance at the given path with initial column
     /// families and a possibility to migrate the database.
-    pub fn builder(path: &Path, cfs: &[ColumnDescriptor]) -> Result<Builder, DBOpenError> {
-        Builder::open(path, cfs)
+    ///
+    /// `known_cfs` catalogs every column family this binary declares across
+    /// all schema versions; existing column families are opened with the
+    /// declared options found there (or RocksDB defaults when absent).
+    pub fn builder(
+        path: &Path,
+        cfs_v0: &[ColumnDescriptor],
+        known_cfs: &[ColumnDescriptor],
+    ) -> Result<Builder, DBOpenError> {
+        Builder::open(path, cfs_v0, known_cfs)
     }
 
     /// Open a new RocksDB instance at the given path with some column families.
     pub fn open_cf(path: &Path, cfs: &[ColumnDescriptor]) -> Result<DB, DBOpenError> {
-        Builder::open(path, cfs)?.finalize(cfs)
+        Builder::open(path, cfs, cfs)?.finalize(cfs)
     }
 
     /// Open a RocksDB instance in read-only mode at the given path with some
@@ -62,7 +71,7 @@ impl DB {
             Ok(names) => names
                 .into_iter()
                 .filter(|name| name != rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
-                .map(|name| ColumnFamilyDescriptor::new(name, Options::default()))
+                .map(|name| Self::descriptor_for_existing(&name, cfs))
                 .collect(),
             Err(_) => cfs.iter().map(Self::descriptor).collect(),
         };
@@ -233,6 +242,14 @@ impl DB {
         Ok(ColumnIterator::new(iterator, direction))
     }
 
+    /// Iterates over the keys sharing `prefix`, relying on the column
+    /// family's prefix extractor to stop at the prefix boundary. The column
+    /// family MUST be opened with a prefix extractor covering exactly the
+    /// encoded `prefix`: without one, RocksDB silently ignores
+    /// `prefix_same_as_start` and the scan leaks past the prefix into
+    /// unrelated keys. Every open path applies the declared column options
+    /// (see [`Self::descriptor_for_existing`]), and
+    /// `reopened_database_applies_declared_prefix_extractor` guards this.
     pub(crate) fn prefix_iterator<C: ColumnSchema, P: Codec>(
         &self,
         prefix: &P,
@@ -282,6 +299,33 @@ impl DB {
     // Convert a ColumnDescriptor to a RocksDB ColumnFamilyDescriptor.
     fn descriptor(descriptor: &ColumnDescriptor) -> ColumnFamilyDescriptor {
         ColumnFamilyDescriptor::new(descriptor.name(), Self::options(descriptor.options()))
+    }
+
+    /// Build the RocksDB descriptor for a column family found on disk: its
+    /// declared options when it is part of the known schema, RocksDB defaults
+    /// otherwise. Column family options only take effect when passed at open
+    /// time, so opening by name would silently drop declared options such as
+    /// the prefix extractor.
+    pub(crate) fn descriptor_for_existing(
+        name: &str,
+        known_cfs: &[ColumnDescriptor],
+    ) -> ColumnFamilyDescriptor {
+        match known_cfs.iter().find(|known| known.name() == name) {
+            Some(descriptor) => {
+                debug!(
+                    options = ?descriptor.options(),
+                    "Opening column family {name:?} with its declared options"
+                );
+                Self::descriptor(descriptor)
+            }
+            None => {
+                debug!(
+                    "Opening column family {name:?} with default options: not part of the known \
+                     schema"
+                );
+                ColumnFamilyDescriptor::new(name, Options::default())
+            }
+        }
     }
 
     // Convert ColumnOptions to RocksDB Options.

--- a/crates/agglayer-storage/src/stores/debug/mod.rs
+++ b/crates/agglayer-storage/src/stores/debug/mod.rs
@@ -28,7 +28,7 @@ pub struct EnabledDebugStore {
 
 impl DebugStore {
     pub fn init_db(path: &Path) -> Result<DB, crate::storage::DBOpenError> {
-        DB::builder(path, cf_definitions::DEBUG_DB_V0)?
+        DB::builder(path, cf_definitions::DEBUG_DB_V0, cf_definitions::DEBUG_DB)?
             .add_cfs(
                 &[ColumnDescriptor::new::<DebugCertificatesProtoColumn>()],
                 backfill_debug_certificates_proto_from_legacy_bincode,

--- a/crates/agglayer-storage/src/stores/pending/mod.rs
+++ b/crates/agglayer-storage/src/stores/pending/mod.rs
@@ -33,12 +33,16 @@ pub struct PendingStore {
 
 impl PendingStore {
     pub fn init_db(path: &Path) -> Result<DB, crate::storage::DBOpenError> {
-        DB::builder(path, cf_definitions::PENDING_DB_V0)?
-            .add_cfs(
-                &[ColumnDescriptor::new::<PendingQueueProtoColumn>()],
-                backfill_pending_certificates_proto_from_legacy_bincode,
-            )?
-            .finalize(cf_definitions::PENDING_DB)
+        DB::builder(
+            path,
+            cf_definitions::PENDING_DB_V0,
+            cf_definitions::PENDING_DB,
+        )?
+        .add_cfs(
+            &[ColumnDescriptor::new::<PendingQueueProtoColumn>()],
+            backfill_pending_certificates_proto_from_legacy_bincode,
+        )?
+        .finalize(cf_definitions::PENDING_DB)
     }
 
     pub fn new(db: Arc<DB>) -> Self {

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -53,12 +53,16 @@ pub struct PerEpochStore<PendingStore, StateStore> {
 
 impl<PendingStore, StateStore> PerEpochStore<PendingStore, StateStore> {
     pub fn init_db(path: &std::path::Path) -> Result<DB, crate::storage::DBOpenError> {
-        DB::builder(path, cf_definitions::EPOCHS_DB_V0)?
-            .add_cfs(
-                &[ColumnDescriptor::new::<CertificatePerIndexProtoColumn>()],
-                backfill_epoch_certificates_proto_from_legacy_bincode,
-            )?
-            .finalize(cf_definitions::EPOCHS_DB)
+        DB::builder(
+            path,
+            cf_definitions::EPOCHS_DB_V0,
+            cf_definitions::EPOCHS_DB,
+        )?
+        .add_cfs(
+            &[ColumnDescriptor::new::<CertificatePerIndexProtoColumn>()],
+            backfill_epoch_certificates_proto_from_legacy_bincode,
+        )?
+        .finalize(cf_definitions::EPOCHS_DB)
     }
 
     pub fn init_db_readonly(path: &std::path::Path) -> Result<DB, crate::storage::DBError> {

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -64,7 +64,7 @@ impl StateStore {
         // path. Each `ensure_cfs` call is a recorded migration step, so new
         // catch-up CFs must be added in a new step instead of changing an
         // already-recorded target list.
-        DB::builder(path, cf_definitions::STATE_DB_V0)?
+        DB::builder(path, cf_definitions::STATE_DB_V0, cf_definitions::STATE_DB)?
             .ensure_cfs(cf_definitions::STATE_DB_V1_ADDED_CFS)?
             .ensure_cfs(cf_definitions::STATE_DB_V2_ADDED_CFS)?
             .finalize(cf_definitions::STATE_DB)

--- a/crates/agglayer-storage/src/stores/state/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/tests.rs
@@ -91,12 +91,16 @@ fn init_db_adds_settlement_job_id_per_certificate_id_cf_to_v1_schema() {
 
     let tmp = TempDBDir::new();
     {
-        let previous_schema = DB::builder(tmp.path.as_path(), cf_definitions::STATE_DB_V0)
-            .expect("V0 schema initialization should succeed")
-            .ensure_cfs(cf_definitions::STATE_DB_V1_ADDED_CFS)
-            .expect("V1 schema migration should succeed")
-            .finalize(cf_definitions::STATE_DB)
-            .expect("V1 schema finalization should succeed");
+        let previous_schema = DB::builder(
+            tmp.path.as_path(),
+            cf_definitions::STATE_DB_V0,
+            cf_definitions::STATE_DB,
+        )
+        .expect("V0 schema initialization should succeed")
+        .ensure_cfs(cf_definitions::STATE_DB_V1_ADDED_CFS)
+        .expect("V1 schema migration should succeed")
+        .finalize(cf_definitions::STATE_DB)
+        .expect("V1 schema finalization should succeed");
         drop(previous_schema);
     }
 

--- a/crates/agglayer-storage/src/stores/state/tests/settlement.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/settlement.rs
@@ -16,6 +16,7 @@ use crate::{
         settlement_attempts::SettlementAttemptsColumn,
         settlement_job_id_per_certificate_id::SettlementJobIdPerCertificateIdColumn,
         settlement_job_results::SettlementJobResultsColumn, settlement_jobs::SettlementJobsColumn,
+        SETTLEMENT_ATTEMPTS_CF,
     },
     error::Error,
     stores::{
@@ -721,6 +722,117 @@ fn list_settlement_attempt_results_does_not_return_results_from_other_jobs() {
             .list_settlement_attempt_results(&job_id)
             .expect("read must succeed"),
         vec![(1, first_result), (2, second_result)]
+    );
+}
+
+/// Reopening an existing database goes through a different code path than
+/// creating a fresh one (`open_rocksdb_existing` opens column families by
+/// name, without the column options carrying the prefix extractor), so
+/// listing must not rely on column-family options to stop at the job-id
+/// prefix boundary. Every job numbers its attempts from 0, so leaking the
+/// next job's entries surfaces as a duplicate attempt 0 during startup
+/// recovery.
+#[test]
+fn list_settlement_attempts_stays_within_job_after_reopen() {
+    let tmp = TempDBDir::new();
+    let job_id = mk_job_id(27);
+    let other_job_id = mk_job_id(28);
+    let attempt = mk_settlement_attempt(1);
+    let result: SettlementAttemptResult =
+        v0::SettlementAttemptResult::contract_call_success_for_test(5)
+            .try_into()
+            .expect("test tx result helper should be decodable");
+
+    {
+        let db = Arc::new(StateStore::init_db(tmp.path.as_path()).expect("Unable to init db"));
+        let store = StateStore::new(db, BackupClient::noop());
+        store
+            .insert_settlement_job(&job_id, &mk_settlement_job(27))
+            .expect("first job insert must succeed");
+        store
+            .insert_settlement_job(&other_job_id, &mk_settlement_job(28))
+            .expect("second job insert must succeed");
+        store
+            .insert_settlement_attempt(&job_id, 0, &attempt)
+            .expect("first job attempt insert must succeed");
+        store
+            .insert_settlement_attempt(&other_job_id, 0, &mk_settlement_attempt(10))
+            .expect("other job attempt insert must succeed");
+        store
+            .record_settlement_attempt_result(&job_id, 0, &result)
+            .expect("first job result insert must succeed");
+        store
+            .record_settlement_attempt_result(
+                &other_job_id,
+                0,
+                &v0::SettlementAttemptResult::contract_call_success_for_test(10)
+                    .try_into()
+                    .expect("test tx result helper should be decodable"),
+            )
+            .expect("other job result insert must succeed");
+    }
+
+    let db = Arc::new(StateStore::init_db(tmp.path.as_path()).expect("Unable to reopen db"));
+    let store = StateStore::new(db, BackupClient::noop());
+
+    assert_eq!(
+        store
+            .list_settlement_attempts(&job_id)
+            .expect("read must succeed"),
+        vec![(0, attempt)]
+    );
+    assert_eq!(
+        store
+            .list_settlement_attempt_results(&job_id)
+            .expect("read must succeed"),
+        vec![(0, result)]
+    );
+}
+
+/// The declared column options — in particular the fixed-prefix extractor —
+/// must be applied when reopening an existing database, not only when
+/// creating a fresh one. This probes RocksDB's own prefix iterator directly,
+/// bypassing the explicit bounds set by `DB::prefix_iterator`: without the
+/// extractor it silently degrades to an unbounded scan.
+#[test]
+fn reopened_database_applies_declared_prefix_extractor() {
+    let tmp = TempDBDir::new();
+    let job_id = mk_job_id(29);
+    let other_job_id = mk_job_id(30);
+
+    {
+        let db = Arc::new(StateStore::init_db(tmp.path.as_path()).expect("Unable to init db"));
+        let store = StateStore::new(db, BackupClient::noop());
+        store
+            .insert_settlement_job(&job_id, &mk_settlement_job(29))
+            .expect("first job insert must succeed");
+        store
+            .insert_settlement_job(&other_job_id, &mk_settlement_job(30))
+            .expect("second job insert must succeed");
+        store
+            .insert_settlement_attempt(&job_id, 0, &mk_settlement_attempt(1))
+            .expect("first job attempt insert must succeed");
+        store
+            .insert_settlement_attempt(&other_job_id, 0, &mk_settlement_attempt(10))
+            .expect("other job attempt insert must succeed");
+    }
+
+    let db = StateStore::init_db(tmp.path.as_path()).expect("Unable to reopen db");
+    let cf = db
+        .raw_rocksdb()
+        .cf_handle(SETTLEMENT_ATTEMPTS_CF)
+        .expect("settlement attempts column family must exist");
+    let prefix = job_id.to_be_bytes();
+    let keys_outside_prefix: Vec<_> = db
+        .raw_rocksdb()
+        .prefix_iterator_cf(cf, prefix)
+        .map(|entry| entry.expect("iteration must succeed").0)
+        .filter(|key| !key.starts_with(&prefix))
+        .collect();
+
+    assert!(
+        keys_outside_prefix.is_empty(),
+        "prefix extractor was not applied on reopen; leaked keys: {keys_outside_prefix:?}",
     );
 }
 


### PR DESCRIPTION
## Problem

On reboot, startup recovery fails with:

```
Error: Failed to load settlement job 01KWW4KKFRFHEW4D5V3MZSA4B4 during startup recovery
Caused by: Duplicate settlement attempt 0 for job 01KWW4KKFRFHEW4D5V3MZSA4B4
```

## Root cause

The settlement attempt columns are keyed by `16-byte job id ‖ 8-byte BE attempt number` and declare a fixed 16-byte prefix extractor, but the extractor (and the rest of the declared column options) was only applied when creating a **fresh** database or a new column family. Reopening an existing database went through `rocksdb::DB::open_cf`, which opens every column family by name with **default options**.

Without a prefix extractor, RocksDB silently ignores `prefix_same_as_start` (see `DBIter`: it is disabled when the CF has no extractor), so the per-job "prefix" listing actually scanned from the requested job id to the end of the column family, sweeping in later jobs' attempts. Every job numbers its attempts from 0, so loading any pending job followed by another job with recorded attempts fails with "Duplicate settlement attempt 0". Fresh databases (first boot, e2e) were unaffected, which is why this only surfaced on reboot — the declared options are identical across v0.5.1 / v0.6.0-rc.1 / v0.6.0-rc.3, so this affects every deployed version equally.

The stored data itself is fine: keys are unique per (job id, attempt number) by construction, so **no data repair is needed** — recovery works again as soon as this fix is deployed.

## Fix

`DB::builder`/`Builder::open` now take the authoritative schema catalog (each store passes its full target schema, e.g. `STATE_DB`); existing and read-only databases open each on-disk column family with its declared options, falling back to defaults (with a debug log) for column families the binary does not know about. This also restores the declared **Lz4 compression** on reopen (new SSTs were silently written with RocksDB's default compression before).

`DB::prefix_iterator` keeps using RocksDB's native prefix seek; it now documents the invariant it relies on (the CF must be opened with an extractor covering exactly the encoded prefix). Mixed SST files from past extractor-less opens are safe: RocksDB skips bloom filters whose recorded extractor mismatches, and the boundary check happens at the iterator layer using the current extractor.

## Tests

Both written first and verified to fail before the fix:

- `list_settlement_attempts_stays_within_job_after_reopen` — end-to-end reproduction of the production failure: two jobs with attempt 0, close, reopen, list.
- `reopened_database_applies_declared_prefix_extractor` — probes the raw RocksDB prefix iterator on a reopened database, directly guarding the invariant `prefix_iterator` relies on.

## Observability

New debug logs for future incidents: the known-CF catalog (with options) at every open, per-CF declared-vs-default options when opening existing databases, options included in the create-CF migration logs, and per-attempt/per-result lines when hydrating a settlement job (emitted before the duplicate checks, so the offending entries are visible if this class of bug ever recurs).

## Verification

`cargo make generate-proto` (no diffs), `cargo check --workspace --tests --all-features`, `mdbook build docs/knowledge-base/`, `cargo make ci-all`, `cargo nextest run --workspace`, and `cargo make pp-check-vkey-change` all pass; targeted storage+settlement tests re-run green after rebasing onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)