### PR TITLE
style: fix clippy 1.97 lints before CI runners update

### DIFF
--- a/crates/agglayer-grpc-types/src/lib.rs
+++ b/crates/agglayer-grpc-types/src/lib.rs
@@ -1,5 +1,8 @@
-#[allow(clippy::needless_lifetimes)]
-#[allow(clippy::useless_borrows_in_formatting)]
+// Machine-generated code (pbjson/prost); exempt from clippy style lints.
+// `clippy::all` is a group name every clippy version knows, so this stays
+// valid on older toolchains where newer lint names would be `unknown_lints`
+// errors under `-D warnings`.
+#[allow(clippy::all)]
 mod generated;
 
 pub use crate::generated::agglayer::*;

--- a/crates/agglayer-grpc-types/src/lib.rs
+++ b/crates/agglayer-grpc-types/src/lib.rs
@@ -1,4 +1,5 @@
 #[allow(clippy::needless_lifetimes)]
+#[allow(clippy::useless_borrows_in_formatting)]
 mod generated;
 
 pub use crate::generated::agglayer::*;

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -215,7 +215,7 @@ impl<PendingStore, StateStore> PerEpochStore<PendingStore, StateStore> {
                 // For read-write access, handle empty checkpoint
                 if checkpoint.is_empty() {
                     if next_certificate_index.load(Ordering::Relaxed) != 0 {
-                        return Err(Error::Unexpected(
+                        Err(Error::Unexpected(
                             "End checkpoint is empty, but there are certificates in the DB"
                                 .to_string(),
                         ))?;
@@ -282,7 +282,7 @@ where
         let lock = self.lock_for_adding_certificate();
 
         if *lock {
-            return Err(Error::AlreadyPacked(*self.epoch_number))?;
+            Err(Error::AlreadyPacked(*self.epoch_number))?;
         }
 
         let certificate_header = self
@@ -377,7 +377,8 @@ where
                     network_id,
                     height,
                     *current_height.get(),
-                ))?;
+                )
+                .into());
             }
             // If the network is found in the end checkpoint and the height minus one is equal to
             // the current network height. We can add the certificate.
@@ -405,7 +406,8 @@ where
                     network_id,
                     height,
                     *current_height.get(),
-                ))?;
+                )
+                .into());
             }
         }
 
@@ -476,7 +478,7 @@ where
         let mut lock = self.lock_for_packing();
 
         if *lock {
-            return Err(Error::AlreadyPacked(*self.epoch_number))?;
+            Err(Error::AlreadyPacked(*self.epoch_number))?;
         }
 
         self.db.put::<PerEpochMetadataColumn>(


### PR DESCRIPTION
This PR fixes the lints that clippy 1.97 raises on main, before the CI
runner images pick up the new stable and break the required Lint check.

Clippy 1.97 (stable since 2026-07-07) introduces
useless_borrows_in_formatting and needless_return_with_question_mark,
both warn-by-default. Under the -D warnings used by cargo make
ci-clippy they are errors: 26 hits in the pbjson-generated serde files
of agglayer-grpc-types and 5 in agglayer-storage per_epoch.

Changes:
- Allow useless_borrows_in_formatting on the generated proto module,
  next to the existing needless_lifetimes allow. The module is
  pbjson-generated; the allow sits in lib.rs so it survives
  cargo make generate-proto.
- Drop the needless returns in per_epoch where clippy's suggestion
  compiles (three sites). The two match-arm sites keep an explicit
  return via Err(...into()): a bare Err(x)? statement no longer counts
  as divergent for definite initialization and trips E0381 on
  end_checkpoint_entry_assignment. This is also why cargo clippy --fix
  rolls back there.

No behavior change: Err(x)? and return Err(x.into()) take the same
error path with the same From conversion.

Verification:
- cargo make ci-clippy (was 31 errors with clippy 1.97, now clean)
- rustup run nightly cargo fmt --all --check
- cargo nextest run -p agglayer-storage: 250 passed
- cargo check -p agglayer-storage