### PR TITLE
docs(settlement): split the admin api design in two

### DIFF
--- a/docs/knowledge-base/src/SUMMARY.md
+++ b/docs/knowledge-base/src/SUMMARY.md
@@ -7,6 +7,6 @@
 - [Protobuf and gRPC](protobuf-and-grpc.md)
 - [Storage](storage.md)
 - [AI Agent Configuration](ai-agents.md)
-  - [Settlement Service Admin API Design](ai-agents/specs/2026-06-08-settlement-admin-api-design.md)
+  - [Settlement Pause, Observability, and Audit Design](ai-agents/specs/2026-06-08-settlement-admin-api-design.md)
   - [Settlement Admin Mutations Design](ai-agents/specs/2026-07-07-settlement-admin-mutations-design.md)
 - [Documentation Publishing](docs-publishing.md)

--- a/docs/knowledge-base/src/SUMMARY.md
+++ b/docs/knowledge-base/src/SUMMARY.md
@@ -8,4 +8,5 @@
 - [Storage](storage.md)
 - [AI Agent Configuration](ai-agents.md)
   - [Settlement Service Admin API Design](ai-agents/specs/2026-06-08-settlement-admin-api-design.md)
+  - [Settlement Admin Mutations Design](ai-agents/specs/2026-07-07-settlement-admin-mutations-design.md)
 - [Documentation Publishing](docs-publishing.md)

--- a/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-admin-api-design.md
+++ b/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-admin-api-design.md
@@ -8,6 +8,19 @@
 | **Target** | The new `agglayer-settlement-service` crate |
 | **Decision owners** | @Ekleog-Polygon (settlement design intent), @Freyskeyd (assignee) |
 
+> **Scope note (2026-07-07).**
+> This design has been split in two.
+> The mutation surface — registering and correcting attempts and job results,
+> plus the JSON-RPC exposure of the abort/reload task controls — is
+> implemented and recorded in
+> [Settlement admin mutations](2026-07-07-settlement-admin-mutations-design.md),
+> together with its deliberate deviations from the sketches below.
+> This document keeps the parts that are not implemented yet:
+> pause/resume with full quiesce and drain reporting,
+> the observability read surface, and the durable admin audit log.
+> Background snapshots and code references predate the mutation
+> implementation and may be stale where they overlap it.
+
 ## Summary
 
 This document designs a production-grade admin and observability API
@@ -28,6 +41,9 @@ The API delivers three capability groups:
 - **Mutation** — add/edit settlement attempts and mark an attempt
   "definitely failed" so the job re-drives on a fresh nonce
   (the wallet-rotation and degraded-RPC fallbacks from the ticket).
+  Split out and implemented — see the
+  [mutations document](2026-07-07-settlement-admin-mutations-design.md);
+  of this group, only audit-log coverage remains in scope here.
 
 The anchor scenario is an **emergency pause during an L1 incident**:
 a full quiesce in which tasks stop both submitting transactions
@@ -35,8 +51,9 @@ and writing on-chain-derived conclusions until an operator resumes.
 
 ## Goals
 
-- Make the three ticket capabilities (pause, add/edit attempts,
-  mark-definitely-failed/retry-with-new-nonce) safe to operate in production.
+- Make the remaining ticket capability, pause, safe to operate in production
+  (add/edit attempts and mark-definitely-failed/retry-with-new-nonce
+  are implemented; see the mutations document).
 - Provide the minimum observability required to use those capabilities
   without flying blind (there is no "list jobs" or status view today).
 - Preserve the infallible-`SettlementJob` invariant.
@@ -46,6 +63,11 @@ and writing on-chain-derived conclusions until an operator resumes.
 
 ## Non-goals
 
+- The attempt/job mutation surface and the task abort/reload controls:
+  implemented, and covered by the
+  [mutations document](2026-07-07-settlement-admin-mutations-design.md).
+  This document only adds on top of it (audit rows for its operations,
+  and pause as the clean fix for its accepted insert race).
 - A job-level terminal-failure state.
   This contradicts the infallible-job invariant
   and is deferred to an explicit maintainer decision (see Open Questions).
@@ -69,6 +91,12 @@ and writing on-chain-derived conclusions until an operator resumes.
 | D6 | Double-settle posture | Operator assertion + contract backstop; mandatory reason; mark-fail and re-drive are separate steps |
 | D7 | Trust + audit | Network-boundary trust + durable, reusable audit log; tower `Layer` for tracing/metrics |
 | D8 | Transport | Public reads on ReadRPC; mutations + audit read on the private Admin RPC; internal surface is the tower `AdminCommand` service |
+
+D5 and D6 are implemented as part of the mutation split.
+The implementation keeps their substance but not every sketched detail
+(per-operation preconditions instead of literal `from=`/`to=` snapshots,
+append-only insert instead of upsert, no audit rows yet);
+the deviations are recorded in the mutations document (D1, D3, D6, D8).
 
 ## Background: the new settlement service
 
@@ -134,7 +162,7 @@ flowchart TB
     R1["settlement_listJobs / getJob / getPauseStatus"]
   end
   subgraph Admin["Private Admin RPC (admin_rpc_addr)"]
-    A1["settlement_pause / resume / addAttempt / editAttempt / markAttemptDefinitelyFailed / ..."]
+    A1["settlement_pause / resume / pauseWallet / resumeWallet"]
     A2["settlement_listAuditLog"]
   end
   R1 -->|read view| SVC
@@ -186,7 +214,18 @@ This extends the existing `AdminCommand` enum and its `tower::Service` impl
 (`settlement_service.rs:260`),
 widening its response from `()` to a typed `AdminResponse`.
 
+The implemented mutation surface deliberately skips this indirection —
+its JSON-RPC adapters call inherent `admin_*` service methods directly
+(mutations document, D8).
+The tower choke point returns with the audit-log work,
+and the mutation commands would join it then.
+
 ### Mutation model (D5)
+
+*Implemented with the mutation surface (mutations document, D6),
+with per-operation preconditions instead of the literal `from=`/`to=`
+check of step 2;
+the audit append of step 3 arrives with the audit-log work below.*
 
 All mutations are **declarative over stored state**, never in-memory patches:
 
@@ -203,40 +242,18 @@ All mutations are **declarative over stored state**, never in-memory patches:
 Storage remains the single source of truth;
 the live task only ever *reads* storage (start/reload),
 so there is no live/stored divergence and no bespoke in-memory edit logic.
-The reload path (#1230) is therefore the **linchpin dependency**
-for all mutations and for resume.
+The reload path (#1230) was therefore the **linchpin dependency**
+for all mutations and for resume;
+it has since landed, and the implemented mutations rely on it.
 
 ## Data model and storage
 
-### The one required `agglayer-types` change: attempt-level "definitely failed"
+### Attempt-level "definitely failed" (implemented)
 
-"Mark a settlement attempt as definitely failed"
-maps onto the existing attempt-result type.
-A human asserting that a `(wallet, nonce)` will never land
-is a terminal client-side outcome,
-so we add **one variant** to `ClientErrorType`:
-`AbandonedByAdmin`.
-
-`admin_override_attempt_result` force-writes
-`SettlementAttemptResult::ClientError { kind: AbandonedByAdmin, message: <reason> }`,
-bypassing `can_be_replaced_by` (`settlement.rs:137`).
-
-Re-drive is **emergent**, not a separate command.
-Once that attempt is resolved (non-pending),
-the run loop has no pending attempt to bump,
-cannot bump the dead nonce
-(`is_wallet_privkey_known` is false after rotation,
-`settlement_task.rs:536`, `:297-305`),
-and falls through to `build_next_attempt_with_new_nonce`
-(`settlement_task.rs:398`) on the new wallet.
-So "retry with new nonce" = mark-failed + resume.
-The job never fails — it is freed to settle elsewhere.
-This is the ticket's fallback for "we cannot wait-for-finalization
-for lack of RPC": the human substitutes the conclusion
-the automated path cannot reach.
-
-Naming note: the variant and the API name must convey
-"this *attempt* is abandoned," never "the job failed."
+The one `agglayer-types` change this design needed —
+the `ClientErrorType::AbandonedByAdmin` attempt-result override,
+with its emergent re-drive on a fresh nonce/wallet —
+is implemented; see the mutations document (D3, D7).
 
 ### Persisted pause state (D4)
 
@@ -292,10 +309,10 @@ pub trait SettlementObservabilityReader {
 }
 
 // Behind `settlement-admin`; NOT in the stores prelude; ADMIN surface only.
+// (The attempt/result bypass writers sketched here originally are
+// implemented on `SettlementWriter` instead — mutations document, D8.)
 #[cfg(feature = "settlement-admin")]
 pub trait SettlementAdminWriter {
-    fn admin_upsert_attempt(&self, …) -> Result<…>;             // bypass insert-only (add/edit attempt)
-    fn admin_override_attempt_result(&self, …) -> Result<…>;    // bypass can_be_replaced_by (mark definitely-failed)
     fn admin_set_pause(&self, scope, on, record) -> Result<…>;  // settlement_pause_cf
 }
 
@@ -311,6 +328,12 @@ only, so it cannot even name the bypass methods —
 a compile-time guarantee that the invariant-bypassing path
 is unreachable from normal code.
 `SettlementService`'s admin path gains the `…Admin…` bounds.
+The implemented mutation surface chose otherwise:
+its bypass writers live on `SettlementWriter` with an `admin_` prefix and a
+documented never-call-from-the-task contract, without a feature gate
+(mutations document, D8).
+Whether the remaining admin writer (pause) and the audit reader keep the
+feature-gated shape sketched here is revisited at implementation time (OQ3).
 
 The `settlement-admin` Cargo feature is primarily for **API-surface hygiene**:
 a crate depending on `agglayer-storage` without the feature
@@ -348,12 +371,14 @@ merges into the single generated
 Shared scalars (`Address`, `Nonce`, `TxHash`, `Uint128`, …)
 live in `ethereum_types.proto`.
 
-This adds **two new files plus one one-line enum edit**:
+This adds **two new files**
+(the enum edit sketched earlier — `CLIENT_ERROR_TYPE_ABANDONED_BY_ADMIN` —
+already landed with the mutation implementation):
 
 ```
 proto/agglayer/storage/v0/
   ethereum_types.proto        (existing — shared scalars)
-  settlement.proto            (existing — EDIT: add one enum variant)
+  settlement.proto            (existing — ABANDONED_BY_ADMIN variant already added)
   admin_audit.proto           (NEW — neutral envelope)
   settlement_admin.proto      (NEW — settlement payload + pause record)
 ```
@@ -367,8 +392,6 @@ proto/agglayer/storage/v0/
 - `settlement_admin.proto`
   (`message SettlementAdminPayload`, `message SettlementPauseRecord`)
   imports `settlement.proto` to reuse `SettlementAttempt`/`SettlementAttemptResult`.
-- The one edit to an existing proto adds the variant to `settlement.proto:63`:
-  `CLIENT_ERROR_TYPE_ABANDONED_BY_ADMIN = 3;`.
 
 Protos are always generated;
 the `settlement-admin` feature gates only the Rust trait/impl
@@ -491,7 +514,11 @@ so this design defines the gate and defers failover to #1318.
 
 Namespace `settlement`.
 Reads are dedicated tower request types (`SettlementObservabilityReader`);
-control and mutation extend the `AdminCommand` enum (`SettlementAdminWriter`).
+control extends the `AdminCommand` enum (`SettlementAdminWriter`).
+The implemented mutations joined the `admin` namespace instead
+(mutations document, D8);
+settle on one namespace story for the remaining methods at implementation
+time.
 
 ### Group A — Observability (public ReadRPC; no audit row)
 
@@ -509,16 +536,23 @@ control and mutation extend the `AdminCommand` enum (`SettlementAdminWriter`).
 | `settlement_resume` | `ResumeGlobal{…}` | `()` | reload + re-evaluate on wake |
 | `settlement_pauseWallet` | `PauseWallet{wallet,…}` | `()` | submission gate |
 | `settlement_resumeWallet` | `ResumeWallet{wallet,…}` | `()` | |
-| `settlement_abortTask` | `AbortTask{job_id,…}` (exists `:105`) | `()` | runtime stop only, **not** terminal |
-| `settlement_reloadTask` | `ReloadAndRestartTask{job_id,…}` (exists `:111`; reload #1230) | `()` | manual escape hatch |
 
-### Group C — Mutation (private Admin RPC; declarative; audit row; per-job lock; auto-reload)
+`abortTask` and `reloadTask` are already exposed as
+`admin_abortSettlementTask` / `admin_reloadSettlementTask`
+(mutations document); the only work left for them here is audit coverage.
 
-| Method | → `AdminCommand` | Params | Errors |
-|---|---|---|---|
-| `settlement_addAttempt` | `AddAttempt{…}` | `job_id, attempt{sender_wallet,nonce,hash,submission_time}, reason, actor`; precondition `from=absent` | InvalidArgument(dup), internal |
-| `settlement_editAttempt` | `EditAttempt{…}` | `job_id, attempt_seq, from:AttemptSnapshot, to:AttemptSnapshot, reason, actor` | ResourceNotFound, InvalidArgument(from-mismatch) |
-| `settlement_markAttemptDefinitelyFailed` | `MarkAttemptDefinitelyFailed{…}` | `job_id, attempt_seq, from_result:Option<…>, reason (**mandatory**), actor` → writes `ClientError{AbandonedByAdmin}` | ResourceNotFound, InvalidArgument |
+### Group C — Mutation (implemented; see the mutations document)
+
+The mutation surface is implemented and recorded in the
+[mutations document](2026-07-07-settlement-admin-mutations-design.md):
+append-only insert, mark-attempt-definitely-failed,
+remove-attempt-result, and force-remove-job-result,
+in the `admin` namespace.
+What remains in scope here is audit coverage:
+when the audit log lands, these operations gain audit rows and the
+mandatory `reason` + `actor` metadata of cross-cutting rule 1
+(mark-definitely-failed already carries a mandatory `reason`,
+persisted only in the attempt result's message until then).
 
 ### Group D — Audit read (private Admin RPC; `AdminAuditReader`)
 
@@ -536,9 +570,8 @@ pub enum AdminCommand {
     PauseGlobal { reason: String, actor: String }, ResumeGlobal { … },
     PauseWallet { wallet: Address, … },           ResumeWallet { … },
     AbortTask { job_id: SettlementJobId, … },      ReloadAndRestartTask { … },
-    AddAttempt { job_id, attempt, … },
-    EditAttempt { job_id, attempt_seq, from, to, … },
-    MarkAttemptDefinitelyFailed { job_id, attempt_seq, from_result, reason, actor },
+    // … plus the implemented mutation operations (mutations document),
+    // folded in when the audit choke point lands.
 }
 pub enum AdminResponse { Ack, PauseStatus(DrainSnapshot) }   // widened from today's ()
 ```
@@ -564,6 +597,13 @@ pub enum AdminResponse { Ack, PauseStatus(DrainSnapshot) }   // widened from tod
    the `SettlementJob` row persists and can be re-spawned.
    There is no admin path to a terminal job failure in v1.
 
+Rules 2 and 3 describe the draft's snapshot-precondition shape;
+the implemented mutations keep their substance (precondition-checked,
+atomic under the per-job lock, state untouched on mismatch) with
+per-operation preconditions instead of literal `from=`/`to=` snapshots
+(mutations document, D1, D6).
+The audit work should follow the implemented shape.
+
 ## Safety invariants (implementation contract)
 
 1. **Infallible-job preserved.**
@@ -580,6 +620,9 @@ pub enum AdminResponse { Ack, PauseStatus(DrainSnapshot) }   // widened from tod
 6. **Intake never rejected** (recorded + parked while paused).
 7. **Capability containment.**
    Bypass writers are unreachable from the settlement task (compile-time).
+   (The implemented mutation surface relaxed this to a documented
+   convention — mutations document, D8; whether the remaining surface
+   restores the compile-time shape is part of OQ3.)
 8. **Auditability.**
    Every state-changing admin action leaves a durable, time-ordered record
    with `actor` + `reason`.
@@ -622,12 +665,13 @@ These double as acceptance scenarios.
 | **0 Foundations** | CFs + types/proto, traits (`ObservabilityReader` always-on; `AdminWriter`/`AdminAuditReader` feature-gated) + `MockStateStore`, audit envelope + tower `Layer`, derived status + list/scan readers | — | No (storage/types; mock-testable) |
 | **1 Observability API** | `listJobs`/`getJob`/`getPauseStatus` on ReadRPC; `listAuditLog` on Admin RPC | node integration (construct + `Arc`-share `SettlementService`; mount namespaces) | No |
 | **2 Pause/resume** | `PauseState` watch + two gates + per-task `TaskRuntimeState` + `getPauseStatus` + pause/resume(+wallet) + restart-loads-pause | Phase 0; the task loop (exists) | No for global; per-wallet failover needs #1318 |
-| **3 Mutations** | `addAttempt`/`editAttempt`/`markAttemptDefinitelyFailed` + admin writers + auto-reload | **reload path #1230** | `markFailed` records now; its re-drive lands with #1318/#1321 |
+| **3 Mutations** | Implemented — see the mutations document; only audit coverage remains | reload path #1230 (landed) | No |
 | **4 (conditional)** | `editJobPayload` | maintainer fork (A) | — |
 
-`abortTask`/`reloadTask` already exist (`settlement_service.rs:105`/`:111`);
-they only need audit + JSON-RPC exposure (fold into Phase 1/2).
-The critical path is **node integration → #1230 reload**.
+`abortTask`/`reloadTask` are exposed on JSON-RPC by the mutation
+implementation; they only need audit (fold into Phase 1/2).
+The old critical path — node integration (#1393) and the #1230 reload —
+has since landed.
 Pause and observability — the anchor value —
 are reachable without the deep execution stubs.
 
@@ -684,6 +728,9 @@ keeping the envelope decoupled from each domain's proto.
 
 Included for API-surface hygiene, with the additive-features caveat documented.
 Reviewers may veto in favour of the trait boundary alone.
+The implemented mutation surface shipped without the feature and without a
+separate trait (mutations document, D8);
+the question stays open for the pause writer and the audit reader.
 
 ### OQ4 — Per-wallet pause: failover vs park
 
@@ -704,7 +751,10 @@ Invariant 9 and the entire double-settle posture (D6)
 depend on the L1 settlement contract being replay-safe
 (a duplicate settlement reverts or no-ops).
 This must be confirmed with the settlement-contract owners
-before relying on `markAttemptDefinitelyFailed` in production.
+before relying on `markAttemptDefinitelyFailed` in production —
+all the more pressing now that the operation is implemented
+(as `admin_markSettlementAttemptDefinitelyFailed`, alongside
+`admin_forceRemoveSettlementJobResult`, which leans on the same backstop).
 
 ## Appendix: key code references
 

--- a/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-admin-api-design.md
+++ b/docs/knowledge-base/src/ai-agents/specs/2026-06-08-settlement-admin-api-design.md
@@ -1,30 +1,29 @@
-# Settlement Service Admin API — Design
+# Settlement service pause, observability, and audit — design
 
 | | |
 |---|---|
 | **Status** | Draft for review |
-| **Date** | 2026-06-08 |
+| **Date** | 2026-06-08 (trimmed to the remaining surface 2026-07-07) |
 | **Ticket** | [agglayer/agglayer#1254](https://github.com/agglayer/agglayer/issues/1254) |
-| **Target** | The new `agglayer-settlement-service` crate |
+| **Target** | The `agglayer-settlement-service` crate |
 | **Decision owners** | @Ekleog-Polygon (settlement design intent), @Freyskeyd (assignee) |
 
 > **Scope note (2026-07-07).**
-> This design has been split in two.
+> The original #1254 admin API design was split in two.
 > The mutation surface — registering and correcting attempts and job results,
-> plus the JSON-RPC exposure of the abort/reload task controls — is
-> implemented and recorded in
+> plus the JSON-RPC exposure of the abort/reload task controls —
+> is implemented and recorded in
 > [Settlement admin mutations](2026-07-07-settlement-admin-mutations-design.md),
-> together with its deliberate deviations from the sketches below.
-> This document keeps the parts that are not implemented yet:
+> together with its deliberate deviations from the original draft.
+> This document covers only the remaining, not-yet-implemented surface:
 > pause/resume with full quiesce and drain reporting,
 > the observability read surface, and the durable admin audit log.
-> Background snapshots and code references predate the mutation
-> implementation and may be stale where they overlap it.
 
 ## Summary
 
-This document designs a production-grade admin and observability API
-for the new settlement service (`crates/agglayer-settlement-service`).
+This document designs the pause, observability, and audit surface
+of the settlement service admin API
+(`crates/agglayer-settlement-service`).
 
 The settlement service drives one L1 contract call per `SettlementJob`
 until it lands, retrying across nonces and wallets.
@@ -32,18 +31,14 @@ It is intentionally **infallible**:
 a job has no terminal-failure state,
 so the orchestrator can safely iterate on subsequent certificates.
 
-The API delivers three capability groups:
+Three capability groups remain to build:
 
 - **Observability** — list and inspect jobs, attempts, results,
   derived status, and pause/drain status.
 - **Control** — globally or per-wallet pause/resume settlement,
-  with a trustworthy "everything has stopped" signal; abort and reload tasks.
-- **Mutation** — add/edit settlement attempts and mark an attempt
-  "definitely failed" so the job re-drives on a fresh nonce
-  (the wallet-rotation and degraded-RPC fallbacks from the ticket).
-  Split out and implemented — see the
-  [mutations document](2026-07-07-settlement-admin-mutations-design.md);
-  of this group, only audit-log coverage remains in scope here.
+  with a trustworthy "everything has stopped" signal.
+- **Audit** — a durable, reusable log of every state-changing admin action,
+  covering this surface and the implemented mutation surface.
 
 The anchor scenario is an **emergency pause during an L1 incident**:
 a full quiesce in which tasks stop both submitting transactions
@@ -51,10 +46,8 @@ and writing on-chain-derived conclusions until an operator resumes.
 
 ## Goals
 
-- Make the remaining ticket capability, pause, safe to operate in production
-  (add/edit attempts and mark-definitely-failed/retry-with-new-nonce
-  are implemented; see the mutations document).
-- Provide the minimum observability required to use those capabilities
+- Make pause safe to operate in production.
+- Provide the minimum observability required to operate the admin surface
   without flying blind (there is no "list jobs" or status view today).
 - Preserve the infallible-`SettlementJob` invariant.
 - Inherit the "do no harm" properties of the existing admin surface
@@ -66,8 +59,6 @@ and writing on-chain-derived conclusions until an operator resumes.
 - The attempt/job mutation surface and the task abort/reload controls:
   implemented, and covered by the
   [mutations document](2026-07-07-settlement-admin-mutations-design.md).
-  This document only adds on top of it (audit rows for its operations,
-  and pause as the clean fix for its accepted insert race).
 - A job-level terminal-failure state.
   This contradicts the infallible-job invariant
   and is deferred to an explicit maintainer decision (see Open Questions).
@@ -75,9 +66,6 @@ and writing on-chain-derived conclusions until an operator resumes.
 - Retrofitting the existing certificate/network admin paths onto the new
   audit log (the audit envelope is designed to be reusable, but only
   settlement is wired up here).
-- Implementing the settlement service's execution primitives
-  (nonce assignment, submit-to-L1, task recovery);
-  these are tracked separately and are treated here as dependencies.
 
 ## Locked decisions
 
@@ -87,18 +75,16 @@ and writing on-chain-derived conclusions until an operator resumes.
 | D2 | Primary scenario | Emergency pause during an L1 incident |
 | D3 | What pause freezes | Submissions **and** conclusions (full quiesce) |
 | D4 | Pause granularity | Global **and** per-wallet, persisted across restart |
-| D5 | Mutation model | Declarative over stored state, `from=`/`to=` preconditions, apply via reload |
-| D6 | Double-settle posture | Operator assertion + contract backstop; mandatory reason; mark-fail and re-drive are separate steps |
 | D7 | Trust + audit | Network-boundary trust + durable, reusable audit log; tower `Layer` for tracing/metrics |
 | D8 | Transport | Public reads on ReadRPC; mutations + audit read on the private Admin RPC; internal surface is the tower `AdminCommand` service |
 
-D5 and D6 are implemented as part of the mutation split.
-The implementation keeps their substance but not every sketched detail
+D5 (mutation model) and D6 (double-settle posture) from the original design
+are implemented; the mutations document records them,
+including where the implementation deviates from the draft
 (per-operation preconditions instead of literal `from=`/`to=` snapshots,
-append-only insert instead of upsert, no audit rows yet);
-the deviations are recorded in the mutations document (D1, D3, D6, D8).
+append-only insert instead of upsert).
 
-## Background: the new settlement service
+## Background: the settlement service
 
 ### Data model
 
@@ -114,43 +100,36 @@ Defined in `crates/agglayer-types/src/settlement.rs`.
   `ClientError` (never reached a definitive on-chain state)
   or `ContractCall` (landed, `Success` or `Revert`).
 - **`SettlementJobResult`** — the single terminal result of a job.
-  It **requires** a `ContractCallResult`
-  (`settlement.rs:85-90`, `:154-166`):
+  It **requires** a `ContractCallResult`:
   a terminal outcome must have landed on-chain.
 
 ### Lifecycle
 
 There is no explicit status enum.
 Job state is *derived*: a job is pending while a `SettlementJob` row exists
-with no `SettlementJobResult`, and completed once the result row is written
-(`settlement_service.rs:187-204`).
-The state machine lives entirely in `SettlementTask::run()`
-(`settlement_task.rs:214`),
+with no `SettlementJobResult`, and completed once the result row is written.
+The state machine lives entirely in `SettlementTask::run()`,
 a single loop that polls control actions, queries L1 for each known nonce,
 and writes a terminal result when an attempt settles.
 
-### Current state (important constraints)
+### Current state (2026-07-07)
 
-- The service is **not yet wired into the node**:
-  `SettlementService` is constructed nowhere,
-  and `lib.rs:9` still carries
-  `#![allow(dead_code)] // TODO remove after settlement service is integrated`.
-- The control surface is small:
-  `admin_abort_task` (`settlement_service.rs:105`) and
-  `admin_reload_and_restart_task` (`:111`),
-  the latter's reload path still `todo!()` (`:161`, XREF #1230).
-- Several execution primitives are stubs:
-  task recovery (#1230), submit-to-L1 (#1321),
-  nonce assignment (#1318/#1319), `is_wallet_privkey_known`
-  (`settlement_task.rs:536`).
-- Storage writers are deliberately constrained:
-  `insert_settlement_attempt` is insert-only and
-  `record_settlement_attempt_result` is upgrade-only
-  via `can_be_replaced_by` (`settlement.rs:137`).
-- The closest existing template is the JSON-RPC `admin` namespace
+- The service is wired into the node (#1393),
+  and the execution primitives that were stubs in the original draft
+  have landed: startup recovery (#1230),
+  nonce assignment and fee bumping (#1318/#1319),
+  and submit-to-L1 (#1321).
+- The mutation surface and the abort/reload task controls are implemented
+  on the private admin listener,
+  and live tasks apply stored edits by reloading from storage
+  (mutations document).
+- What does not exist yet is exactly this document's surface:
+  no pause mechanism, no list/status observability,
+  and no durable audit of admin actions.
+- The closest existing admin template is the JSON-RPC `admin` namespace
   (`crates/agglayer-jsonrpc-api/src/admin.rs`),
-  especially `forceEditCertificate` (`admin.rs:165`):
-  atomic `from=`/`to=` precondition edits with optional reprocessing.
+  especially `forceEditCertificate`:
+  atomic precondition edits with optional reprocessing.
 
 ## Architecture overview
 
@@ -179,8 +158,7 @@ flowchart TB
   plus the audit-log read
   (the only place `actor`/`reason` operator metadata is exposed).
 - No new listener is introduced;
-  both surfaces reuse the transports the node already binds
-  (`node.rs:334-336`).
+  both surfaces reuse the transports the node already binds.
 
 Most public reads are store-backed,
 but `getPauseStatus` and the `live_phase` field of `getJob`
@@ -197,77 +175,38 @@ They never touch storage directly.
 
 ```mermaid
 flowchart LR
-  RPC["settlement_* JSON-RPC method"] -->|typed request| TOWER
+  RPC["JSON-RPC method"] -->|typed request| TOWER
   subgraph TOWER["tower::Service on SettlementService"]
     AC["AdminCommand (control + mutation)"]
     RD["read request types (observability)"]
   end
   AC --> H["AdminCommand handler"]
   H -->|"1. per-job lock"| H
-  H -->|"2. check from= / write to= / append audit (one WriteBatch)"| STORE[(storage)]
+  H -->|"2. check preconditions / write / append audit (one WriteBatch)"| STORE[(storage)]
   H -->|"3. ReloadAndRestart (if live task)"| TASK[task]
 ```
 
 The `AdminCommand` handler is the single choke point
-where audit-row writes and the mutation transaction live.
-This extends the existing `AdminCommand` enum and its `tower::Service` impl
-(`settlement_service.rs:260`),
+where audit-row writes and the admin mutation transaction live.
+This extends the existing `AdminCommand` enum and its `tower::Service` impl,
 widening its response from `()` to a typed `AdminResponse`.
-
-The implemented mutation surface deliberately skips this indirection —
-its JSON-RPC adapters call inherent `admin_*` service methods directly
-(mutations document, D8).
-The tower choke point returns with the audit-log work,
-and the mutation commands would join it then.
-
-### Mutation model (D5)
-
-*Implemented with the mutation surface (mutations document, D6),
-with per-operation preconditions instead of the literal `from=`/`to=`
-check of step 2;
-the audit append of step 3 arrives with the audit-log work below.*
-
-All mutations are **declarative over stored state**, never in-memory patches:
-
-1. The handler takes the per-job write lock
-   (`StateStore.settlement_write_locks`, `stores/state/mod.rs:54`).
-2. It reads the current stored value and checks it equals the caller's `from=`.
-3. It writes `to=` and appends the audit row in the **same `WriteBatch`**.
-4. If a live task exists for the job, it sends `ReloadAndRestart`,
-   so the task tears down its in-memory `attempts` map
-   and reloads fresh from storage.
-   If no live task exists, the edit simply persists
-   and is picked up on the next recovery.
-
-Storage remains the single source of truth;
-the live task only ever *reads* storage (start/reload),
-so there is no live/stored divergence and no bespoke in-memory edit logic.
-The reload path (#1230) was therefore the **linchpin dependency**
-for all mutations and for resume;
-it has since landed, and the implemented mutations rely on it.
+The implemented mutations currently skip this indirection and call
+inherent `admin_*` service methods directly (mutations document, D8);
+they fold back into the choke point when the audit log lands.
 
 ## Data model and storage
-
-### Attempt-level "definitely failed" (implemented)
-
-The one `agglayer-types` change this design needed —
-the `ClientErrorType::AbandonedByAdmin` attempt-result override,
-with its emergent re-drive on a fresh nonce/wallet —
-is implemented; see the mutations document (D3, D7).
 
 ### Persisted pause state (D4)
 
 A presence-based CF mirroring the established durable-toggle pattern
-of `disabled_networks_cf` (`columns/mod.rs:11`):
+of `disabled_networks_cf`:
 
 - `settlement_pause_cf`:
   key `Global` or `Wallet(Address)`;
   value `SettlementPauseRecord { actor, reason, since }`.
 - "Globally paused?" = key `Global` present.
   Per-wallet pauses = scan.
-- Loaded once at `SettlementService::start`
-  (today a no-op stub, `settlement_service.rs:58-74`),
-  so pause survives restart.
+- Loaded once at `SettlementService::start`, so pause survives restart.
 
 The runtime side (in-memory `watch`, the quiescence barrier, drain reporting)
 is described under [Pause mechanism](#pause-quiesce-and-drain-mechanism).
@@ -295,7 +234,14 @@ also lack durable audit today and could adopt it later (out of scope).
   The bytes are a real proto message, never an arbitrary blob;
   carrying them as `bytes` keeps the envelope decoupled from each domain's proto.
 
-### Dedicated traits and the `settlement-admin` feature
+When the audit log lands, the implemented mutation and task-control
+operations (mutations document) adopt it as well:
+every state-changing admin call gains an atomic audit row and the
+mandatory `actor` metadata
+(mark-definitely-failed already requires a `reason`,
+persisted only in the attempt result's message until then).
+
+### Dedicated traits
 
 The capability split is enforced at the type level.
 
@@ -308,44 +254,24 @@ pub trait SettlementObservabilityReader {
     fn get_pause_state(&self) -> Result<…>;                      // settlement_pause_cf
 }
 
-// Behind `settlement-admin`; NOT in the stores prelude; ADMIN surface only.
-// (The attempt/result bypass writers sketched here originally are
-// implemented on `SettlementWriter` instead — mutations document, D8.)
-#[cfg(feature = "settlement-admin")]
+// ADMIN surface only.
 pub trait SettlementAdminWriter {
     fn admin_set_pause(&self, scope, on, record) -> Result<…>;  // settlement_pause_cf
 }
 
-// Behind `settlement-admin`; ADMIN surface only. Neutral (reusable).
-#[cfg(feature = "settlement-admin")]
+// ADMIN surface only. Neutral (reusable).
 pub trait AdminAuditReader {
     fn list_admin_audit(&self, time_range, filter, page) -> Result<…>;
 }
 ```
 
-The settlement **task** stays bounded by `SettlementReader + SettlementWriter`
-only, so it cannot even name the bypass methods —
-a compile-time guarantee that the invariant-bypassing path
-is unreachable from normal code.
-`SettlementService`'s admin path gains the `…Admin…` bounds.
-The implemented mutation surface chose otherwise:
-its bypass writers live on `SettlementWriter` with an `admin_` prefix and a
-documented never-call-from-the-task contract, without a feature gate
-(mutations document, D8).
-Whether the remaining admin writer (pause) and the audit reader keep the
-feature-gated shape sketched here is revisited at implementation time (OQ3).
-
-The `settlement-admin` Cargo feature is primarily for **API-surface hygiene**:
-a crate depending on `agglayer-storage` without the feature
-cannot `use` the bypass trait,
-so it never appears in autocomplete for unrelated code.
-Caveat: Cargo features are additive and unified across a workspace build,
-so in the final node binary the code is compiled in regardless —
-the feature is authoring hygiene and build-slimming, not a runtime gate.
-The trait boundary is the real guard.
-The audit CF is always registered;
-only the trait methods are feature-gated,
-so toggling the feature never triggers a schema migration.
+The settlement **task** stays bounded by `SettlementReader + SettlementWriter`,
+so it cannot even name the admin-only methods.
+The implemented mutations placed their bypass writers on `SettlementWriter`
+itself, with an `admin_` prefix and a documented never-call-from-the-task
+contract (mutations document, D8);
+whether the pause writer and audit reader get dedicated feature-gated traits
+as originally sketched, or follow that convention, is OQ3.
 
 ### Derived status view
 
@@ -371,14 +297,12 @@ merges into the single generated
 Shared scalars (`Address`, `Nonce`, `TxHash`, `Uint128`, …)
 live in `ethereum_types.proto`.
 
-This adds **two new files**
-(the enum edit sketched earlier — `CLIENT_ERROR_TYPE_ABANDONED_BY_ADMIN` —
-already landed with the mutation implementation):
+This adds **two new files**:
 
 ```
 proto/agglayer/storage/v0/
   ethereum_types.proto        (existing — shared scalars)
-  settlement.proto            (existing — ABANDONED_BY_ADMIN variant already added)
+  settlement.proto            (existing — shared settlement messages)
   admin_audit.proto           (NEW — neutral envelope)
   settlement_admin.proto      (NEW — settlement payload + pause record)
 ```
@@ -393,9 +317,7 @@ proto/agglayer/storage/v0/
   (`message SettlementAdminPayload`, `message SettlementPauseRecord`)
   imports `settlement.proto` to reuse `SettlementAttempt`/`SettlementAttemptResult`.
 
-Protos are always generated;
-the `settlement-admin` feature gates only the Rust trait/impl
-that uses `SettlementAdminPayload`.
+Protos are always generated.
 Rust-side codecs use `impl_codec_using_protobuf_for!`
 in `types/admin_audit.rs` and `types/settlement/…`.
 
@@ -425,15 +347,14 @@ outside the `STATE_DB_V0` set.
 
 "Zero on-chain-derived decisions while paused" requires two gates:
 
-1. **Loop-top barrier**, next to `try_handle_control_action`
-   (`settlement_task.rs:419`):
+1. **Loop-top barrier**, next to `try_handle_control_action`:
    if `global` is set, or the wallet this task would act on is paused,
    the task transitions to **Parked** and awaits the watch (resume)
    or cancellation.
    It does not even read L1.
 2. **Pre-persist gate**, immediately before every conclusion writer
-   (`write_job_result_to_db` `:867`, the nonce-revert/external writers)
-   and before `submit_attempt_to_l1` (`:459`):
+   (`write_job_result_to_db`, the nonce-revert/external writers)
+   and before `submit_attempt_to_l1`:
    re-check pause.
    If pause landed mid-iteration after a read but before the write,
    discard the just-computed conclusion (safely re-derived on resume) and park.
@@ -492,7 +413,7 @@ An optional `wait=true` with a timeout can be added later.
   and guarantees no action on stale pre-incident reads.
 - **Restart**: `start` loads `settlement_pause_cf`;
   if globally paused, the watch is seeded paused,
-  so any task recovered later (#1230) parks immediately.
+  so any task recovered at startup (#1230) parks immediately.
   A mid-incident restart comes back paused.
 - **Intake while paused** (infallibility-critical):
   `request_new_settlement` still records the `SettlementJob` row,
@@ -505,20 +426,21 @@ An optional `wait=true` with a timeout can be added later.
 
 A per-wallet pause gates "build/submit a new attempt on wallet W."
 For wallet rotation you pause the old wallet so nothing new lands there.
-Whether a task **fails over** to another wallet or **parks**
-depends on the wallet-selection policy
-in `build_next_attempt_with_new_nonce` (#1318, currently `todo!()`),
-so this design defines the gate and defers failover to #1318.
+Since the original draft, the wallet-selection policy has landed:
+fresh attempts go to the default configured wallet
+(`build_next_attempt_with_new_nonce`).
+What a task does when the wallet it would submit on is paused —
+park until resume, or fail over when another wallet is available —
+is settled at implementation time (OQ4).
 
 ## API surface
 
-Namespace `settlement`.
+Public reads keep the `settlement` namespace on ReadRPC;
+admin-side methods should follow the implemented mutations into the
+`admin` namespace on the private listener (mutations document, D8) —
+final naming at implementation time.
 Reads are dedicated tower request types (`SettlementObservabilityReader`);
 control extends the `AdminCommand` enum (`SettlementAdminWriter`).
-The implemented mutations joined the `admin` namespace instead
-(mutations document, D8);
-settle on one namespace story for the remaining methods at implementation
-time.
 
 ### Group A — Observability (public ReadRPC; no audit row)
 
@@ -537,24 +459,11 @@ time.
 | `settlement_pauseWallet` | `PauseWallet{wallet,…}` | `()` | submission gate |
 | `settlement_resumeWallet` | `ResumeWallet{wallet,…}` | `()` | |
 
-`abortTask` and `reloadTask` are already exposed as
+The abort/reload task controls are already exposed as
 `admin_abortSettlementTask` / `admin_reloadSettlementTask`
 (mutations document); the only work left for them here is audit coverage.
 
-### Group C — Mutation (implemented; see the mutations document)
-
-The mutation surface is implemented and recorded in the
-[mutations document](2026-07-07-settlement-admin-mutations-design.md):
-append-only insert, mark-attempt-definitely-failed,
-remove-attempt-result, and force-remove-job-result,
-in the `admin` namespace.
-What remains in scope here is audit coverage:
-when the audit log lands, these operations gain audit rows and the
-mandatory `reason` + `actor` metadata of cross-cutting rule 1
-(mark-definitely-failed already carries a mandatory `reason`,
-persisted only in the attempt result's message until then).
-
-### Group D — Audit read (private Admin RPC; `AdminAuditReader`)
+### Group C — Audit read (private Admin RPC; `AdminAuditReader`)
 
 | Method | Params | Response | Errors |
 |---|---|---|---|
@@ -578,58 +487,44 @@ pub enum AdminResponse { Ack, PauseStatus(DrainSnapshot) }   // widened from tod
 
 ### Cross-cutting rules
 
-1. **Mandatory `reason` + `actor`** on every B/C operation,
+1. **Mandatory `reason` + `actor`** on every state-changing admin
+   operation — the control group here, plus the implemented mutations —
    producing one atomic audit row written in the same `WriteBatch`
-   as the mutation.
-2. **Mutation transaction**: per-job lock → read current → assert `== from`
-   → write `to` → append audit → release → reload live task (if any).
-3. **`from=`/`to=` mismatch → `InvalidArgument`**
-   (consistent with `forceEditCertificate`), leaving state untouched.
-4. **Errors** reuse the existing `Error` type
+   as the write itself.
+2. **Precondition-checked writes.**
+   Every admin write checks its preconditions under the per-job
+   (or service-level) lock and leaves state untouched on failure,
+   the shape locked by the implemented mutations (mutations document, D6).
+3. **Errors** reuse the existing `Error` type
    (`ResourceNotFound` = `-10008`, `InvalidArgument`, `internal`);
    no new codes.
-5. **Pause does not gate admin mutations.**
+4. **Pause does not gate admin mutations.**
    Pause freezes task autonomy, never the operator's deliberate edits
    (pause → edit → resume is a core workflow).
    The tower `Layer` performs tracing/metrics/audit-intent only.
-6. **`abortTask` is not abandonment.**
-   It stops the current in-memory task;
-   the `SettlementJob` row persists and can be re-spawned.
-   There is no admin path to a terminal job failure in v1.
-
-Rules 2 and 3 describe the draft's snapshot-precondition shape;
-the implemented mutations keep their substance (precondition-checked,
-atomic under the per-job lock, state untouched on mismatch) with
-per-operation preconditions instead of literal `from=`/`to=` snapshots
-(mutations document, D1, D6).
-The audit work should follow the implemented shape.
 
 ## Safety invariants (implementation contract)
 
 1. **Infallible-job preserved.**
-   No v1 admin op produces a terminal job failure;
-   `abortTask` and `markAttemptDefinitelyFailed` are runtime/attempt-level only.
+   No admin op produces a terminal job failure
+   (the implemented mutations already honor this;
+   pause/resume never reject or fail a job).
 2. **Full quiesce.**
    A paused task never submits and never persists a conclusion (two gates).
 3. **Atomicity.**
-   Each mutation and its audit row commit in one `WriteBatch`
-   under the per-job lock; all `from=` checks precede any write.
+   Each admin write and its audit row commit in one `WriteBatch`
+   under the appropriate lock; precondition checks precede any write.
 4. **Single source of truth.**
    Live tasks only read storage; admin never patches in-memory state.
 5. **Pause survives restart.**
 6. **Intake never rejected** (recorded + parked while paused).
-7. **Capability containment.**
-   Bypass writers are unreachable from the settlement task (compile-time).
-   (The implemented mutation surface relaxed this to a documented
-   convention — mutations document, D8; whether the remaining surface
-   restores the compile-time shape is part of OQ3.)
-8. **Auditability.**
+7. **Auditability.**
    Every state-changing admin action leaves a durable, time-ordered record
    with `actor` + `reason`.
-9. **Double-settle backstop (assumption).**
-   `markAttemptDefinitelyFailed` is a trusted operator assertion;
-   its safety rests on the L1 settlement contract being replay-safe
-   (Open Question 6).
+8. **Capability containment.**
+   Admin-only writers stay unreachable from the settlement task —
+   by trait boundary or by documented convention
+   (OQ3; the implemented mutations chose the convention).
 
 ## Personas and runbooks
 
@@ -643,37 +538,35 @@ These double as acceptance scenarios.
 - **Protocol engineer — wallet rotation (ticket core).**
   `pauseWallet{OLD}` → bring up the new signer →
   for each stuck job: `getJob` →
-  `markAttemptDefinitelyFailed{reason}` → auto-reload →
-  the task re-drives on the new wallet (#1318) → settles.
-  Relies on contract replay-safety.
-- **SRE — stuck/underpriced nonce.**
-  `getJob` → if the tx was cancelled/replaced out-of-band,
-  `addAttempt` to register the replacement;
-  if the nonce is dead, `markAttemptDefinitelyFailed` → re-drive.
-- **Operator — degraded RPC.**
-  Confirm settlement via a block explorer →
-  `editAttempt` / `markAttemptDefinitelyFailed`
-  to inject the conclusion the service cannot auto-derive.
+  `admin_markSettlementAttemptDefinitelyFailed`
+  (implemented — mutations document) →
+  the reloaded task re-drives on the new wallet → settles.
+  Relies on contract replay-safety (OQ6).
 - **Reviewer (read-only).**
   `listJobs` + `getJob` on the public surface;
   `listAuditLog` on the admin surface for post-incident analysis.
 
+The mutation-centric runbooks
+(porting an externally-submitted transaction, dead nonces,
+undoing a wrong assertion, un-completing a job)
+live in the mutations document.
+
 ## Dependency and phasing map
 
-| Phase | Deliverable | Depends on | Blocked by stubs? |
+| Phase | Deliverable | Depends on | Blocked? |
 |---|---|---|---|
-| **0 Foundations** | CFs + types/proto, traits (`ObservabilityReader` always-on; `AdminWriter`/`AdminAuditReader` feature-gated) + `MockStateStore`, audit envelope + tower `Layer`, derived status + list/scan readers | — | No (storage/types; mock-testable) |
-| **1 Observability API** | `listJobs`/`getJob`/`getPauseStatus` on ReadRPC; `listAuditLog` on Admin RPC | node integration (construct + `Arc`-share `SettlementService`; mount namespaces) | No |
-| **2 Pause/resume** | `PauseState` watch + two gates + per-task `TaskRuntimeState` + `getPauseStatus` + pause/resume(+wallet) + restart-loads-pause | Phase 0; the task loop (exists) | No for global; per-wallet failover needs #1318 |
-| **3 Mutations** | Implemented — see the mutations document; only audit coverage remains | reload path #1230 (landed) | No |
-| **4 (conditional)** | `editJobPayload` | maintainer fork (A) | — |
+| **0 Foundations** | CFs + types/proto, traits + `MockStateStore`, audit envelope + tower `Layer`, derived status + list/scan readers | — | No (storage/types; mock-testable) |
+| **1 Observability API** | `listJobs`/`getJob`/`getPauseStatus` on ReadRPC; `listAuditLog` on Admin RPC | mount the read namespaces in the node (the service itself is integrated, #1393) | No |
+| **2 Pause/resume** | `PauseState` watch + two gates + per-task `TaskRuntimeState` + pause/resume(+wallet) + restart-loads-pause | Phase 0; the task loop (exists) | No |
+| **3 (conditional)** | `editJobPayload` | maintainer fork (A) in OQ1 | — |
 
-`abortTask`/`reloadTask` are exposed on JSON-RPC by the mutation
-implementation; they only need audit (fold into Phase 1/2).
-The old critical path — node integration (#1393) and the #1230 reload —
-has since landed.
-Pause and observability — the anchor value —
-are reachable without the deep execution stubs.
+When the audit log lands (Phase 0/1),
+the implemented mutation and task-control operations adopt it
+(audit rows + mandatory `actor`).
+All blockers of the original draft — node integration (#1393),
+startup recovery/reload (#1230),
+and the execution primitives (#1318/#1319/#1321) — have landed;
+the phases above are unblocked.
 
 ## Open questions
 
@@ -726,17 +619,26 @@ keeping the envelope decoupled from each domain's proto.
 
 ### OQ3 — `settlement-admin` feature flag
 
-Included for API-surface hygiene, with the additive-features caveat documented.
-Reviewers may veto in favour of the trait boundary alone.
-The implemented mutation surface shipped without the feature and without a
-separate trait (mutations document, D8);
-the question stays open for the pause writer and the audit reader.
+The original draft feature-gated the admin writer and audit reader behind
+a `settlement-admin` Cargo feature for API-surface hygiene
+(features are additive and unified across a workspace build,
+so it can never be a runtime gate — the trait boundary is the real guard).
+The implemented mutations shipped without the feature and without a
+separate trait (mutations document, D8).
+Decide for the pause writer and the audit reader:
+dedicated feature-gated traits as sketched here,
+or the implemented convention.
 
 ### OQ4 — Per-wallet pause: failover vs park
 
-Whether a task fails over to another wallet or parks
-ties to the wallet-selection policy in #1318.
-This design defines the gate and defers the behavior.
+Whether a task whose wallet is paused fails over to another wallet
+or parks until resume.
+The wallet-selection policy has landed since the draft
+(fresh attempts go to the default configured wallet),
+so the question reduces to parking behavior when the default wallet
+itself is paused, and whether rotated-away wallets need anything beyond
+the natural fall-through to the default wallet.
+Settle at implementation time.
 
 ### OQ5 — Public/private read split (resolved)
 
@@ -747,34 +649,35 @@ No new listener; no redaction needed.
 
 ### OQ6 — Contract replay-safety (must confirm)
 
-Invariant 9 and the entire double-settle posture (D6)
-depend on the L1 settlement contract being replay-safe
+The double-settle posture inherited by the implemented mutations
+(mutations document, safety invariant 5)
+depends on the L1 settlement contract being replay-safe
 (a duplicate settlement reverts or no-ops).
 This must be confirmed with the settlement-contract owners
-before relying on `markAttemptDefinitelyFailed` in production —
-all the more pressing now that the operation is implemented
-(as `admin_markSettlementAttemptDefinitelyFailed`, alongside
-`admin_forceRemoveSettlementJobResult`, which leans on the same backstop).
+before relying on `admin_markSettlementAttemptDefinitelyFailed`
+or `admin_forceRemoveSettlementJobResult` in production.
 
 ## Appendix: key code references
 
 - Domain types: `crates/agglayer-types/src/settlement.rs`
-  (`SettlementJobResult` `:85`, `can_be_replaced_by` `:137`,
-  `ContractCallResult` `:154`).
-- Service + admin surface: `crates/agglayer-settlement-service/src/settlement_service.rs`
-  (`start` `:58`, `admin_abort_task` `:105`, `admin_reload_and_restart_task` `:111`,
-  reload `todo!()` `:161`, derived pending/done `:187-204`, `AdminCommand` `:260`).
+  (`SettlementJobResult` requires an on-chain `ContractCallResult`;
+  `can_be_replaced_by` upgrade rule).
+- Service and admin surface:
+  `crates/agglayer-settlement-service/src/settlement_service.rs`
+  (`AdminCommand`, task registry, derived pending/completed state).
 - State machine: `crates/agglayer-settlement-service/src/settlement_task.rs`
-  (`run` `:214`, `try_handle_control_action` `:419`,
-  `is_wallet_privkey_known` `:536`, `build_next_attempt_with_new_nonce` `:398`,
-  `write_job_result_to_db` `:867`).
+  (`run` loop, `try_handle_control_action`,
+  `build_next_attempt_with_new_nonce`, `write_job_result_to_db`,
+  `submit_attempt_to_l1`).
 - Existing admin template: `crates/agglayer-jsonrpc-api/src/admin.rs`
-  (`forceEditCertificate` `:165`, `start` `:237`).
+  (`forceEditCertificate`);
+  the implemented settlement admin adapters are described in the
+  mutations document.
 - Storage: `crates/agglayer-storage/src/columns/mod.rs`
-  (`DISABLED_NETWORKS_CF` `:11`, settlement CFs `:32-36`),
-  per-job lock `crates/agglayer-storage/src/stores/state/mod.rs:54`.
-- Node wiring: `crates/agglayer-node/src/node.rs`
-  (admin router `:306-315`, listeners `:334-336`).
+  (`DISABLED_NETWORKS_CF`, settlement CFs);
+  per-job lock in `crates/agglayer-storage/src/stores/state/mod.rs`.
+- Node wiring: `crates/agglayer-node/src/node.rs` (admin router, listeners).
 - Codegen: `buf.storage.gen.yaml`, protos under `proto/agglayer/storage/v0/`.
-- Related issues: #1230 (reload/recovery), #1318/#1319 (nonce assignment),
-  #1321 (submit-to-L1), #1314, #1382, #1525 (SP1 v6 migration).
+- Related issues: #1230 (startup recovery, landed),
+  #1318/#1319/#1321 (execution primitives, landed),
+  #1525 (SP1 v6 migration, cf. OQ1).

--- a/docs/knowledge-base/src/ai-agents/specs/2026-07-07-settlement-admin-mutations-design.md
+++ b/docs/knowledge-base/src/ai-agents/specs/2026-07-07-settlement-admin-mutations-design.md
@@ -1,0 +1,311 @@
+# Settlement admin mutations (issue 1254) — design
+
+- Issue: <https://github.com/agglayer/agglayer/issues/1254>
+- Related: PR 1562 (full settlement admin and observability API design).
+  That design is being split in two:
+  this document records the **mutation surface**, which is implemented;
+  the [PR 1562 document](2026-06-08-settlement-admin-api-design.md)
+  keeps the parts that are not implemented yet
+  (pause/resume with full quiesce, observability reads, durable audit log).
+- Status: implemented
+- Date: 2026-07-07
+
+## Context
+
+The settlement service (`crates/agglayer-settlement-service`) drives one L1
+contract call per `SettlementJob` until it lands, retrying across nonces and
+wallets.
+A job is intentionally **infallible**: it has no terminal-failure state,
+so the certificate orchestrator can safely iterate on subsequent certificates.
+Job state is derived from row presence in storage:
+a job is pending while it has no `SettlementJobResult` row,
+and completed once that row is written.
+Every pending job has one live `SettlementTask` driving it
+(spawned at intake or by startup recovery).
+
+Operators need a small set of manual interventions on stored settlement state:
+
+- **Register an attempt the service does not know about** — a settlement
+  transaction submitted out-of-band, or ported from the legacy settlement path
+  (a pre-existing settlement tx hash recorded before the settlement service
+  owned submission).
+- **Assert that an attempt will never land** — e.g. the wallet was rotated
+  away and the nonce is dead, or an RPC outage prevents the service from ever
+  deriving the conclusion itself.
+- **Undo a recorded attempt result** — hand the attempt back to the task so
+  it re-derives the outcome from L1, e.g. after a wrong assertion.
+- **Un-complete a job** — remove a terminal result that should not have been
+  recorded, so the job is driven again.
+
+This document explains the API that covers these four needs, and why it is
+shaped the way it is.
+It deliberately implements the minimum:
+no pause/quiesce, no list/inspect observability, no audit log
+(see Non-goals).
+
+## Goals
+
+- Ship the four mutations above as JSON-RPC methods on the private admin
+  listener, plus the pre-existing abort/reload task controls.
+- Preserve the infallible-`SettlementJob` invariant:
+  no admin operation produces a terminal job failure.
+- Keep storage the single source of truth:
+  admin operations edit stored state and tell the live task to reload;
+  they never patch task memory.
+- Do no harm: precondition-checked, per-job-locked, insert-only where
+  overwriting could destroy evidence.
+
+## Non-goals
+
+- Pause/resume (global or per-wallet), quiesce, and drain reporting.
+- The observability read surface (`listJobs` / `getJob` / status views).
+- The durable admin audit log.
+  The mandatory `reason` of mark-definitely-failed is persisted only inside
+  the attempt result's error message.
+- A job-level terminal-failure state (contradicts the infallible-job
+  invariant; unchanged from the PR 1562 design).
+
+These stay covered by the PR 1562 document.
+
+## API surface
+
+All methods live in the `admin` JSON-RPC namespace, served only on the
+private admin listener (`admin_rpc_addr`), next to the certificate admin
+methods (`admin_forceEditCertificate` and friends).
+Implementation: `crates/agglayer-jsonrpc-api/src/settlement_admin.rs`,
+thin adapters over `SettlementService::admin_*` methods.
+
+| Method | Semantics |
+|---|---|
+| `admin_insertSettlementAttempt(job_id, attempt)` | Append one new attempt to a pending job; returns the assigned attempt number. Never overwrites. |
+| `admin_markSettlementAttemptDefinitelyFailed(job_id, attempt_number, reason)` | Overwrite the attempt's result with an operator assertion that it will never land. |
+| `admin_removeSettlementAttemptResult(job_id, attempt_number)` | Delete the attempt's result; the task re-derives it from L1. |
+| `admin_forceRemoveSettlementJobResult(job_id)` | Delete the job's terminal result and immediately re-drive the job. |
+| `admin_abortSettlementTask(job_id)` | Stop the in-memory task (runtime-only; not a terminal state). |
+| `admin_reloadSettlementTask(job_id)` | Make the live task drop its memory and reload from storage. |
+
+`attempt` for insert takes `txHash` (mandatory) and optional `senderWallet`,
+`nonce`, `submissionTimeUnixSecs`, `maxFeePerGas`, `maxPriorityFeePerGas`.
+
+The three attempt mutations respond with
+`{ attemptNumber, liveTask: "notified" | "absent" | "notify-failed" }`;
+`liveTask` reports whether the running task was told to reload
+(see the mutation model below).
+
+## Design decisions and rationale
+
+### D1 — Insert is append-only, with store-assigned attempt numbers
+
+`admin_insertSettlementAttempt` always adds one new attempt under the next
+unused attempt sequence number (max existing + 1) and returns it.
+It is **not** an upsert:
+when porting a pre-existing settlement tx hash, overwriting an
+already-recorded attempt would silently destroy evidence the task relies on.
+Assigning the number in the store (under the per-job write lock) keeps the
+operation race-free and spares the operator from picking a slot.
+This diverges from the PR 1562 draft, which sketched `admin_upsert_attempt`
+with an edit capability; editing is covered by remove-result + insert instead.
+
+### D2 — Missing attempt fields are resolved from L1 by tx hash
+
+Only the transaction hash is mandatory.
+A missing sender or nonce is resolved by fetching the transaction from the
+L1 RPC (`eth_getTransactionByHash`); an unknown transaction is rejected with
+instructions to pass the fields explicitly.
+Missing fees fall back to the fetched transaction's fees
+(an accurate baseline for the task's fee-bumping retries),
+or 0 when the transaction was not fetched
+(a retry then starts over from freshly estimated fees).
+A missing submission time defaults to now;
+it only seeds the retry backoff.
+Rationale: the porting flow starts from a tx hash;
+requiring the operator to copy sender/nonce/fees by hand is error-prone
+for no gain.
+
+### D3 — "Definitely failed" is an attempt-result override, never a job state
+
+A human asserting that an attempt will never land is a terminal client-side
+outcome for that attempt, so it maps onto the existing
+`SettlementAttemptResult::ClientError` with one new variant:
+`ClientErrorType::AbandonedByAdmin`
+(proto: `CLIENT_ERROR_TYPE_ABANDONED_BY_ADMIN = 3`).
+The write bypasses the regular upgrade-only rule (`can_be_replaced_by`)
+through a dedicated storage method.
+
+Re-drive is **emergent**, not a separate command:
+once the attempt is no longer pending, the reloaded run loop either
+re-drives the same nonce (wallet still under the service's control)
+or falls through to a fresh nonce on the default wallet
+(wallet rotated away, private key unknown).
+The job never fails — it is freed to settle elsewhere,
+preserving the infallible-job invariant.
+
+This is a trusted operator assertion:
+if the abandoned transaction can still land,
+only the settlement contract's replay protection prevents a double
+settlement (unchanged assumption from the PR 1562 design).
+Real on-chain evidence observed later still supersedes the assertion,
+because `ClientError -> ContractCall` remains a legal upgrade.
+
+### D4 — Remove-result is the undo
+
+`admin_removeSettlementAttemptResult` deletes the result row and nothing
+else, handing the attempt back to the task as pending.
+It exists because admin assertions must be reversible:
+a wrong mark-definitely-failed (or any wrongly recorded client error)
+is corrected by removing the result and letting the task re-derive the truth
+from L1, rather than by hand-writing a replacement result.
+It was not in the PR 1562 draft.
+
+### D5 — Force-remove of a job's terminal result
+
+`admin_forceRemoveSettlementJobResult` un-completes a job:
+it deletes the `SettlementJobResult` row, drops the in-memory watcher that
+still broadcasts the removed result, and spawns a fresh task that re-drives
+the job from stored state.
+Attempts and their results are untouched;
+remove attempt results first if they must be re-derived too.
+
+Guards, in order:
+
+1. refuse while a live task exists for the job
+   (a completed job has none; this blocks mid-completion races
+   and misuse on pending jobs);
+2. refuse when the job does not exist or has no terminal result;
+3. after the removal, respawn the task immediately,
+   so the "every pending job has a running task" invariant holds without a
+   node restart.
+
+The `force` prefix follows `admin_forceEditCertificate`:
+this is the one operation that moves a job backwards,
+and if the removed result was real,
+double-settle safety again rests on the contract.
+It still does not violate the infallible-job direction —
+it turns a completed job into a pending one, never the reverse.
+
+### D6 — Mutation model: declarative over stored state, reload to apply
+
+All mutations follow the model locked in the PR 1562 design:
+
+1. the storage method takes the per-job write lock
+   (`StateStore::with_settlement_write_lock`),
+   checks its preconditions, and writes;
+2. the service then tells the live task, if any, to drop its in-memory
+   `attempts` map and reload from storage
+   (`TaskAdminCommand::ReloadAndRestart`);
+3. tasks only ever read storage (start/reload),
+   so there is no bespoke in-memory edit path to diverge.
+
+The notification is best-effort, and the response says so honestly:
+`liveTask` is `notified` (task will reload), `absent` (no live task;
+the edit is picked up whenever one starts), or `notify-failed`
+(task still acts on stale memory; `admin_reloadSettlementTask` is the
+escape hatch).
+For a pending job, anything but `notified` is an anomaly worth
+investigating — after node integration (PR 1393),
+every pending job normally has a live task.
+
+Every attempt mutation refuses a job that already has a terminal result:
+a completed job is never re-driven,
+so editing its attempts could only create inconsistencies
+(`admin_forceRemoveSettlementJobResult` is the explicit way back).
+
+**Accepted race**: between an admin write and the task observing its reload,
+the task can act on pre-edit memory.
+For insert, the task may collide with the admin-assigned attempt number and
+panic on the insert-only storage write, wedging the job in memory until a
+reload or restart; the window is one loop iteration and the failure is loud.
+The clean fix is the pause/quiesce mechanism from the PR 1562 design;
+until then the race is documented rather than closed.
+The other mutations are race-benign (see D7).
+
+### D7 — An admin abandon outranks client-side notes, but yields to L1
+
+`record_settlement_attempt_result` (the regular, task-facing writer) keeps
+an `AbandonedByAdmin` result and **reports success** when asked to overwrite
+it with another client error (nonce-used / settled-elsewhere notes,
+submit failures).
+Rationale: a task that has not observed the override yet may legitimately
+try to record such a note; refusing would make the task panic on a conflict
+it cannot resolve — the panic-loop family fixed by PR 1617 —
+and the admin assertion is semantically at least as strong as any
+client-side note.
+On-chain evidence (`ContractCall`) still replaces the assertion through the
+normal upgrade rule, so a wrong assertion self-heals when the transaction
+lands after all.
+
+### D8 — Simplicity choices (deviations from the PR 1562 draft)
+
+Reviewed and chosen deliberately when the surface shrank to mutations-only:
+
+- **No separate `SettlementAdminWriter` trait, no `settlement-admin` cargo
+  feature.** The four bypass methods live on `SettlementWriter` with an
+  `admin_` prefix and a documented contract that the settlement task must
+  never call them.
+  This trades the draft's compile-time capability containment for one fewer
+  trait; the containment was hygiene, not a security boundary
+  (cargo features are additive anyway).
+- **No tower `AdminCommand` extension.** The JSON-RPC adapters call the
+  service's inherent `admin_*` methods directly.
+  The tower command-as-data indirection only pays for itself when a
+  cross-cutting layer (the audit log) needs a single choke point;
+  it should return together with the audit work.
+- **`admin` namespace, not a `settlement` namespace.**
+  The methods join the existing admin RPC surface
+  (one listener, one namespace, one operator entry point)
+  as a second jsonrpsee trait merged into the same server.
+- **No audit rows.** Deferred with the audit design in PR 1562;
+  `reason` survives only inside the abandoned result's message.
+
+## Safety invariants
+
+1. **Infallible job preserved** — no operation adds a terminal job failure;
+   force-remove only moves a job from completed back to pending.
+2. **Storage is the single source of truth** — tasks apply admin edits by
+   reloading; nothing patches task memory.
+3. **Per-job atomicity** — every mutation checks and writes under the job's
+   settlement write lock.
+4. **Evidence is never silently overwritten** — insert is append-only;
+   only the explicit override and the two explicit removals touch existing
+   rows, each behind its own preconditions.
+5. **Double-settle backstop is the contract** — mark-definitely-failed and
+   force-remove are trusted operator assertions;
+   their safety rests on the L1 settlement contract being replay-safe.
+6. **Capability containment is by convention now** — the bypass writers are
+   reachable from settlement code as a type-system matter;
+   the contract lives in the trait docs (weaker than the draft, see D8).
+
+## Runbooks
+
+- **Port an externally-submitted settlement tx** (legacy path, out-of-band
+  replacement): `admin_insertSettlementAttempt(job_id, { txHash })` —
+  sender, nonce, and fees resolve from L1; the task tracks the attempt like
+  its own.
+- **Dead nonce after wallet rotation**: confirm the transaction cannot land,
+  `admin_markSettlementAttemptDefinitelyFailed(job_id, n, reason)`;
+  the reloaded task re-drives on a fresh nonce/wallet.
+- **Wrong assertion**: `admin_removeSettlementAttemptResult(job_id, n)`;
+  the task re-derives the attempt's outcome from L1.
+- **Wrongly recorded terminal result**: optionally clear the misleading
+  attempt results, then `admin_forceRemoveSettlementJobResult(job_id)`;
+  a fresh task re-drives the job immediately.
+- **Recovery when `liveTask != "notified"`**:
+  `admin_reloadSettlementTask(job_id)`, or `admin_abortSettlementTask` and
+  let the next restart respawn from storage.
+
+## Key code references
+
+- RPC surface: `crates/agglayer-jsonrpc-api/src/settlement_admin.rs`,
+  merged into the admin router in `crates/agglayer-jsonrpc-api/src/admin.rs`
+  and wired in `crates/agglayer-node/src/node.rs`.
+- Service methods and mutation model:
+  `crates/agglayer-settlement-service/src/settlement_service.rs`
+  (`NewSettlementAttempt`, `LiveTaskNotification`, `admin_*` methods).
+- Storage writers and guards:
+  `crates/agglayer-storage/src/stores/interfaces/writer/settlement_writer.rs`
+  (trait contract) and
+  `crates/agglayer-storage/src/stores/state/settlement/mod.rs`
+  (implementation, per-job lock, D7 conflict rule).
+- Domain type: `ClientErrorType::AbandonedByAdmin` in
+  `crates/agglayer-types/src/settlement.rs`;
+  proto in `proto/agglayer/storage/v0/settlement.proto`.

--- a/docs/knowledge-base/src/ai-agents/specs/2026-07-07-settlement-admin-mutations-design.md
+++ b/docs/knowledge-base/src/ai-agents/specs/2026-07-07-settlement-admin-mutations-design.md
@@ -77,9 +77,9 @@ thin adapters over `SettlementService::admin_*` methods.
 
 | Method | Semantics |
 |---|---|
-| `admin_insertSettlementAttempt(job_id, attempt)` | Append one new attempt to a pending job; returns the assigned attempt number. Never overwrites. |
-| `admin_markSettlementAttemptDefinitelyFailed(job_id, attempt_number, reason)` | Overwrite the attempt's result with an operator assertion that it will never land. |
-| `admin_removeSettlementAttemptResult(job_id, attempt_number)` | Delete the attempt's result; the task re-derives it from L1. |
+| `admin_insertSettlementAttempt(job_id, attempt, force?)` | Append one new attempt to the job; returns the assigned attempt number. Never overwrites. |
+| `admin_markSettlementAttemptDefinitelyFailed(job_id, attempt_number, reason, force?)` | Overwrite the attempt's result with an operator assertion that it will never land. |
+| `admin_removeSettlementAttemptResult(job_id, attempt_number, force?)` | Delete the attempt's result; the task re-derives it from L1. |
 | `admin_forceRemoveSettlementJobResult(job_id)` | Delete the job's terminal result and immediately re-drive the job. |
 | `admin_abortSettlementTask(job_id)` | Stop the in-memory task (runtime-only; not a terminal state). |
 | `admin_reloadSettlementTask(job_id)` | Make the live task drop its memory and reload from storage. |
@@ -91,6 +91,9 @@ The three attempt mutations respond with
 `{ attemptNumber, liveTask: "notified" | "absent" | "notify-failed" }`;
 `liveTask` reports whether the running task was told to reload
 (see the mutation model below).
+Their optional trailing `force` parameter takes the literal string
+`"force=true"` or `"force=false"` (the `admin_forceEditCertificate` style;
+omitted means false) and gates edits on completed jobs (see D6).
 
 ## Design decisions and rationale
 
@@ -164,7 +167,9 @@ it deletes the `SettlementJobResult` row, drops the in-memory watcher that
 still broadcasts the removed result, and spawns a fresh task that re-drives
 the job from stored state.
 Attempts and their results are untouched;
-remove attempt results first if they must be re-derived too.
+correct them **first**, with the attempt mutations' `force` parameter,
+while the terminal result still blocks the job from being re-driven
+(see D6).
 
 Guards, in order:
 
@@ -205,10 +210,20 @@ For a pending job, anything but `notified` is an anomaly worth
 investigating — after node integration (PR 1393),
 every pending job normally has a live task.
 
-Every attempt mutation refuses a job that already has a terminal result:
+Every attempt mutation refuses a job that already has a terminal result,
+unless its `force` parameter is `"force=true"`:
 a completed job is never re-driven,
-so editing its attempts could only create inconsistencies
-(`admin_forceRemoveSettlementJobResult` is the explicit way back).
+so editing its attempts could normally only create inconsistencies.
+The forced variant exists to prepare
+`admin_forceRemoveSettlementJobResult`:
+attempt-result corrections must land while the job still has its terminal
+result, because removing the result immediately respawns the task,
+which could re-derive and re-record the job result from the uncorrected
+attempts before the operator gets a chance to adjust them.
+On a completed job there is no live task,
+so a forced edit reporting `liveTask: "absent"` is the expected state;
+the correction is observed by the task that
+`admin_forceRemoveSettlementJobResult` spawns.
 
 **Accepted race**: between an admin write and the task observing its reload,
 the task can act on pre-edit memory.
@@ -286,9 +301,10 @@ Reviewed and chosen deliberately when the surface shrank to mutations-only:
   the reloaded task re-drives on a fresh nonce/wallet.
 - **Wrong assertion**: `admin_removeSettlementAttemptResult(job_id, n)`;
   the task re-derives the attempt's outcome from L1.
-- **Wrongly recorded terminal result**: optionally clear the misleading
-  attempt results, then `admin_forceRemoveSettlementJobResult(job_id)`;
-  a fresh task re-drives the job immediately.
+- **Wrongly recorded terminal result**: first correct the misleading
+  attempt results with `"force=true"` (mark abandoned, remove, or insert),
+  then `admin_forceRemoveSettlementJobResult(job_id)`;
+  a fresh task re-drives the job immediately from the corrected attempts.
 - **Recovery when `liveTask != "notified"`**:
   `admin_reloadSettlementTask(job_id)`, or `admin_abortSettlementTask` and
   let the next restart respawn from storage.


### PR DESCRIPTION
## What

Splits the settlement admin API design document from #1562 into two:

- **New:** `docs/knowledge-base/src/ai-agents/specs/2026-07-07-settlement-admin-mutations-design.md`
  — the **mutation surface**: insert-attempt, mark-attempt-definitely-failed,
  remove-attempt-result, force-remove-job-result, plus the JSON-RPC exposure of the
  abort/reload task controls. Written as-built: this half is implemented
  (implementation PR to follow separately), and the document records where the
  implementation deliberately deviates from the #1562 draft — append-only insert
  instead of upsert, two new "undo" operations (remove-result, force-remove),
  L1-resolved attempt fields, the `admin` namespace, no separate
  `SettlementAdminWriter` trait / `settlement-admin` cargo feature, no tower
  `AdminCommand` indirection yet, and no audit rows yet.
- **Rewritten:** `2026-06-08-settlement-admin-api-design.md` — now titled
  "Settlement service pause, observability, and audit" and covering only the
  remaining, not-yet-implemented surface: pause/resume with full quiesce and
  trustworthy drain reporting, the observability read surface, and the durable
  admin audit log. Mutation content is replaced by pointers to the mutations
  document (the audit log will cover the implemented mutations when it lands),
  and the background/current-state and phasing sections are refreshed: node
  integration (#1393), startup recovery/reload (#1230), and the execution
  primitives (#1318/#1319/#1321) have all landed since the draft, so the
  remaining phases are unblocked.

The first commit is the mechanical split; the second is the rewrite of the
remainder document, so the two steps can be reviewed separately.

## Why

I'm just cutting the mutations bit off of #1562 to be able to focus on its
implementation.

**Note for reviewers:** I have not fully reviewed the "remainder" half (the
rewritten 2026-06-08 document) myself — treat it as the same draft-for-review it
was in #1562, restated to cover only what is left to build.

Refs: #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
