### PR TITLE
refactor(telemetry): expose the metrics test harness via testutils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,12 +495,8 @@ dependencies = [
  "jsonrpsee",
  "lazy_static",
  "mockall",
- "opentelemetry 0.31.0",
- "opentelemetry-prometheus 0.31.0",
- "opentelemetry_sdk 0.31.0",
  "pessimistic-proof",
  "pin-project",
- "prometheus",
  "prover-executor",
  "rand 0.9.3",
  "reqwest 0.12.28",
@@ -694,6 +690,7 @@ dependencies = [
 name = "agglayer-telemetry"
 version = "0.1.0"
 dependencies = [
+ "agglayer-telemetry 0.1.0",
  "axum 0.8.8",
  "buildstructor 0.6.0",
  "eyre",

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -61,10 +61,6 @@ hyper-util = { version = "0.1.20", features = ["client"] }
 fail = { workspace = true, features = ["failpoints"] }
 lazy_static.workspace = true
 mockall.workspace = true
-opentelemetry = { version = "0.31.0", features = ["metrics"] }
-opentelemetry-prometheus = "0.31.0"
-opentelemetry_sdk = { version = "0.31.0", features = ["metrics"] }
-prometheus = "0.14.0"
 rand.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
@@ -74,6 +70,7 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 agglayer-jsonrpc-api = { workspace = true, features = ["testutils"] }
 agglayer-config = { workspace = true, features = ["testutils"] }
 agglayer-storage = { workspace = true, features = ["testutils"] }
+agglayer-telemetry = { workspace = true, features = ["testutils"] }
 agglayer-types = { workspace = true, features = ["testutils"] }
 
 [features]

--- a/crates/agglayer-node/src/metrics.rs
+++ b/crates/agglayer-node/src/metrics.rs
@@ -185,6 +185,7 @@ mod tests {
         stores::{PendingCertificateWriter as _, StateWriter as _},
         tests::TempDBDir,
     };
+    use agglayer_telemetry::testutils::MetricsHarness;
     use agglayer_types::{
         Certificate, CertificateIndex, CertificateStatus, CertificateStatusError, EpochNumber,
         Height, NetworkId,
@@ -322,30 +323,13 @@ mod tests {
         );
     }
 
-    fn gather(registry: &prometheus::Registry) -> String {
-        use prometheus::Encoder as _;
-
-        let encoder = prometheus::TextEncoder::new();
-        let mut out = Vec::new();
-        encoder.encode(&registry.gather(), &mut out).unwrap();
-        String::from_utf8(out).unwrap()
-    }
-
     #[test]
     fn registration_does_not_extend_store_lifetime() {
         // A real meter provider must be installed, otherwise the no-op meter
-        // discards the callbacks and this test cannot observe retention.
-        let registry = prometheus::Registry::new();
-        let exporter = opentelemetry_prometheus::exporter()
-            .with_registry(registry.clone())
-            .build()
-            .unwrap();
-        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
-            .with_reader(exporter)
-            .build();
-        // This test deliberately owns the process-global meter provider:
-        // nextest runs one process per test, so nothing else can race it.
-        opentelemetry::global::set_meter_provider(provider);
+        // discards the callbacks and this test cannot observe retention. The
+        // harness owns the process-global meter provider and relies on
+        // nextest's process-per-test isolation.
+        let harness = MetricsHarness::install();
 
         let pending_tmp = TempDBDir::new();
         let state_tmp = TempDBDir::new();
@@ -356,14 +340,13 @@ mod tests {
         register_network_state_metrics(&pending_store, &state_store);
 
         // Positive control: the registration must land on the provider this
-        // test installed, otherwise the retention check below is vacuous
-        // (e.g. a dependency drift splitting the `opentelemetry` globals).
+        // test installed, otherwise the retention check below is vacuous.
         let network_id = NetworkId::new(2);
         let certificate = Certificate::new_for_test(network_id, Height::ZERO);
         pending_store
             .insert_pending_certificate(network_id, Height::ZERO, &certificate)
             .unwrap();
-        let metrics = gather(&registry);
+        let metrics = harness.gather();
         assert!(
             metrics.lines().any(|line| {
                 line.starts_with("agglayer_node_network_height{")
@@ -383,7 +366,7 @@ mod tests {
 
         // With the original stores gone the weak upgrades fail and every
         // per-network series disappears from the scrape.
-        let metrics = gather(&registry);
+        let metrics = harness.gather();
         assert!(
             metrics
                 .lines()

--- a/crates/agglayer-telemetry/Cargo.toml
+++ b/crates/agglayer-telemetry/Cargo.toml
@@ -20,3 +20,9 @@ eyre.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tracing.workspace = true
+
+[dev-dependencies]
+agglayer-telemetry = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = []

--- a/crates/agglayer-telemetry/Cargo.toml
+++ b/crates/agglayer-telemetry/Cargo.toml
@@ -26,3 +26,8 @@ agglayer-telemetry = { workspace = true, features = ["testutils"] }
 
 [features]
 testutils = []
+
+# The self dev-dependency only activates `testutils` for this crate's own
+# unit tests; cargo-udeps cannot see that usage (same as agglayer-clock).
+[package.metadata.cargo-udeps.ignore]
+development = ["agglayer-telemetry"]

--- a/crates/agglayer-telemetry/src/lib.rs
+++ b/crates/agglayer-telemetry/src/lib.rs
@@ -23,6 +23,10 @@ pub mod certificate;
 pub mod clock;
 pub mod network;
 
+// Testing.
+#[cfg(feature = "testutils")]
+pub mod testutils;
+
 pub use opentelemetry::KeyValue;
 
 lazy_static! {
@@ -126,7 +130,7 @@ impl ServerBuilder {
     ///
     /// # Panics
     ///
-    /// Panics on failure of the gather_metrics internal methods (unlikely)
+    /// Panics on failure of the internal meter provider setup (unlikely)
     ///
     /// # Errors
     ///
@@ -145,13 +149,13 @@ impl ServerBuilder {
         >,
     > {
         let registry = registry.unwrap_or_default();
-        Self::init_meter_provider(&registry);
+        init_meter_provider(&registry);
 
         let app = Router::new()
             .route(
                 "/metrics",
                 get(|State(registry): State<prometheus::Registry>| async move {
-                    match Self::gather_metrics(&registry) {
+                    match encode_registry(&registry) {
                         Ok(metrics) => Response::new(metrics),
                         Err(error) => Response::builder()
                             .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -171,31 +175,33 @@ impl ServerBuilder {
         Ok(axum::serve(listener, app.into_make_service())
             .with_graceful_shutdown(shutdown_signal(cancellation_token)))
     }
+}
 
-    fn init_meter_provider(registry: &Registry) {
-        // configure OpenTelemetry to use the registry
-        let exporter = opentelemetry_prometheus::exporter()
-            .with_registry(registry.clone())
-            .build()
-            .unwrap();
+/// Installs a fresh [`SdkMeterProvider`] backed by `registry` as the
+/// process-global meter provider.
+fn init_meter_provider(registry: &Registry) {
+    // configure OpenTelemetry to use the registry
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .build()
+        .unwrap();
 
-        // set up a meter to create instruments
-        let provider = SdkMeterProvider::builder().with_reader(exporter).build();
+    // set up a meter to create instruments
+    let provider = SdkMeterProvider::builder().with_reader(exporter).build();
 
-        global::set_meter_provider(provider);
-    }
+    global::set_meter_provider(provider);
+}
 
-    fn gather_metrics(registry: &prometheus::Registry) -> eyre::Result<String> {
-        // Encode data as text or protobuf
-        let encoder = TextEncoder::new();
-        let metric_families = registry.gather();
-        let mut result = Vec::new();
-        encoder
-            .encode(&metric_families, &mut result)
-            .wrap_err("Error gathering metrics")?;
+/// Encodes the current content of `registry` as prometheus text.
+fn encode_registry(registry: &Registry) -> eyre::Result<String> {
+    let encoder = TextEncoder::new();
+    let metric_families = registry.gather();
+    let mut result = Vec::new();
+    encoder
+        .encode(&metric_families, &mut result)
+        .wrap_err("Error gathering metrics")?;
 
-        String::from_utf8(result).wrap_err("Error formatting metrics")
-    }
+    String::from_utf8(result).wrap_err("Error formatting metrics")
 }
 
 async fn shutdown_signal(cancellation: CancellationToken) {

--- a/crates/agglayer-telemetry/src/network.rs
+++ b/crates/agglayer-telemetry/src/network.rs
@@ -150,18 +150,8 @@ fn observe_heights(
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use opentelemetry::global;
-    use opentelemetry_sdk::metrics::SdkMeterProvider;
-    use prometheus::{Encoder as _, Registry, TextEncoder};
-
     use super::*;
-
-    fn gather(registry: &Registry) -> String {
-        let encoder = TextEncoder::new();
-        let mut out = Vec::new();
-        encoder.encode(&registry.gather(), &mut out).unwrap();
-        String::from_utf8(out).unwrap()
-    }
+    use crate::testutils::MetricsHarness;
 
     /// Extract the value of the sample line for `name`, `network_id` and,
     /// when given, the `stage` label.
@@ -188,17 +178,11 @@ mod tests {
 
     #[test]
     fn network_state_gauges_export_per_network_series() {
-        let registry = Registry::new();
-        let exporter = opentelemetry_prometheus::exporter()
-            .with_registry(registry.clone())
-            .build()
-            .unwrap();
-        let provider = SdkMeterProvider::builder().with_reader(exporter).build();
         // This test deliberately owns the process-global meter provider:
         // nextest runs one process per test, so nothing else can race it.
         // Future exporter-based tests in this crate must keep that isolation
-        // in mind (each test must install its own provider and registry).
-        global::set_meter_provider(provider);
+        // in mind (each test must install its own harness).
+        let harness = MetricsHarness::install();
 
         let pending = Arc::new(Mutex::new(vec![
             NetworkHeightSample {
@@ -248,7 +232,7 @@ mod tests {
             }),
         });
 
-        let metrics = gather(&registry);
+        let metrics = harness.gather();
 
         assert_eq!(
             sample_value(&metrics, NETWORK_HEIGHT, 1, Some("pending")),
@@ -292,7 +276,7 @@ mod tests {
         settled.lock().unwrap().clear();
         in_error.lock().unwrap().clear();
 
-        let metrics = gather(&registry);
+        let metrics = harness.gather();
         assert!(
             metrics
                 .lines()

--- a/crates/agglayer-telemetry/src/testutils.rs
+++ b/crates/agglayer-telemetry/src/testutils.rs
@@ -1,0 +1,77 @@
+//! Test-only helpers for asserting on real exported metrics.
+
+use prometheus::Registry;
+
+use crate::{encode_registry, init_meter_provider};
+
+/// Test harness binding the process-global meter provider to a local
+/// prometheus registry.
+///
+/// The default global meter is a no-op that silently discards instruments
+/// and observable-gauge callbacks, so a test asserting on exported metrics
+/// must install a real provider first. [`MetricsHarness::install`] reuses
+/// the same installation code path as the production metrics server
+/// ([`ServerBuilder`](crate::ServerBuilder)).
+///
+/// # Isolation
+///
+/// Installing the harness replaces the meter provider for the whole
+/// process. Tests using it rely on nextest's process-per-test isolation
+/// and must each install their own harness.
+#[derive(Debug)]
+pub struct MetricsHarness {
+    registry: Registry,
+}
+
+impl MetricsHarness {
+    /// Installs a fresh `SdkMeterProvider` backed by a private prometheus
+    /// registry as the process-global meter provider.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the prometheus exporter cannot be built, which indicates
+    /// a bug in the metrics pipeline rather than a recoverable condition.
+    #[must_use]
+    pub fn install() -> Self {
+        let registry = Registry::new();
+        init_meter_provider(&registry);
+        Self { registry }
+    }
+
+    /// Encodes the current registry content as prometheus text.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the registry content cannot be encoded, which indicates
+    /// a bug in the metrics pipeline rather than a recoverable condition.
+    #[must_use]
+    pub fn gather(&self) -> String {
+        encode_registry(&self.registry).expect("failed to encode the metrics registry")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_binds_global_meter_and_gather_exports_instruments() {
+        // This test deliberately owns the process-global meter provider:
+        // nextest runs one process per test, so nothing else can race it.
+        let harness = MetricsHarness::install();
+
+        let counter = opentelemetry::global::meter("harness-test")
+            .u64_counter("harness_test_counter")
+            .build();
+        counter.add(3, &[]);
+
+        // The prometheus exporter appends `_total` to counter names.
+        let metrics = harness.gather();
+        assert!(
+            metrics
+                .lines()
+                .any(|line| line.starts_with("harness_test_counter") && line.ends_with(" 3")),
+            "expected a harness_test_counter sample, got:\n{metrics}"
+        );
+    }
+}


### PR DESCRIPTION
agglayer-node carried four hard-pinned dev-dependencies
(opentelemetry, opentelemetry_sdk, opentelemetry-prometheus,
prometheus) for a single test: the lifetime-regression check in
metrics.rs needs a real meter provider because the no-op meter
discards gauge callbacks.

Extract the provider-install and text-encode logic from
ServerBuilder into crate-private free functions and expose a
MetricsHarness behind a new additive testutils feature (the
agglayer-storage pattern). install() binds the process-global
meter provider to a private prometheus registry through the same
code path production uses; gather() returns the prometheus text.
Tests using it rely on nextest's process-per-test isolation.

agglayer-node now dev-depends on agglayer-telemetry/testutils and
the four pins leave its manifest. The version-skew hazard flagged
in the #1633 review (a lagging dev-dep pin could split the
opentelemetry globals and silently defuse the lifetime test) cannot
recur: the harness and the instruments come from the same crate.
The duplicated gather() helpers in the telemetry network.rs and
node metrics.rs tests collapse into the harness.

Closes #1671
