### PR TITLE
refactor(storage): reopen the database with declared column options in finalize

### DIFF
--- a/crates/agglayer-storage/src/storage/migration/mod.rs
+++ b/crates/agglayer-storage/src/storage/migration/mod.rs
@@ -45,18 +45,12 @@ impl Builder {
     /// initial schema (v0). It automatically sets up migration tracking and
     /// validates the database schema.
     ///
-    /// `known_cfs` catalogs every column family this binary declares across
-    /// all schema versions. Column family options only apply when passed at
-    /// open time, so an existing database is opened with the declared options
-    /// looked up there (RocksDB defaults for on-disk column families it does
-    /// not list).
-    pub fn open(
-        path: &Path,
-        cfs_v0: &[ColumnDescriptor],
-        known_cfs: &[ColumnDescriptor],
-    ) -> Result<Self, DBOpenError> {
+    /// The handle opened here only serves the migration steps; existing
+    /// column families are opened with default options. [`Self::finalize`]
+    /// reopens the database with the declared column options before handing
+    /// it out.
+    pub fn open(path: &Path, cfs_v0: &[ColumnDescriptor]) -> Result<Self, DBOpenError> {
         debug!("Preparing database for initialization and migration");
-        debug!(?known_cfs, "Column families known to this binary");
         let desc_v0: Vec<_> = cfs_v0.iter().map(DB::descriptor).collect();
         let cfs_v0: BTreeSet<_> = desc_v0.iter().map(|d| d.name()).collect();
 
@@ -84,12 +78,12 @@ impl Builder {
             Self::open_rocksdb_fresh(path, cfs)?
         } else if cfs_db.contains(MigrationRecordColumn::COLUMN_FAMILY_NAME) {
             // Move on to migration as usual.
-            Self::open_rocksdb_existing(path, &cfs_db, known_cfs)?
+            Self::open_rocksdb_existing(path, &cfs_db)?
         } else if cfs_db.iter().eq(cfs_v0.iter()) {
             // Initialize migration record.
             let mut cfs = cfs_db;
             cfs.insert(MigrationRecordColumn::COLUMN_FAMILY_NAME.into());
-            Self::open_rocksdb_existing(path, &cfs, known_cfs)?
+            Self::open_rocksdb_existing(path, &cfs)?
         } else {
             // Unexpected schema.
             return Err(DBOpenError::UnexpectedSchema);
@@ -142,28 +136,14 @@ impl Builder {
         })
     }
 
-    fn open_rocksdb_existing(
-        path: &Path,
-        cfs: &BTreeSet<impl AsRef<str>>,
-        known_cfs: &[ColumnDescriptor],
-    ) -> Result<DB, DBError> {
+    fn open_rocksdb_existing(path: &Path, cfs: &BTreeSet<impl AsRef<str>>) -> Result<DB, DBError> {
         debug!("Opening existing database");
 
         let mut options = rocksdb::Options::default();
         options.create_missing_column_families(true);
 
-        let known_cfs: Vec<ColumnDescriptor> = known_cfs
-            .iter()
-            .cloned()
-            .chain([ColumnDescriptor::new::<MigrationRecordColumn>()])
-            .collect();
-        let descriptors: Vec<_> = cfs
-            .iter()
-            .map(|name| DB::descriptor_for_existing(name.as_ref(), &known_cfs))
-            .collect();
-
         Ok(DB {
-            rocksdb: rocksdb::DB::open_cf_descriptors(&options, path, descriptors)?,
+            rocksdb: rocksdb::DB::open_cf(&options, path, cfs.iter().map(AsRef::as_ref))?,
             default_write_options: Some(Self::writeopts()),
         })
     }
@@ -267,8 +247,14 @@ impl Builder {
     /// Completes the migration process and returns the database.
     ///
     /// This method validates that all declared migration steps have been
-    /// executed and returns the fully migrated database ready for use.
-    pub fn finalize(self, _expected_schema: &[ColumnDescriptor]) -> Result<DB, DBOpenError> {
+    /// executed, then unconditionally closes the migration-time handle and
+    /// reopens the database with the column options declared in
+    /// `expected_schema` (RocksDB defaults for on-disk column families it
+    /// does not list). Column family options — prefix extractors,
+    /// compression — only take effect when passed at open time, and the
+    /// migration-time handle opens existing column families by name without
+    /// them.
+    pub fn finalize(self, expected_schema: &[ColumnDescriptor]) -> Result<DB, DBOpenError> {
         if self.step < self.start_step {
             return Err(DBOpenError::FewerStepsDeclared {
                 declared: self.step,
@@ -276,7 +262,33 @@ impl Builder {
             });
         }
 
-        Ok(self.db)
+        let path = self.db.rocksdb.path().to_path_buf();
+        // Close the migration-time handle so the reopen below can take the
+        // RocksDB lock.
+        drop(self.db);
+
+        debug!("Reopening database with declared column options");
+        let known_cfs: Vec<ColumnDescriptor> = expected_schema
+            .iter()
+            .cloned()
+            .chain([ColumnDescriptor::new::<MigrationRecordColumn>()])
+            .collect();
+        let descriptors: Vec<_> = rocksdb::DB::list_cf(&rocksdb::Options::default(), &path)
+            .map_err(DBError::from)?
+            .into_iter()
+            .filter(|name| name != rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+            .map(|name| DB::descriptor_for_existing(&name, &known_cfs))
+            .collect();
+
+        Ok(DB {
+            rocksdb: rocksdb::DB::open_cf_descriptors(
+                &rocksdb::Options::default(),
+                &path,
+                descriptors,
+            )
+            .map_err(DBError::from)?,
+            default_write_options: Some(Self::writeopts()),
+        })
     }
 
     fn perform_step(

--- a/crates/agglayer-storage/src/storage/migration/test/sample.rs
+++ b/crates/agglayer-storage/src/storage/migration/test/sample.rs
@@ -106,11 +106,11 @@ pub const CFS_V2: &[ColumnDescriptor] = &[
 impl Builder {
     pub fn open_sample(path: &Path) -> Result<Self, DBOpenError> {
         let cfs = [ColumnDescriptor::new::<NetworkInfoV0Column>()];
-        Self::open(path, &cfs, &cfs)
+        Self::open(path, &cfs)
     }
 
     pub fn open_sample_v1(path: &Path) -> Result<Self, DBOpenError> {
-        Self::open(path, CFS_V1, CFS_V1)
+        Self::open(path, CFS_V1)
     }
 
     pub fn sample_migrate_v0_v1(self) -> Result<Self, DBOpenError> {

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -42,21 +42,13 @@ pub struct DB {
 impl DB {
     /// Open a new RocksDB instance at the given path with initial column
     /// families and a possibility to migrate the database.
-    ///
-    /// `known_cfs` catalogs every column family this binary declares across
-    /// all schema versions; existing column families are opened with the
-    /// declared options found there (or RocksDB defaults when absent).
-    pub fn builder(
-        path: &Path,
-        cfs_v0: &[ColumnDescriptor],
-        known_cfs: &[ColumnDescriptor],
-    ) -> Result<Builder, DBOpenError> {
-        Builder::open(path, cfs_v0, known_cfs)
+    pub fn builder(path: &Path, cfs_v0: &[ColumnDescriptor]) -> Result<Builder, DBOpenError> {
+        Builder::open(path, cfs_v0)
     }
 
     /// Open a new RocksDB instance at the given path with some column families.
     pub fn open_cf(path: &Path, cfs: &[ColumnDescriptor]) -> Result<DB, DBOpenError> {
-        Builder::open(path, cfs, cfs)?.finalize(cfs)
+        Builder::open(path, cfs)?.finalize(cfs)
     }
 
     /// Open a RocksDB instance in read-only mode at the given path with some

--- a/crates/agglayer-storage/src/stores/debug/mod.rs
+++ b/crates/agglayer-storage/src/stores/debug/mod.rs
@@ -28,7 +28,7 @@ pub struct EnabledDebugStore {
 
 impl DebugStore {
     pub fn init_db(path: &Path) -> Result<DB, crate::storage::DBOpenError> {
-        DB::builder(path, cf_definitions::DEBUG_DB_V0, cf_definitions::DEBUG_DB)?
+        DB::builder(path, cf_definitions::DEBUG_DB_V0)?
             .add_cfs(
                 &[ColumnDescriptor::new::<DebugCertificatesProtoColumn>()],
                 backfill_debug_certificates_proto_from_legacy_bincode,

--- a/crates/agglayer-storage/src/stores/pending/mod.rs
+++ b/crates/agglayer-storage/src/stores/pending/mod.rs
@@ -33,16 +33,12 @@ pub struct PendingStore {
 
 impl PendingStore {
     pub fn init_db(path: &Path) -> Result<DB, crate::storage::DBOpenError> {
-        DB::builder(
-            path,
-            cf_definitions::PENDING_DB_V0,
-            cf_definitions::PENDING_DB,
-        )?
-        .add_cfs(
-            &[ColumnDescriptor::new::<PendingQueueProtoColumn>()],
-            backfill_pending_certificates_proto_from_legacy_bincode,
-        )?
-        .finalize(cf_definitions::PENDING_DB)
+        DB::builder(path, cf_definitions::PENDING_DB_V0)?
+            .add_cfs(
+                &[ColumnDescriptor::new::<PendingQueueProtoColumn>()],
+                backfill_pending_certificates_proto_from_legacy_bincode,
+            )?
+            .finalize(cf_definitions::PENDING_DB)
     }
 
     pub fn new(db: Arc<DB>) -> Self {

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -53,16 +53,12 @@ pub struct PerEpochStore<PendingStore, StateStore> {
 
 impl<PendingStore, StateStore> PerEpochStore<PendingStore, StateStore> {
     pub fn init_db(path: &std::path::Path) -> Result<DB, crate::storage::DBOpenError> {
-        DB::builder(
-            path,
-            cf_definitions::EPOCHS_DB_V0,
-            cf_definitions::EPOCHS_DB,
-        )?
-        .add_cfs(
-            &[ColumnDescriptor::new::<CertificatePerIndexProtoColumn>()],
-            backfill_epoch_certificates_proto_from_legacy_bincode,
-        )?
-        .finalize(cf_definitions::EPOCHS_DB)
+        DB::builder(path, cf_definitions::EPOCHS_DB_V0)?
+            .add_cfs(
+                &[ColumnDescriptor::new::<CertificatePerIndexProtoColumn>()],
+                backfill_epoch_certificates_proto_from_legacy_bincode,
+            )?
+            .finalize(cf_definitions::EPOCHS_DB)
     }
 
     pub fn init_db_readonly(path: &std::path::Path) -> Result<DB, crate::storage::DBError> {

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -64,7 +64,7 @@ impl StateStore {
         // path. Each `ensure_cfs` call is a recorded migration step, so new
         // catch-up CFs must be added in a new step instead of changing an
         // already-recorded target list.
-        DB::builder(path, cf_definitions::STATE_DB_V0, cf_definitions::STATE_DB)?
+        DB::builder(path, cf_definitions::STATE_DB_V0)?
             .ensure_cfs(cf_definitions::STATE_DB_V1_ADDED_CFS)?
             .ensure_cfs(cf_definitions::STATE_DB_V2_ADDED_CFS)?
             .finalize(cf_definitions::STATE_DB)

--- a/crates/agglayer-storage/src/stores/state/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/tests.rs
@@ -91,16 +91,12 @@ fn init_db_adds_settlement_job_id_per_certificate_id_cf_to_v1_schema() {
 
     let tmp = TempDBDir::new();
     {
-        let previous_schema = DB::builder(
-            tmp.path.as_path(),
-            cf_definitions::STATE_DB_V0,
-            cf_definitions::STATE_DB,
-        )
-        .expect("V0 schema initialization should succeed")
-        .ensure_cfs(cf_definitions::STATE_DB_V1_ADDED_CFS)
-        .expect("V1 schema migration should succeed")
-        .finalize(cf_definitions::STATE_DB)
-        .expect("V1 schema finalization should succeed");
+        let previous_schema = DB::builder(tmp.path.as_path(), cf_definitions::STATE_DB_V0)
+            .expect("V0 schema initialization should succeed")
+            .ensure_cfs(cf_definitions::STATE_DB_V1_ADDED_CFS)
+            .expect("V1 schema migration should succeed")
+            .finalize(cf_definitions::STATE_DB)
+            .expect("V1 schema finalization should succeed");
         drop(previous_schema);
     }
 


### PR DESCRIPTION
Follow-up to #1630 (now merged) — simplifies how declared column options get applied on existing databases.

## Design

`Builder::finalize()` already receives the authoritative expected schema (previously unused). Instead of threading a `known_cfs` catalog into `Builder::open` so that existing column families open with their declared options, `finalize()` now **unconditionally closes the migration-time handle and reopens the database** with the declared options looked up from `expected_schema` (+ the migration-record CF; RocksDB defaults for on-disk CFs it does not list).

The migration steps themselves run on a plainly-opened handle with default options, which is harmless: CF options only affect the live handle, and the handle the node actually runs with is now always opened with declared options in exactly one place, regardless of which path (fresh create, existing open, mid-migration CF creation) produced the CFs. Cost: one extra close+reopen per store per boot, negligible at startup.

## Reverted from #1630 (no longer needed)

- `known_cfs` parameter on `DB::builder` / `Builder::open` / `open_rocksdb_existing` (back to their original signatures; existing DBs open by name again for the migration-time handle)
- The catalog argument at the four stores' `init_db` call sites, the migration test sample helpers, and the state legacy-schema test

## Kept from #1630

- `DB::descriptor_for_existing` (now used by `finalize` and the read-only path) with its per-CF declared-vs-default debug logs
- `open_cf_readonly` opening with declared options (read-only opens don't go through `finalize`)
- Option logging on CF creation during migrations, and the settlement-task hydration debug logs
- Both reopen regression tests — `list_settlement_attempts_stays_within_job_after_reopen` and `reopened_database_applies_declared_prefix_extractor` — which pass **unchanged**, now guarded by the finalize reopen alone

## Verification

`cargo make generate-proto` (no diffs), `cargo check --workspace --tests --all-features`, `cargo make ci-all`, `cargo nextest run --workspace --no-fail-fast` (829 tests), and `cargo make pp-check-vkey-change` all pass; the two reopen regression tests re-verified green after rebasing onto main (#1630 squash-merged mid-verification). One unrelated flake surfaced along the way: `agglayer-clock block::tests::test_block_clock_starting_with_genesis_already_passed` takes ~12.2s against its 13s rstest timeout even on an idle machine and timed out once under full parallel load; it passes in isolation and on the re-run. Worth loosening that timeout separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)