### PR TITLE
ci: move docker build cache to a registry and split circuits stage

### DIFF
--- a/.github/workflows/buildcache-cleanup.yml
+++ b/.github/workflows/buildcache-cleanup.yml
@@ -1,0 +1,24 @@
+name: Buildcache cleanup
+
+on:
+  schedule:
+    # The buildx cache export rewrites the buildcache tag on every main push,
+    # leaving untagged cache manifests behind in GHCR. GHCR has no built-in
+    # retention for untagged versions, so prune them weekly.
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    name: Delete untagged buildcache versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: agglayer-buildcache
+          package-type: container
+          delete-only-untagged-versions: "true"
+          min-versions-to-keep: 5

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -85,10 +85,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: ${{ inputs.push == true && 'type=image' || format('type=docker,dest={0}/{1}.tar', inputs.local-artifact-dir, inputs.local-artifact-name) }}
-          cache-from: type=gha
-          # Keep merge queue/local artifact builds cache-read-only; cache export is
+          # The buildx cache lives in GHCR instead of the 10GB Actions cache so
+          # rust-cache churn from other jobs cannot evict the cargo-chef layers.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-buildcache:main
+          # Only pushes to main export the cache; merge queue, PR, and branch
+          # dispatch builds stay cache-read-only (see PR #1593). Cache export is
           # expensive and blocks the E2E required check.
-          cache-to: ${{ inputs.push == true && 'type=gha,mode=max' || '' }}
+          cache-to: ${{ inputs.push == true && github.ref == 'refs/heads/main' && format('type=registry,ref={0}/{1}-buildcache:main,mode=max,image-manifest=true', env.REGISTRY, env.IMAGE_NAME) || '' }}
 
       - name: Upload artifact
         if: inputs.push == false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,9 +88,11 @@ jobs:
           # The buildx cache lives in GHCR instead of the 10GB Actions cache so
           # rust-cache churn from other jobs cannot evict the cargo-chef layers.
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-buildcache:main
-          # Only pushes to main export the cache; merge queue, PR, and branch
-          # dispatch builds stay cache-read-only (see PR #1593). Cache export is
-          # expensive and blocks the E2E required check.
+          # Only builds on the main ref export the cache: pushes to main, and
+          # manual dispatches on main (useful to warm or refresh the cache).
+          # Merge queue, PR, and branch dispatch builds stay cache-read-only
+          # (see PR #1593). Cache export is expensive and blocks the E2E
+          # required check.
           cache-to: ${{ inputs.push == true && github.ref == 'refs/heads/main' && format('type=registry,ref={0}/{1}-buildcache:main,mode=max,image-manifest=true', env.REGISTRY, env.IMAGE_NAME) || '' }}
 
       - name: Upload artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM --platform=${BUILDPLATFORM} rust:slim-bookworm AS chef
 
-ARG CIRCUIT_ARTIFACTS_URL_BASE=https://sp1-circuits.s3-us-east-2.amazonaws.com
-ARG CIRCUIT_TYPE=plonk
-ARG CIRCUIT_VERSION=v6.1.0
 ARG PROTOC_VERSION=28.2
 ARG CHEF_VERSION=0.1.68
 
@@ -21,6 +18,23 @@ COPY --link Cargo.lock Cargo.lock
 RUN cargo chef prepare --recipe-path recipe.json --bin agglayer
 
 FROM --platform=${BUILDPLATFORM} golang:1.22 AS go-builder
+
+# The SP1 circuits live in their own stage, keyed only on the CIRCUIT_* args,
+# so a Rust dependency cache miss does not re-download ~1GB from S3.
+FROM debian:bookworm-slim AS circuits
+
+ARG CIRCUIT_ARTIFACTS_URL_BASE=https://sp1-circuits.s3-us-east-2.amazonaws.com
+ARG CIRCUIT_TYPE=plonk
+ARG CIRCUIT_VERSION=v6.1.0
+
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+RUN mkdir -p /root/.sp1/circuits/${CIRCUIT_TYPE}/${CIRCUIT_VERSION} \
+    && curl -s -o /tmp/circuits.tar.gz ${CIRCUIT_ARTIFACTS_URL_BASE}/${CIRCUIT_VERSION}-${CIRCUIT_TYPE}.tar.gz \
+    && tar -Pxzf /tmp/circuits.tar.gz -C /root/.sp1/circuits/${CIRCUIT_TYPE}/${CIRCUIT_VERSION} \
+    && rm /tmp/circuits.tar.gz
 
 FROM chef AS builder
 
@@ -43,10 +57,6 @@ COPY --from=planner /app/recipe.json recipe.json
 # Notice that we are specifying the --target flag!
 RUN cargo chef cook --release --recipe-path recipe.json
 
-RUN mkdir -p /root/.sp1/circuits/${CIRCUIT_TYPE}/${CIRCUIT_VERSION}
-RUN curl -s -o /tmp/circuits.tar.gz ${CIRCUIT_ARTIFACTS_URL_BASE}/${CIRCUIT_VERSION}-${CIRCUIT_TYPE}.tar.gz \
-    && tar -Pxzf/tmp/circuits.tar.gz -C /root/.sp1/circuits/${CIRCUIT_TYPE}/${CIRCUIT_VERSION}
-
 COPY --link crates crates
 COPY --link Cargo.toml Cargo.toml
 COPY --link Cargo.lock Cargo.lock
@@ -67,6 +77,6 @@ FROM --platform=${BUILDPLATFORM} debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y ca-certificates
 COPY --from=builder /app/target/release/agglayer /usr/local/bin/
-COPY --from=builder /root/.sp1/circuits /root/.sp1/circuits
+COPY --from=circuits /root/.sp1/circuits /root/.sp1/circuits
 
 CMD ["/usr/local/bin/agglayer"]


### PR DESCRIPTION
This PR implements items 1-3 of #1664 to cut merge queue Docker build
time.

Store the buildx cache in ghcr.io/agglayer/agglayer-buildcache instead
of the 10GB Actions cache, where rust-cache churn from other jobs
evicts the cargo-chef layers and forces ~6m dependency rebuilds on most
merge queue runs. Only pushes to main export the cache; merge queue,
PR, and branch dispatch builds stay cache-read-only (same policy as
PR #1593, now also enforced for branch dispatches).

Add a weekly cleanup workflow that deletes untagged buildcache
versions, since GHCR has no built-in retention for them.

Move the SP1 circuits download into a dedicated Dockerfile stage keyed
only on the CIRCUIT_* args, so a Rust cache miss no longer re-downloads
~1GB from S3. The final image now copies the circuits from that stage.

Item 4 of #1664 (replacing the image tarball artifact with a registry
push) is intentionally left for a follow-up PR.

Rollout notes:
- The buildcache package does not exist until the first main push
  after merge, so builds log a cache-import warning and run cold once.
- A cleanup cron run before that first push fails on the missing
  package; it recovers on its own once the cache is exported.

Verification:
- python3 yaml.safe_load on both workflow files
- docker build --check . (no warnings)
- docker build --target circuits . and container inspection: 2.8G of
  plonk artifacts at /root/.sp1/circuits/plonk/v6.1.0
- git diff --check
- Full-image compile-time independence from the circuits stage is
  expected to be exercised by the docker build on merge_group, or via
  workflow_dispatch of the Test workflow on this branch