### PR TITLE
build(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      # Required for scheduled runs: rustsec/audit-check reports findings
+      # by opening an issue on schedule/workflow_dispatch events.
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3746,9 +3746,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Fix the failing scheduled Audit workflow on main.

The 2026-07-07 scheduled run failed on advisory RUSTSEC-2026-0204:
invalid pointer dereference in the fmt::Pointer impl for Atomic and
Shared in crossbeam-epoch < 0.9.20. This bumps the root lockfile to
0.9.20 (semver-compatible, transitive).

The same run also failed to open its report issue with "Resource not
accessible by integration": rustsec/audit-check opens an issue on
schedule/workflow_dispatch findings, but the job token only granted
checks: write. The workflow now also grants issues: write.

Note: crates/pessimistic-proof-program/Cargo.lock still pins
crossbeam-epoch 0.9.18 on purpose. Bumping it would change the SP1
program ELF and its verification key; the audit CI only scans the
root lockfile.