### PR TITLE
feat(rpc): disable the interop_sendTx method

### DIFF
--- a/crates/agglayer-jsonrpc-api/src/error.rs
+++ b/crates/agglayer-jsonrpc-api/src/error.rs
@@ -33,6 +33,9 @@ pub mod code {
 
     /// Resource not found.
     pub const RESOURCE_NOT_FOUND: i32 = -10008;
+
+    /// Method permanently disabled.
+    pub const METHOD_DISABLED: i32 = -10009;
 }
 
 #[derive(PartialEq, Eq, Serialize, Debug, Clone, thiserror::Error)]
@@ -145,6 +148,9 @@ pub enum Error {
     #[error("Resource not found: {0}")]
     ResourceNotFound(String),
 
+    #[error("The {method} method is disabled")]
+    MethodDisabled { method: &'static str },
+
     #[error("Internal error: {0}")]
     Internal(String),
 }
@@ -167,6 +173,7 @@ impl Error {
             Self::Status(_) => code::STATUS_ERROR,
             Self::SendCertificate { .. } => code::SEND_CERTIFICATE,
             Self::RateLimited { .. } => code::RATE_LIMITED,
+            Self::MethodDisabled { .. } => code::METHOD_DISABLED,
         }
     }
 }

--- a/crates/agglayer-jsonrpc-api/src/lib.rs
+++ b/crates/agglayer-jsonrpc-api/src/lib.rs
@@ -23,7 +23,7 @@ use jsonrpsee::{
     server::{HttpBody, PingConfig, ServerBuilder},
 };
 use tower_http::{compression::CompressionLayer, cors::CorsLayer};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{service::AgglayerService, signed_tx::SignedTx};
 
@@ -203,7 +203,25 @@ where
     EpochsStore: EpochStoreReader + 'static,
 {
     async fn send_tx(&self, tx: SignedTx) -> RpcResult<B256> {
-        Ok(self.service.send_tx(tx).await?)
+        // The legacy `interop_sendTx` proof-settlement flow is disabled
+        // (https://github.com/agglayer/agglayer/issues/1632). The method stays
+        // registered so callers receive an explicit error instead of a generic
+        // "method not found".
+        let rollup_id = tx.tx.rollup_id;
+        agglayer_telemetry::SEND_TX.add(
+            1,
+            &[agglayer_telemetry::KeyValue::new(
+                "rollup_id",
+                rollup_id.to_string(),
+            )],
+        );
+        warn!(
+            rollup_id,
+            "Rejected interop_sendTx call: method is disabled"
+        );
+        Err(Error::MethodDisabled {
+            method: "interop_sendTx",
+        })
     }
 
     async fn get_tx_status(&self, hash: B256) -> RpcResult<TxStatus> {

--- a/crates/agglayer-jsonrpc-api/src/tests.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests.rs
@@ -5,3 +5,4 @@ mod get_latest_known_certificate_header;
 mod get_token_balance;
 mod get_tx_status;
 mod send_certificate;
+mod send_tx;

--- a/crates/agglayer-jsonrpc-api/src/tests/errors.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/errors.rs
@@ -147,6 +147,10 @@ type WallClockLimitedInfo = <component::SendTx as Component>::LimitedInfo;
     "cert_notfound",
     agglayer_rpc::CertificateRetrievalError::NotFound { certificate_id: CertificateId::new(Digest([0x51; 32])) }
 )]
+#[case(
+    "method_disabled",
+    Error::MethodDisabled { method: "interop_sendTx" }
+)]
 fn rpc_error_rendering(#[case] name: &str, #[case] err: impl Into<Error>) {
     let err: Error = err.into();
     let debug_str = format!("{err:?}");

--- a/crates/agglayer-jsonrpc-api/src/tests/send_tx.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/send_tx.rs
@@ -1,0 +1,50 @@
+//! Tests for the disabled `interop_sendTx` method.
+
+use jsonrpsee::{
+    core::{client::ClientT, ClientError},
+    rpc_params,
+};
+use serde_json::json;
+
+use crate::testutils::TestContext;
+
+/// A wire-valid `SignedTx` JSON payload (zero proof, zero signature with
+/// `v = 27`). It must deserialize successfully so the request reaches the
+/// handler instead of being rejected with an invalid params error.
+fn signed_tx_json() -> serde_json::Value {
+    json!({
+        "tx": {
+            "RollupID": 1,
+            "lastVerifiedBatch": "0x0",
+            "newVerifiedBatch": "0x1",
+            "ZKP": {
+                "newStateRoot":
+                    "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "newLocalExitRoot":
+                    "0x0000000000000000000000000000000000000000000000000000000000000002",
+                "proof": format!("0x{}", "00".repeat(24 * 32)),
+            },
+        },
+        "signature": format!("0x{}1b", "00".repeat(64)),
+    })
+}
+
+#[test_log::test(tokio::test)]
+async fn send_tx_returns_method_disabled_error() {
+    let config = TestContext::get_default_config();
+    let context = TestContext::new_with_config(config).await;
+
+    let result: Result<alloy::primitives::B256, ClientError> = context
+        .api_client
+        .request("interop_sendTx", rpc_params![signed_tx_json()])
+        .await;
+
+    let error = result.unwrap_err();
+    let ClientError::Call(err) = error else {
+        panic!("expected a call error, got: {error}");
+    };
+
+    // Wire contract: `interop_sendTx` is disabled (issue #1632).
+    assert_eq!(err.code(), -10009);
+    assert_eq!(err.message(), "The interop_sendTx method is disabled");
+}

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__method_disabled.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__method_disabled.snap
@@ -1,0 +1,13 @@
+---
+source: crates/agglayer-jsonrpc-api/src/tests/errors.rs
+expression: "MethodDisabled { method: \"interop_sendTx\" }"
+---
+{
+  "code": -10009,
+  "data": {
+    "method-disabled": {
+      "method": "interop_sendTx"
+    }
+  },
+  "message": "The interop_sendTx method is disabled"
+}


### PR DESCRIPTION
Replace the legacy proof-settlement flow behind `interop_sendTx` with
an immediate `MethodDisabled` error (code -10009). The method stays
registered so callers get an explicit error instead of a generic
"method not found". Calls are still counted by the SEND_TX metric and
logged at warn level to keep residual callers observable.

The service/kernel machinery behind the old flow (kernel settlement
path, zkevm-node client, sendTx rate limiting, dedicated settlement
signer and related config) is left in place and will be removed in a
stacked follow-up PR, which will not target v0.6.0.

Closes #1632

BREAKING-CHANGE: `interop_sendTx` no longer settles proofs; it always
returns JSON-RPC error -10009 ("The interop_sendTx method is
disabled").