### PR TITLE
fix(settlement): avoid control allocation for completed recovery jobs

### DIFF
--- a/crates/agglayer-settlement-service/src/settlement_service.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service.rs
@@ -19,8 +19,8 @@ use tracing::{error, info, warn};
 
 use crate::{
     settlement_task::{
-        SettlementTask, SettlementTaskRunResult, StoredSettlementJob, TaskAdminCommand,
-        TaskControl, TaskControlHandle,
+        RecoveredSettlementJob, SettlementTask, SettlementTaskRunResult, StoredSettlementJob,
+        TaskAdminCommand, TaskControl, TaskControlHandle,
     },
     wallet_nonce_locks::WalletNonceLocks,
 };
@@ -219,13 +219,22 @@ impl<
         let mut resumed_jobs = 0usize;
         let mut skipped_jobs = 0u64;
         for job_id in job_ids {
-            let (task_control_handle, task_control) =
-                TaskControlHandle::new(&self.cancellation_token);
-            match self.load_stored_job(job_id, task_control).await {
-                Ok(StoredSettlementJob::Completed(_)) => {
+            match SettlementTask::recover_from_storage(
+                job_id,
+                self.tx_config.clone(),
+                self.provider.clone(),
+                self.store.clone(),
+                self.wallet_nonce_locks.clone(),
+            )
+            .await
+            {
+                Ok(RecoveredSettlementJob::Completed(_)) => {
                     completed_jobs += 1;
                 }
-                Ok(StoredSettlementJob::Pending(task)) => {
+                Ok(RecoveredSettlementJob::Pending(pending)) => {
+                    let (task_control_handle, task_control) =
+                        TaskControlHandle::new(&self.cancellation_token);
+                    let task = pending.into_task(task_control);
                     self.spawn_settlement_task(job_id, task, task_control_handle)
                         .await;
                     resumed_jobs += 1;

--- a/crates/agglayer-settlement-service/src/settlement_service/tests.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service/tests.rs
@@ -196,6 +196,8 @@ fn mk_result(seed: u8, outcome: ContractCallOutcome) -> SettlementJobResult {
 
 #[tokio::test]
 async fn start_scans_jobs_and_skips_completed_ones() {
+    // Completed jobs are classified via recover_from_storage (no TaskControl)
+    // and must leave neither controls nor watchers installed.
     let mut store = MockStateStore::new();
     let job_id = mk_job_id(9);
     let job = mk_job(9);
@@ -222,6 +224,60 @@ async fn start_scans_jobs_and_skips_completed_ones() {
 
     assert!(service.task_controls.lock().await.is_empty());
     assert!(service.result_watchers.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn start_resumes_pending_job_with_task_controls_tied_to_service_cancellation() {
+    let mut store = MockStateStore::new();
+    let job_id = mk_job_id(10);
+    let job = mk_job(10);
+
+    store
+        .expect_list_settlement_job_ids()
+        .once()
+        .return_once(move || Ok(vec![job_id]));
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job)));
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(|_| Ok(None));
+    store
+        .expect_list_settlement_attempt_results()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(|_| Ok(Vec::new()));
+    store
+        .expect_list_settlement_attempts()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(|_| Ok(Vec::new()));
+
+    let cancellation_token = CancellationToken::new();
+    let service = mk_service_with_token(Arc::new(store), cancellation_token.clone()).await;
+
+    assert!(service.task_controls.lock().await.contains_key(&job_id));
+    assert!(service.result_watchers.lock().await.contains_key(&job_id));
+
+    cancellation_token.cancel();
+
+    let wait_for_shutdown = async {
+        while !service.task_controls.lock().await.is_empty() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(1), wait_for_shutdown)
+        .await
+        .expect("recovered pending task should stop within timeout");
+
+    assert!(
+        service.task_controls.lock().await.is_empty(),
+        "recovered task should stop and clear control on service cancellation"
+    );
 }
 
 #[tokio::test]

--- a/crates/agglayer-settlement-service/src/settlement_service/tests.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service/tests.rs
@@ -268,24 +268,23 @@ async fn start_resumes_pending_job_with_task_controls_tied_to_service_cancellati
     let cancellation_token = CancellationToken::new();
     let service = mk_service_with_token(Arc::new(store), cancellation_token.clone()).await;
 
-    assert!(service.task_controls.lock().await.contains_key(&job_id));
+    assert!(service
+        .task_controls
+        .lock()
+        .expect("settlement task_controls lock poisoned")
+        .contains_key(&job_id));
     assert!(service.result_watchers.lock().await.contains_key(&job_id));
 
     cancellation_token.cancel();
 
-    let wait_for_shutdown = async {
-        while !service.task_controls.lock().await.is_empty() {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(1), wait_for_shutdown)
-        .await
-        .expect("recovered pending task should stop within timeout");
-
-    assert!(
-        service.task_controls.lock().await.is_empty(),
-        "recovered task should stop and clear control on service cancellation"
-    );
+    wait_until(|| {
+        service
+            .task_controls
+            .lock()
+            .expect("settlement task_controls lock poisoned")
+            .is_empty()
+    })
+    .await;
 }
 
 #[tokio::test]

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -248,11 +248,7 @@ pub(crate) struct PendingSettlementJob<L1Provider, SettlementStore> {
     attempts: ActiveSettlementAttempts,
 }
 
-impl<
-        L1Provider: Provider + WalletProvider + 'static,
-        SettlementStore: SettlementReader + SettlementWriter,
-    > PendingSettlementJob<L1Provider, SettlementStore>
-{
+impl<L1Provider, SettlementStore> PendingSettlementJob<L1Provider, SettlementStore> {
     pub(crate) fn into_task(
         self,
         control: TaskControl,

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -515,8 +515,7 @@ impl<
         wallet_nonce_locks: Arc<WalletNonceLocks>,
         control: TaskControl,
     ) -> eyre::Result<StoredSettlementJob<L1Provider, SettlementStore>> {
-        match Self::recover_from_storage(id, tx_config, provider, store, wallet_nonce_locks)
-            .await?
+        match Self::recover_from_storage(id, tx_config, provider, store, wallet_nonce_locks).await?
         {
             RecoveredSettlementJob::Pending(pending) => {
                 Ok(StoredSettlementJob::Pending(pending.into_task(control)))

--- a/crates/agglayer-settlement-service/src/settlement_task.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task.rs
@@ -235,6 +235,46 @@ pub enum StoredSettlementJob<L1Provider, SettlementStore> {
     Completed(SettlementJobResult),
 }
 
+/// Hydrated pending settlement job that has not yet been bound to runtime
+/// task controls. Used by startup recovery so completed jobs never allocate
+/// admin channels or cancellation tokens.
+pub(crate) struct PendingSettlementJob<L1Provider, SettlementStore> {
+    id: SettlementJobId,
+    job: SettlementJob,
+    tx_config: Arc<SettlementTransactionConfig>,
+    provider: Arc<L1Provider>,
+    store: Arc<SettlementStore>,
+    wallet_nonce_locks: Arc<WalletNonceLocks>,
+    attempts: ActiveSettlementAttempts,
+}
+
+impl<
+        L1Provider: Provider + WalletProvider + 'static,
+        SettlementStore: SettlementReader + SettlementWriter,
+    > PendingSettlementJob<L1Provider, SettlementStore>
+{
+    pub(crate) fn into_task(
+        self,
+        control: TaskControl,
+    ) -> SettlementTask<L1Provider, SettlementStore> {
+        SettlementTask {
+            id: self.id,
+            job: self.job,
+            tx_config: self.tx_config,
+            provider: self.provider,
+            store: self.store,
+            wallet_nonce_locks: self.wallet_nonce_locks,
+            control,
+            attempts: self.attempts,
+        }
+    }
+}
+
+pub(crate) enum RecoveredSettlementJob<L1Provider, SettlementStore> {
+    Pending(PendingSettlementJob<L1Provider, SettlementStore>),
+    Completed(SettlementJobResult),
+}
+
 #[derive(Debug)]
 pub enum TaskAdminCommand {
     ReloadAndRestart,
@@ -475,22 +515,40 @@ impl<
         wallet_nonce_locks: Arc<WalletNonceLocks>,
         control: TaskControl,
     ) -> eyre::Result<StoredSettlementJob<L1Provider, SettlementStore>> {
-        let (job, result) = Self::load_settlement_job_from_db(store.as_ref(), id).await?;
-        if let Some(result) = result {
-            Ok(StoredSettlementJob::Completed(result))
-        } else {
-            let mut this = SettlementTask {
-                id,
-                job,
-                tx_config,
-                provider,
-                store,
-                wallet_nonce_locks,
-                control,
-                attempts: BTreeMap::new(),
-            };
-            this.load_settlement_attempts_from_db()?;
-            Ok(StoredSettlementJob::Pending(this))
+        match Self::recover_from_storage(id, tx_config, provider, store, wallet_nonce_locks)
+            .await?
+        {
+            RecoveredSettlementJob::Pending(pending) => {
+                Ok(StoredSettlementJob::Pending(pending.into_task(control)))
+            }
+            RecoveredSettlementJob::Completed(result) => Ok(StoredSettlementJob::Completed(result)),
+        }
+    }
+
+    /// Classify and hydrate a settlement job from storage without allocating
+    /// runtime task controls. Startup recovery attaches controls only for
+    /// [`RecoveredSettlementJob::Pending`].
+    pub(crate) async fn recover_from_storage(
+        id: SettlementJobId,
+        tx_config: Arc<SettlementTransactionConfig>,
+        provider: Arc<L1Provider>,
+        store: Arc<SettlementStore>,
+        wallet_nonce_locks: Arc<WalletNonceLocks>,
+    ) -> eyre::Result<RecoveredSettlementJob<L1Provider, SettlementStore>> {
+        match Self::load_settlement_job_from_db(store.as_ref(), id).await? {
+            (_job, Some(result)) => Ok(RecoveredSettlementJob::Completed(result)),
+            (job, None) => {
+                let attempts = Self::load_settlement_attempts_from_store(store.as_ref(), id)?;
+                Ok(RecoveredSettlementJob::Pending(PendingSettlementJob {
+                    id,
+                    job,
+                    tx_config,
+                    provider,
+                    store,
+                    wallet_nonce_locks,
+                    attempts,
+                }))
+            }
         }
     }
 
@@ -1535,12 +1593,19 @@ impl<
         Ok((job, result))
     }
 
+    #[cfg(test)]
     fn load_settlement_attempts_from_db(&mut self) -> eyre::Result<()> {
-        let results = self.store.list_settlement_attempt_results(&self.id)?;
-        let attempts = self.store.list_settlement_attempts(&self.id)?;
-
-        self.attempts = hydrate_settlement_attempts(attempts, results, self.id)?;
+        self.attempts = Self::load_settlement_attempts_from_store(self.store.as_ref(), self.id)?;
         Ok(())
+    }
+
+    fn load_settlement_attempts_from_store(
+        store: &SettlementStore,
+        id: SettlementJobId,
+    ) -> eyre::Result<ActiveSettlementAttempts> {
+        let results = store.list_settlement_attempt_results(&id)?;
+        let attempts = store.list_settlement_attempts(&id)?;
+        hydrate_settlement_attempts(attempts, results, id)
     }
 
     fn save_attempt_to_db(

--- a/crates/agglayer-settlement-service/src/settlement_task/tests.rs
+++ b/crates/agglayer-settlement-service/src/settlement_task/tests.rs
@@ -361,6 +361,97 @@ async fn load_settlement_job_from_db_reports_missing_job() {
 }
 
 #[tokio::test]
+async fn recover_from_storage_returns_completed_without_loading_attempts() {
+    let mut store = MockStateStore::new();
+    let job_id = mk_job_id(50);
+    let job = mk_job();
+    let job_result = mk_job_result(6, ContractCallOutcome::Success);
+    let expected_job_result = job_result.clone();
+
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |recorded_job_id| recorded_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job)));
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |recorded_job_id| recorded_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job_result)));
+    store.expect_list_settlement_attempts().never();
+    store.expect_list_settlement_attempt_results().never();
+
+    let loaded = SettlementTask::recover_from_storage(
+        job_id,
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(mk_provider()),
+        Arc::new(store),
+        Arc::new(WalletNonceLocks::default()),
+    )
+    .await
+    .expect("completed settlement job should recover");
+
+    match loaded {
+        RecoveredSettlementJob::Completed(loaded_result) => {
+            assert_eq!(loaded_result, expected_job_result);
+        }
+        RecoveredSettlementJob::Pending(_) => {
+            panic!("completed settlement job should not recover as pending")
+        }
+    }
+}
+
+#[tokio::test]
+async fn recover_from_storage_returns_pending_with_hydrated_attempts() {
+    let mut store = MockStateStore::new();
+    let job_id = mk_job_id(51);
+    let job = mk_job();
+    let expected_job = job.clone();
+
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |recorded_job_id| recorded_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job)));
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |recorded_job_id| recorded_job_id == &job_id)
+        .return_once(|_| Ok(None));
+    store
+        .expect_list_settlement_attempt_results()
+        .once()
+        .withf(move |recorded_job_id| recorded_job_id == &job_id)
+        .return_once(|_| Ok(Vec::new()));
+    store
+        .expect_list_settlement_attempts()
+        .once()
+        .withf(move |recorded_job_id| recorded_job_id == &job_id)
+        .return_once(|_| Ok(Vec::new()));
+
+    let loaded = SettlementTask::recover_from_storage(
+        job_id,
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(mk_provider()),
+        Arc::new(store),
+        Arc::new(WalletNonceLocks::default()),
+    )
+    .await
+    .expect("pending settlement job should recover");
+
+    match loaded {
+        RecoveredSettlementJob::Pending(pending) => {
+            assert_eq!(pending.id, job_id);
+            assert_eq!(pending.job, expected_job);
+            assert!(pending.attempts.is_empty());
+        }
+        RecoveredSettlementJob::Completed(_) => {
+            panic!("pending settlement job should not recover as completed")
+        }
+    }
+}
+
+#[tokio::test]
 async fn load_returns_completed_settlement_job() {
     let mut store = MockStateStore::new();
     let job_id = mk_job_id(5);


### PR DESCRIPTION
Closes #1591

## Summary

Refactored settlement recovery so completed jobs do not allocate runtime task controls.

## Changes

- Added `SettlementTask::recover_from_storage(...)` to load/classify jobs from storage first.
- Added `PendingSettlementJob` with `into_task(control)` to attach runtime controls only for pending jobs.
- Updated startup recovery (`resume_pending_settlement_jobs`) to:
  - skip completed jobs without creating controls
  - create controls only for pending jobs before spawning
- Updated reload/restart recovery path with the same recovery-first pattern.
- Added/updated tests for completed and pending recovery paths.

## Tests

Passed:
- `cargo make blast-radius`
- `cargo check --workspace --tests --all-features`
- targeted settlement-service tests for this change:
  - `recover_from_storage_returns_completed_without_loading_attempts`
  - `recover_from_storage_returns_pending_with_hydrated_attempts`
  - `load_returns_completed_settlement_job`
  - `start_scans_jobs_and_skips_completed_ones`
  - `start_resumes_pending_job_with_task_controls`
  - `recovered_pending_task_honors_service_cancellation`
  - `reload_and_restart_preserves_watcher_when_reload_finds_completed_job`
  - `request_new_settlement_records_certificate_link_before_job`