### PR TITLE
feat(settlement): admin RPC task controls for settlement jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "agglayer-contracts",
  "agglayer-rate-limiting",
  "agglayer-rpc",
+ "agglayer-settlement-service",
  "agglayer-storage",
  "agglayer-telemetry 0.1.0",
  "agglayer-tries 0.18.0",

--- a/crates/agglayer-jsonrpc-api/Cargo.toml
+++ b/crates/agglayer-jsonrpc-api/Cargo.toml
@@ -9,6 +9,7 @@ agglayer-config.workspace = true
 agglayer-contracts.workspace = true
 agglayer-rate-limiting.workspace = true
 agglayer-rpc.workspace = true
+agglayer-settlement-service.workspace = true
 agglayer-storage.workspace = true
 agglayer-telemetry.workspace = true
 agglayer-tries.workspace = true

--- a/crates/agglayer-jsonrpc-api/src/admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/admin.rs
@@ -223,7 +223,18 @@ pub(crate) trait AdminAgglayer {
     /// A pending job without a live task (after an admin abort or a
     /// failed in-task reload) gets a fresh task spawned from storage:
     /// this is the recovery step after `admin_abortSettlementTask`.
-    /// Fails if the job is unknown or already completed.
+    ///
+    /// A reload issued while an abort is still taking effect may be
+    /// accepted but dropped: the task can exit on the cancellation
+    /// without draining its command queue. When chaining after an
+    /// abort, allow the abort to take effect and issue the reload
+    /// again; once the aborted task is gone, the reload respawns the
+    /// job from storage, and repeating it is harmless (idempotent
+    /// recovery).
+    ///
+    /// Fails if the job is unknown or already completed, or with a
+    /// task-not-responding error when the live task's command queue is
+    /// unavailable.
     #[method(name = "reloadAndRestartSettlementTask")]
     async fn reload_and_restart_settlement_task(&self, job_id: SettlementJobId) -> RpcResult<()>;
 }

--- a/crates/agglayer-jsonrpc-api/src/admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/admin.rs
@@ -10,7 +10,7 @@ use agglayer_storage::stores::{
 use agglayer_tries::smt::SmtPath;
 use agglayer_types::{
     Address, Certificate, CertificateHeader, CertificateId, CertificateStatus,
-    CertificateStatusError, Digest, Height, NetworkId, SettlementTxHash, U256,
+    CertificateStatusError, Digest, Height, NetworkId, SettlementJobId, SettlementTxHash, U256,
 };
 use alloy::providers::{Provider, WalletProvider};
 use jsonrpsee::{core::async_trait, proc_macros::rpc, server::ServerBuilder};
@@ -201,6 +201,31 @@ pub(crate) trait AdminAgglayer {
     async fn disable_network(&self, network_id: NetworkId) -> RpcResult<()>;
     #[method(name = "enableNetwork")]
     async fn enable_network(&self, network_id: NetworkId) -> RpcResult<()>;
+
+    /// Stop the in-memory settlement task of a job.
+    ///
+    /// **JSON-RPC method:** `admin_abortSettlementTask`
+    ///
+    /// Requests cancellation of the task driving `job_id` and returns
+    /// before the task observes it. Runtime-only: the job stays pending
+    /// in storage and no terminal result is recorded, so the certificate
+    /// waiting on it stays blocked until the task is restarted with
+    /// `admin_reloadAndRestartSettlementTask`. Fails when no task is
+    /// running (job unknown, completed, or already aborted).
+    #[method(name = "abortSettlementTask")]
+    async fn abort_settlement_task(&self, job_id: SettlementJobId) -> RpcResult<()>;
+
+    /// Reload a settlement job from storage and (re)start its task.
+    ///
+    /// **JSON-RPC method:** `admin_reloadAndRestartSettlementTask`
+    ///
+    /// A live task drops its in-memory state and reloads from storage.
+    /// A pending job without a live task (after an admin abort or a
+    /// failed in-task reload) gets a fresh task spawned from storage:
+    /// this is the recovery step after `admin_abortSettlementTask`.
+    /// Fails if the job is unknown or already completed.
+    #[method(name = "reloadAndRestartSettlementTask")]
+    async fn reload_and_restart_settlement_task(&self, job_id: SettlementJobId) -> RpcResult<()>;
 }
 
 /// The Admin RPC agglayer service implementation.
@@ -210,7 +235,6 @@ pub struct AdminAgglayerImpl<PendingStore, StateStore, DebugStore, L1Provider> {
     state: Arc<StateStore>,
     debug_store: Arc<DebugStore>,
     config: Arc<Config>,
-    #[allow(dead_code)] // used by the settlement admin methods in the next commit
     settlement_service: SettlementService<L1Provider, StateStore>,
 }
 
@@ -810,5 +834,23 @@ where
             error!(?error, "Failed to enable network {network_id}");
             Error::internal(format!("Unable to enable network {network_id}"))
         })
+    }
+
+    #[instrument(skip(self))]
+    async fn abort_settlement_task(&self, job_id: SettlementJobId) -> RpcResult<()> {
+        warn!(?job_id, "Aborting settlement task via admin RPC");
+        Ok(self.settlement_service.admin_abort_task(job_id).await?)
+    }
+
+    #[instrument(skip(self))]
+    async fn reload_and_restart_settlement_task(&self, job_id: SettlementJobId) -> RpcResult<()> {
+        warn!(
+            ?job_id,
+            "Reloading and restarting settlement task via admin RPC"
+        );
+        Ok(self
+            .settlement_service
+            .admin_reload_and_restart_task(job_id)
+            .await?)
     }
 }

--- a/crates/agglayer-jsonrpc-api/src/admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/admin.rs
@@ -1,15 +1,18 @@
 use std::sync::Arc;
 
 use agglayer_config::Config;
+use agglayer_settlement_service::SettlementService;
 use agglayer_storage::stores::{
-    DebugReader, DebugWriter, PendingCertificateReader, PendingCertificateWriter, StateReader,
-    StateWriter, UpdateEvenIfAlreadyPresent, UpdateStatusToCandidate,
+    DebugReader, DebugWriter, PendingCertificateReader, PendingCertificateWriter, SettlementReader,
+    SettlementWriter, StateReader, StateWriter, UpdateEvenIfAlreadyPresent,
+    UpdateStatusToCandidate,
 };
 use agglayer_tries::smt::SmtPath;
 use agglayer_types::{
     Address, Certificate, CertificateHeader, CertificateId, CertificateStatus,
     CertificateStatusError, Digest, Height, NetworkId, SettlementTxHash, U256,
 };
+use alloy::providers::{Provider, WalletProvider};
 use jsonrpsee::{core::async_trait, proc_macros::rpc, server::ServerBuilder};
 use pessimistic_proof::local_balance_tree::BalanceTree;
 use serde::{Deserialize, Serialize};
@@ -201,15 +204,19 @@ pub(crate) trait AdminAgglayer {
 }
 
 /// The Admin RPC agglayer service implementation.
-pub struct AdminAgglayerImpl<PendingStore, StateStore, DebugStore> {
+pub struct AdminAgglayerImpl<PendingStore, StateStore, DebugStore, L1Provider> {
     certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
     pending_store: Arc<PendingStore>,
     state: Arc<StateStore>,
     debug_store: Arc<DebugStore>,
     config: Arc<Config>,
+    #[allow(dead_code)] // used by the settlement admin methods in the next commit
+    settlement_service: SettlementService<L1Provider, StateStore>,
 }
 
-impl<PendingStore, StateStore, DebugStore> AdminAgglayerImpl<PendingStore, StateStore, DebugStore> {
+impl<PendingStore, StateStore, DebugStore, L1Provider>
+    AdminAgglayerImpl<PendingStore, StateStore, DebugStore, L1Provider>
+{
     /// Create an instance of the admin RPC agglayer service.
     pub fn new(
         certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
@@ -217,6 +224,7 @@ impl<PendingStore, StateStore, DebugStore> AdminAgglayerImpl<PendingStore, State
         state: Arc<StateStore>,
         debug_store: Arc<DebugStore>,
         config: Arc<Config>,
+        settlement_service: SettlementService<L1Provider, StateStore>,
     ) -> Self {
         Self {
             certificate_sender,
@@ -224,15 +232,18 @@ impl<PendingStore, StateStore, DebugStore> AdminAgglayerImpl<PendingStore, State
             state,
             debug_store,
             config,
+            settlement_service,
         }
     }
 }
 
-impl<PendingStore, StateStore, DebugStore> AdminAgglayerImpl<PendingStore, StateStore, DebugStore>
+impl<PendingStore, StateStore, DebugStore, L1Provider>
+    AdminAgglayerImpl<PendingStore, StateStore, DebugStore, L1Provider>
 where
     PendingStore: PendingCertificateWriter + PendingCertificateReader + 'static,
-    StateStore: StateReader + StateWriter + 'static,
+    StateStore: StateReader + StateWriter + SettlementReader + SettlementWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
+    L1Provider: Provider + WalletProvider + 'static,
 {
     pub async fn start(self) -> eyre::Result<axum::Router> {
         // Create the RPC service
@@ -295,8 +306,8 @@ where
     }
 }
 
-impl<PendingStore, StateStore, DebugStore> Drop
-    for AdminAgglayerImpl<PendingStore, StateStore, DebugStore>
+impl<PendingStore, StateStore, DebugStore, L1Provider> Drop
+    for AdminAgglayerImpl<PendingStore, StateStore, DebugStore, L1Provider>
 {
     fn drop(&mut self) {
         info!("Shutting down the agglayer service");
@@ -304,12 +315,13 @@ impl<PendingStore, StateStore, DebugStore> Drop
 }
 
 #[async_trait]
-impl<PendingStore, StateStore, DebugStore> AdminAgglayerServer
-    for AdminAgglayerImpl<PendingStore, StateStore, DebugStore>
+impl<PendingStore, StateStore, DebugStore, L1Provider> AdminAgglayerServer
+    for AdminAgglayerImpl<PendingStore, StateStore, DebugStore, L1Provider>
 where
     PendingStore: PendingCertificateWriter + PendingCertificateReader + 'static,
-    StateStore: StateReader + StateWriter + 'static,
+    StateStore: StateReader + StateWriter + SettlementReader + SettlementWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
+    L1Provider: Provider + WalletProvider + 'static,
 {
     #[instrument(skip(self))]
     async fn get_token_balance(

--- a/crates/agglayer-jsonrpc-api/src/error.rs
+++ b/crates/agglayer-jsonrpc-api/src/error.rs
@@ -107,6 +107,30 @@ impl From<TxStatusError> for StatusError {
     }
 }
 
+#[derive(PartialEq, Eq, Serialize, Debug, Clone, thiserror::Error)]
+#[serde(rename_all = "kebab-case")]
+pub enum SettlementAdminError {
+    #[error("Settlement job {job_id} is already completed")]
+    #[serde(rename_all = "kebab-case")]
+    JobCompleted { job_id: String },
+
+    #[error("No live settlement task for job {job_id}")]
+    #[serde(rename_all = "kebab-case")]
+    NoLiveTask { job_id: String },
+
+    #[error("Settlement task for job {job_id} did not accept the admin command: {detail}")]
+    #[serde(rename_all = "kebab-case")]
+    TaskNotResponding { job_id: String, detail: String },
+
+    #[error("Failed to reload settlement task for job {job_id}: {detail}")]
+    #[serde(rename_all = "kebab-case")]
+    ReloadFailed { job_id: String, detail: String },
+
+    #[error("Storage error while handling settlement admin command for job {job_id}: {detail}")]
+    #[serde(rename_all = "kebab-case")]
+    Storage { job_id: String, detail: String },
+}
+
 /// Application-level RPC errors returned by AggLayer.
 ///
 /// Implementation note:
@@ -155,7 +179,7 @@ pub enum Error {
     MethodDisabled { method: &'static str },
 
     #[error("Settlement admin error: {0}")]
-    SettlementAdmin(String),
+    SettlementAdmin(#[from] SettlementAdminError),
 
     #[error("Internal error: {0}")]
     Internal(String),
@@ -278,7 +302,29 @@ impl From<agglayer_settlement_service::SettlementAdminError> for Error {
         use agglayer_settlement_service::SettlementAdminError as E;
         match error {
             E::JobNotFound(job_id) => Self::ResourceNotFound(format!("SettlementJob({job_id})")),
-            error => Self::SettlementAdmin(error.to_string()),
+            E::JobCompleted(job_id) => SettlementAdminError::JobCompleted {
+                job_id: job_id.to_string(),
+            }
+            .into(),
+            E::NoLiveTask(job_id) => SettlementAdminError::NoLiveTask {
+                job_id: job_id.to_string(),
+            }
+            .into(),
+            E::TaskNotResponding { job_id, reason } => SettlementAdminError::TaskNotResponding {
+                job_id: job_id.to_string(),
+                detail: reason,
+            }
+            .into(),
+            E::ReloadFailed { job_id, reason } => SettlementAdminError::ReloadFailed {
+                job_id: job_id.to_string(),
+                detail: reason,
+            }
+            .into(),
+            E::Storage { job_id, source } => SettlementAdminError::Storage {
+                job_id: job_id.to_string(),
+                detail: source.to_string(),
+            }
+            .into(),
         }
     }
 }

--- a/crates/agglayer-jsonrpc-api/src/error.rs
+++ b/crates/agglayer-jsonrpc-api/src/error.rs
@@ -36,6 +36,9 @@ pub mod code {
 
     /// Method permanently disabled.
     pub const METHOD_DISABLED: i32 = -10009;
+
+    /// Settlement admin operation failure.
+    pub const SETTLEMENT_ADMIN: i32 = -10010;
 }
 
 #[derive(PartialEq, Eq, Serialize, Debug, Clone, thiserror::Error)]
@@ -151,6 +154,9 @@ pub enum Error {
     #[error("The {method} method is disabled")]
     MethodDisabled { method: &'static str },
 
+    #[error("Settlement admin error: {0}")]
+    SettlementAdmin(String),
+
     #[error("Internal error: {0}")]
     Internal(String),
 }
@@ -174,6 +180,7 @@ impl Error {
             Self::SendCertificate { .. } => code::SEND_CERTIFICATE,
             Self::RateLimited { .. } => code::RATE_LIMITED,
             Self::MethodDisabled { .. } => code::METHOD_DISABLED,
+            Self::SettlementAdmin(_) => code::SETTLEMENT_ADMIN,
         }
     }
 }
@@ -263,6 +270,16 @@ impl From<agglayer_rpc::GetNetworkInfoError> for Error {
         // Since NetworkStateRetrievalError is currently empty, convert to internal
         // error
         Self::internal(format!("Network state retrieval error: {err}"))
+    }
+}
+
+impl From<agglayer_settlement_service::SettlementAdminError> for Error {
+    fn from(error: agglayer_settlement_service::SettlementAdminError) -> Self {
+        use agglayer_settlement_service::SettlementAdminError as E;
+        match error {
+            E::JobNotFound(job_id) => Self::ResourceNotFound(format!("SettlementJob({job_id})")),
+            error => Self::SettlementAdmin(error.to_string()),
+        }
     }
 }
 

--- a/crates/agglayer-jsonrpc-api/src/tests.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests.rs
@@ -6,3 +6,4 @@ mod get_token_balance;
 mod get_tx_status;
 mod send_certificate;
 mod send_tx;
+mod settlement_admin;

--- a/crates/agglayer-jsonrpc-api/src/tests/errors.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/errors.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 
 use agglayer_rate_limiting::{self, component, Component};
 use agglayer_rpc::error::SignatureVerificationError;
-use agglayer_types::{Address, CertificateId, Digest};
+use agglayer_settlement_service::SettlementAdminError;
+use agglayer_types::{Address, CertificateId, Digest, SettlementJobId};
 use alloy::{
     contract::Error as ContractError,
     primitives::{SignatureError as AlloySignatureError, B256},
@@ -150,6 +151,14 @@ type WallClockLimitedInfo = <component::SendTx as Component>::LimitedInfo;
 #[case(
     "method_disabled",
     Error::MethodDisabled { method: "interop_sendTx" }
+)]
+#[case(
+    "settlement_admin_job_not_found",
+    SettlementAdminError::JobNotFound(SettlementJobId::from(7u128))
+)]
+#[case(
+    "settlement_admin_no_live_task",
+    SettlementAdminError::NoLiveTask(SettlementJobId::from(8u128))
 )]
 fn rpc_error_rendering(#[case] name: &str, #[case] err: impl Into<Error>) {
     let err: Error = err.into();

--- a/crates/agglayer-jsonrpc-api/src/tests/errors.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/errors.rs
@@ -160,6 +160,31 @@ type WallClockLimitedInfo = <component::SendTx as Component>::LimitedInfo;
     "settlement_admin_no_live_task",
     SettlementAdminError::NoLiveTask(SettlementJobId::from(8u128))
 )]
+#[case(
+    "settlement_admin_job_completed",
+    SettlementAdminError::JobCompleted(SettlementJobId::from(9u128))
+)]
+#[case(
+    "settlement_admin_task_not_responding",
+    SettlementAdminError::TaskNotResponding {
+        job_id: SettlementJobId::from(10u128),
+        reason: "channel closed".to_string(),
+    }
+)]
+#[case(
+    "settlement_admin_reload_failed",
+    SettlementAdminError::ReloadFailed {
+        job_id: SettlementJobId::from(11u128),
+        reason: "boom".to_string(),
+    }
+)]
+#[case(
+    "settlement_admin_storage",
+    SettlementAdminError::Storage {
+        job_id: SettlementJobId::from(12u128),
+        source: agglayer_storage::error::Error::Unexpected("boom".to_string()),
+    }
+)]
 fn rpc_error_rendering(#[case] name: &str, #[case] err: impl Into<Error>) {
     let err: Error = err.into();
     let debug_str = format!("{err:?}");

--- a/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
@@ -1,0 +1,114 @@
+//! Tests for the settlement task admin RPC methods.
+
+use agglayer_storage::stores::SettlementWriter;
+use agglayer_types::{SettlementJob, SettlementJobId, U256};
+use jsonrpsee::{core::client::ClientT, rpc_params};
+
+use crate::testutils::TestContext;
+
+fn mk_job_id(seed: u128) -> SettlementJobId {
+    SettlementJobId::from(seed)
+}
+
+fn mk_job(seed: u8) -> SettlementJob {
+    SettlementJob {
+        contract_address: agglayer_types::Address::from([seed; 20]),
+        calldata: vec![seed, seed.wrapping_add(1)].into(),
+        eth_value: U256::from(seed),
+        gas_limit: seed as u128 + 100_000,
+    }
+}
+
+/// Seed one pending settlement job directly in storage. The settlement
+/// service does not know about it until reload-and-restart spawns its
+/// task.
+fn seed_pending_job(context: &TestContext, seed: u8) -> SettlementJobId {
+    let job_id = mk_job_id(seed as u128);
+    context
+        .state_store
+        .insert_settlement_job(&job_id, &mk_job(seed))
+        .expect("job insert must succeed");
+    job_id
+}
+
+async fn wait_until_task_gone(context: &TestContext, job_id: SettlementJobId) {
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        while context.settlement_service.has_live_task(job_id).await {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("aborted task should deregister");
+}
+
+fn assert_error_code(error: jsonrpsee::core::client::Error, code: i32) {
+    match error {
+        jsonrpsee::core::client::Error::Call(call_error) => {
+            assert_eq!(call_error.code(), code)
+        }
+        other => panic!("expected a call error, got {other:?}"),
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn abort_and_reload_settlement_task_round_trip() {
+    let context = TestContext::new_with_config(TestContext::get_default_config()).await;
+    let job_id = seed_pending_job(&context, 1);
+
+    // Dead-task path: reload-and-restart spawns the task from storage.
+    let () = context
+        .admin_client
+        .request("admin_reloadAndRestartSettlementTask", rpc_params![job_id])
+        .await
+        .expect("reload of a pending job must respawn its task");
+    assert!(context.settlement_service.has_live_task(job_id).await);
+
+    // Live-task path: a second reload is accepted by the running task.
+    let () = context
+        .admin_client
+        .request("admin_reloadAndRestartSettlementTask", rpc_params![job_id])
+        .await
+        .expect("reload of a live task must be accepted");
+
+    // Abort stops it.
+    let () = context
+        .admin_client
+        .request("admin_abortSettlementTask", rpc_params![job_id])
+        .await
+        .expect("abort of a live task must succeed");
+    wait_until_task_gone(&context, job_id).await;
+
+    // A second abort reports the dead task.
+    let error = context
+        .admin_client
+        .request::<(), _>("admin_abortSettlementTask", rpc_params![job_id])
+        .await
+        .expect_err("abort without a live task must fail");
+    assert_error_code(error, crate::error::code::SETTLEMENT_ADMIN);
+
+    // And reload-and-restart revives it: the full unstick cycle.
+    let () = context
+        .admin_client
+        .request("admin_reloadAndRestartSettlementTask", rpc_params![job_id])
+        .await
+        .expect("reload after abort must respawn the task");
+    assert!(context.settlement_service.has_live_task(job_id).await);
+}
+
+#[test_log::test(tokio::test)]
+async fn settlement_task_controls_report_unknown_job() {
+    let context = TestContext::new_with_config(TestContext::get_default_config()).await;
+    let job_id = mk_job_id(99);
+
+    for method in [
+        "admin_abortSettlementTask",
+        "admin_reloadAndRestartSettlementTask",
+    ] {
+        let error = context
+            .admin_client
+            .request::<(), _>(method, rpc_params![job_id])
+            .await
+            .expect_err("unknown job must fail");
+        assert_error_code(error, crate::error::code::RESOURCE_NOT_FOUND);
+    }
+}

--- a/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
@@ -1,7 +1,10 @@
 //! Tests for the settlement task admin RPC methods.
 
 use agglayer_storage::stores::SettlementWriter;
-use agglayer_types::{SettlementJob, SettlementJobId, U256};
+use agglayer_types::{
+    ContractCallOutcome, ContractCallResult, Digest, Nonce, SettlementAttemptNumber, SettlementJob,
+    SettlementJobId, SettlementJobResult, SettlementTxHash, B256, U256,
+};
 use jsonrpsee::{core::client::ClientT, rpc_params};
 
 use crate::testutils::TestContext;
@@ -31,6 +34,29 @@ fn seed_pending_job(context: &TestContext, seed: u8) -> SettlementJobId {
     job_id
 }
 
+/// Seed a settlement job with a stored terminal result: a completed job
+/// with no live task, as after a settled transaction and a node restart.
+fn seed_completed_job(context: &TestContext, seed: u8) -> SettlementJobId {
+    let job_id = seed_pending_job(context, seed);
+    let result = SettlementJobResult {
+        wallet: agglayer_types::Address::from([seed; 20]),
+        nonce: Nonce(seed as u64),
+        attempt_number: SettlementAttemptNumber(seed as u64),
+        contract_call_result: ContractCallResult {
+            outcome: ContractCallOutcome::Success,
+            metadata: vec![].into(),
+            block_hash: B256::from([seed; 32]),
+            block_number: seed as u64,
+            tx_hash: SettlementTxHash::new(Digest::from([seed; 32])),
+        },
+    };
+    context
+        .state_store
+        .insert_settlement_job_result(&job_id, &result)
+        .expect("job result insert must succeed");
+    job_id
+}
+
 async fn wait_until_task_gone(context: &TestContext, job_id: SettlementJobId) {
     tokio::time::timeout(std::time::Duration::from_secs(10), async {
         while context.settlement_service.has_live_task(job_id).await {
@@ -52,6 +78,11 @@ fn assert_error_code(error: jsonrpsee::core::client::Error, code: i32) {
 
 #[test_log::test(tokio::test)]
 async fn abort_and_reload_settlement_task_round_trip() {
+    // Determinism assumption: on the current_thread test runtime the
+    // abort's control-map read and cancel() have no await point between
+    // them, so the run-loop's reload-arm handle swap cannot interleave
+    // and the abort always lands on the task's current control handle.
+    // Mirrors the determinism comments in the settlement-service tests.
     let context = TestContext::new_with_config(TestContext::get_default_config()).await;
     let job_id = seed_pending_job(&context, 1);
 
@@ -93,6 +124,24 @@ async fn abort_and_reload_settlement_task_round_trip() {
         .await
         .expect("reload after abort must respawn the task");
     assert!(context.settlement_service.has_live_task(job_id).await);
+}
+
+#[test_log::test(tokio::test)]
+async fn settlement_task_controls_report_completed_job() {
+    let context = TestContext::new_with_config(TestContext::get_default_config()).await;
+    let job_id = seed_completed_job(&context, 42);
+
+    for method in [
+        "admin_abortSettlementTask",
+        "admin_reloadAndRestartSettlementTask",
+    ] {
+        let error = context
+            .admin_client
+            .request::<(), _>(method, rpc_params![job_id])
+            .await
+            .expect_err("completed job must fail");
+        assert_error_code(error, crate::error::code::SETTLEMENT_ADMIN);
+    }
 }
 
 #[test_log::test(tokio::test)]

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_job_completed.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_job_completed.snap
@@ -1,0 +1,16 @@
+---
+source: crates/agglayer-jsonrpc-api/src/tests/errors.rs
+expression: "SettlementAdmin(JobCompleted { job_id: \"00000000000000000000000009\" })"
+snapshot_kind: text
+---
+{
+  "code": -10010,
+  "data": {
+    "settlement-admin": {
+      "job-completed": {
+        "job-id": "00000000000000000000000009"
+      }
+    }
+  },
+  "message": "Settlement admin error: Settlement job 00000000000000000000000009 is already completed"
+}

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_job_not_found.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_job_not_found.snap
@@ -1,0 +1,12 @@
+---
+source: crates/agglayer-jsonrpc-api/src/tests/errors.rs
+expression: "ResourceNotFound(\"SettlementJob(00000000000000000000000007)\")"
+snapshot_kind: text
+---
+{
+  "code": -10008,
+  "data": {
+    "resource-not-found": "SettlementJob(00000000000000000000000007)"
+  },
+  "message": "Resource not found: SettlementJob(00000000000000000000000007)"
+}

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_no_live_task.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_no_live_task.snap
@@ -1,12 +1,16 @@
 ---
 source: crates/agglayer-jsonrpc-api/src/tests/errors.rs
-expression: "SettlementAdmin(\"No live settlement task for job 00000000000000000000000008\")"
+expression: "SettlementAdmin(NoLiveTask { job_id: \"00000000000000000000000008\" })"
 snapshot_kind: text
 ---
 {
   "code": -10010,
   "data": {
-    "settlement-admin": "No live settlement task for job 00000000000000000000000008"
+    "settlement-admin": {
+      "no-live-task": {
+        "job-id": "00000000000000000000000008"
+      }
+    }
   },
   "message": "Settlement admin error: No live settlement task for job 00000000000000000000000008"
 }

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_no_live_task.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_no_live_task.snap
@@ -1,0 +1,12 @@
+---
+source: crates/agglayer-jsonrpc-api/src/tests/errors.rs
+expression: "SettlementAdmin(\"No live settlement task for job 00000000000000000000000008\")"
+snapshot_kind: text
+---
+{
+  "code": -10010,
+  "data": {
+    "settlement-admin": "No live settlement task for job 00000000000000000000000008"
+  },
+  "message": "Settlement admin error: No live settlement task for job 00000000000000000000000008"
+}

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_reload_failed.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_reload_failed.snap
@@ -1,0 +1,17 @@
+---
+source: crates/agglayer-jsonrpc-api/src/tests/errors.rs
+expression: "SettlementAdmin(ReloadFailed { job_id: \"0000000000000000000000000B\", detail: \"boom\" })"
+snapshot_kind: text
+---
+{
+  "code": -10010,
+  "data": {
+    "settlement-admin": {
+      "reload-failed": {
+        "detail": "boom",
+        "job-id": "0000000000000000000000000B"
+      }
+    }
+  },
+  "message": "Settlement admin error: Failed to reload settlement task for job 0000000000000000000000000B: boom"
+}

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_storage.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_storage.snap
@@ -1,0 +1,17 @@
+---
+source: crates/agglayer-jsonrpc-api/src/tests/errors.rs
+expression: "SettlementAdmin(Storage { job_id: \"0000000000000000000000000C\", detail: \"An unexpected error occurred: boom\\n        This is a critical bug that needs to be reported on `https://github.com/agglayer/agglayer/issues`\" })"
+snapshot_kind: text
+---
+{
+  "code": -10010,
+  "data": {
+    "settlement-admin": {
+      "storage": {
+        "detail": "An unexpected error occurred: boom\n        This is a critical bug that needs to be reported on `https://github.com/agglayer/agglayer/issues`",
+        "job-id": "0000000000000000000000000C"
+      }
+    }
+  },
+  "message": "Settlement admin error: Storage error while handling settlement admin command for job 0000000000000000000000000C: An unexpected error occurred: boom\n        This is a critical bug that needs to be reported on `https://github.com/agglayer/agglayer/issues`"
+}

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_task_not_responding.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__errors__settlement_admin_task_not_responding.snap
@@ -1,0 +1,17 @@
+---
+source: crates/agglayer-jsonrpc-api/src/tests/errors.rs
+expression: "SettlementAdmin(TaskNotResponding { job_id: \"0000000000000000000000000A\", detail: \"channel closed\" })"
+snapshot_kind: text
+---
+{
+  "code": -10010,
+  "data": {
+    "settlement-admin": {
+      "task-not-responding": {
+        "detail": "channel closed",
+        "job-id": "0000000000000000000000000A"
+      }
+    }
+  },
+  "message": "Settlement admin error: Settlement task for job 0000000000000000000000000A did not accept the admin command: channel closed"
+}

--- a/crates/agglayer-jsonrpc-api/src/testutils.rs
+++ b/crates/agglayer-jsonrpc-api/src/testutils.rs
@@ -1,7 +1,11 @@
 use std::{future::IntoFuture as _, net::SocketAddr, sync::Arc};
 
-use agglayer_config::Config;
+use agglayer_config::{
+    settlement_service::{SettlementServiceConfig, SettlementTransactionConfig},
+    Config,
+};
 use agglayer_contracts::L1RpcClient;
+use agglayer_settlement_service::SettlementService;
 use agglayer_storage::{
     backup::BackupClient,
     stores::{debug::DebugStore, epochs::EpochsStore, pending::PendingStore, state::StateStore},
@@ -9,11 +13,16 @@ use agglayer_storage::{
 };
 use agglayer_types::{Certificate, CertificateId, Height, NetworkId};
 use alloy::{
+    network::EthereumWallet,
     providers::{
-        fillers::{BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller},
+        fillers::{
+            BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
+            WalletFiller,
+        },
         mock::Asserter,
         Identity, ProviderBuilder, RootProvider,
     },
+    signers::local::PrivateKeySigner,
     transports::mock::MockTransport,
 };
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
@@ -28,6 +37,21 @@ pub type MockProvider = FillProvider<
     JoinFill<
         Identity,
         JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+    >,
+    RootProvider,
+    alloy::network::Ethereum,
+>;
+
+/// Provider used by the test settlement service: wallet-carrying, with
+/// a dead HTTP endpoint. Startup recovery does no L1 calls, spawned
+/// tasks block retrying against L1 until cancelled.
+pub type SettlementTestProvider = FillProvider<
+    JoinFill<
+        JoinFill<
+            Identity,
+            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+        >,
+        WalletFiller<EthereumWallet>,
     >,
     RootProvider,
     alloy::network::Ethereum,
@@ -62,6 +86,7 @@ pub struct TestContext {
     pub cancellation_token: CancellationToken,
     pub state_store: Arc<StateStore>,
     pub pending_store: Arc<PendingStore>,
+    pub settlement_service: SettlementService<SettlementTestProvider, StateStore>,
     pub api_client: HttpClient,
     pub admin_client: HttpClient,
     pub config: Arc<Config>,
@@ -148,6 +173,29 @@ impl TestContext {
         // Create AgglayerImpl
         let agglayer_impl = crate::AgglayerImpl::new(v0_service, rpc_service);
 
+        // A settlement service over the (empty) state store, with its own
+        // wallet-carrying provider pointed at a dead endpoint: startup
+        // recovery finds no jobs, and spawned tasks retry against L1
+        // until cancelled instead of completing.
+        let settlement_provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(
+                PrivateKeySigner::from_slice(&[0x11; 32]).expect("valid test signing key"),
+            ))
+            .connect_http(
+                "http://127.0.0.1:0"
+                    .parse()
+                    .expect("test provider URL should parse"),
+            );
+        let settlement_service = SettlementService::start(
+            SettlementServiceConfig::default(),
+            Arc::new(SettlementTransactionConfig::default()),
+            Arc::new(settlement_provider),
+            state_store.clone(),
+            cancellation_token.clone(),
+        )
+        .await
+        .expect("settlement service should start");
+
         // Create the routers
         let router = agglayer_impl.start().await.unwrap();
         let admin_router = AdminAgglayerImpl::new(
@@ -156,6 +204,7 @@ impl TestContext {
             state_store.clone(),
             debug_store.clone(),
             config.clone(),
+            settlement_service.clone(),
         )
         .start()
         .await
@@ -187,6 +236,7 @@ impl TestContext {
             cancellation_token,
             state_store,
             pending_store,
+            settlement_service,
             api_client,
             admin_client,
             config,

--- a/crates/agglayer-jsonrpc-api/src/testutils.rs
+++ b/crates/agglayer-jsonrpc-api/src/testutils.rs
@@ -42,9 +42,10 @@ pub type MockProvider = FillProvider<
     alloy::network::Ethereum,
 >;
 
-/// Provider used by the test settlement service: wallet-carrying, with
-/// a dead HTTP endpoint. Startup recovery does no L1 calls, spawned
-/// tasks block retrying against L1 until cancelled.
+/// Provider used by the test settlement service: wallet-carrying, pointed
+/// at a never-accepting local listener. Startup recovery does no L1 calls
+/// on the empty store; a task that does reach L1 hangs in its retry loop
+/// and exits on cancellation.
 pub type SettlementTestProvider = FillProvider<
     JoinFill<
         JoinFill<
@@ -87,6 +88,9 @@ pub struct TestContext {
     pub state_store: Arc<StateStore>,
     pub pending_store: Arc<PendingStore>,
     pub settlement_service: SettlementService<SettlementTestProvider, StateStore>,
+    /// Keeps the never-accepting settlement L1 sink bound for the whole
+    /// test so in-flight settlement task requests hang instead of erroring.
+    pub _settlement_l1_sink: std::net::TcpListener,
     pub api_client: HttpClient,
     pub admin_client: HttpClient,
     pub config: Arc<Config>,
@@ -173,16 +177,30 @@ impl TestContext {
         // Create AgglayerImpl
         let agglayer_impl = crate::AgglayerImpl::new(v0_service, rpc_service);
 
+        // L1 sink for the settlement service: a bound listener that never
+        // accepts. Connections complete (kernel backlog) but requests get
+        // no response, so a settlement task that reaches L1 blocks inside
+        // its retry loop until cancellation instead of panicking on a
+        // non-retryable connect error.
+        let settlement_l1_sink =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("bind settlement L1 sink");
+        let settlement_l1_url = format!(
+            "http://{}/",
+            settlement_l1_sink
+                .local_addr()
+                .expect("settlement L1 sink address")
+        );
+
         // A settlement service over the (empty) state store, with its own
-        // wallet-carrying provider pointed at a dead endpoint: startup
-        // recovery finds no jobs, and spawned tasks retry against L1
-        // until cancelled instead of completing.
+        // wallet-carrying provider pointed at the never-accepting sink:
+        // startup recovery finds no jobs, and a spawned task that reaches
+        // L1 hangs in its retry loop until cancelled instead of completing.
         let settlement_provider = ProviderBuilder::new()
             .wallet(EthereumWallet::from(
                 PrivateKeySigner::from_slice(&[0x11; 32]).expect("valid test signing key"),
             ))
             .connect_http(
-                "http://127.0.0.1:0"
+                settlement_l1_url
                     .parse()
                     .expect("test provider URL should parse"),
             );
@@ -237,6 +255,7 @@ impl TestContext {
             state_store,
             pending_store,
             settlement_service,
+            _settlement_l1_sink: settlement_l1_sink,
             api_client,
             admin_client,
             config,

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -282,6 +282,7 @@ impl Node {
             )
             .await?,
         );
+        let settlement_service_for_admin = (*settlement_service).clone();
 
         let (data_sender, data_receiver) = mpsc::channel(
             config
@@ -323,6 +324,7 @@ impl Node {
             state_store.clone(),
             debug_store.clone(),
             config.clone(),
+            settlement_service_for_admin,
         )
         .start()
         .await


### PR DESCRIPTION
## What

Second slice of the settlement admin floor for #1675, stacked on #1681. It wires the settlement service into the private admin JSON-RPC listener and exposes the two task controls:

- `admin_abortSettlementTask(job_id)` requests cancellation of the in-memory task. The job stays pending in storage, so this is recoverable.
- `admin_reloadAndRestartSettlementTask(job_id)` tells a live task to drop its memory and reload from storage. When no task is running for a pending job (after an abort, or a failed in-task reload), it spawns a fresh one from storage. Together the two calls form the unstick cycle from the issue.

The reads (`admin_listSettlementJobs`, `admin_getSettlementJob`) come in PR 3.

## Wiring

`AdminAgglayerImpl` gains an `L1Provider` generic and a `SettlementService<L1Provider, StateStore>` field; `node.rs` keeps a clone of the service before the orchestrator consumes the `Arc`. The plumbing matches the shape drafted in #1663, so its mutation slice can rebase onto it without friction.

Error responses follow the crate's nested-enum pattern: unknown jobs return the existing `-10008` resource-not-found, everything else returns a new `-10010` whose `data` payload carries a machine-readable variant tag (`job-completed`, `no-live-task`, `task-not-responding`, `reload-failed`, `storage`). Scripts branch on the tag, not on message prose. All six mappings are snapshot-pinned, and the `From` impl matches exhaustively, so a future service-side variant becomes a compile error at the boundary instead of an unclassified string.

## Tests

The API tests drive the real HTTP admin server, a real RocksDB store, and a real settlement service. The fixture points that service at a never-accepting TCP listener: a task that reaches L1 hangs in its retry loop until cancelled, rather than panicking on a non-retryable connect error, which keeps the round-trip test deterministic. Covered end to end: respawning a dead task, reloading a live one, abort, double abort (`-10010`), revival after abort, and unknown (`-10008`) plus completed (`-10010`) jobs on both methods.

## Notes for reviewers

- The method docs disclose the abort/reload race: a reload issued while an abort is still taking effect can be accepted and then dropped as the task exits. Retrying once the task is gone respawns from storage, and repeated reloads are harmless.
- The admin listener stays gated by network placement only, unchanged from the existing `admin_force*` methods.

Refs #1675