### PR TITLE
feat(settlement): admin RPC reads for settlement jobs

### DIFF
--- a/crates/agglayer-jsonrpc-api/src/admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/admin.rs
@@ -22,7 +22,15 @@ use tracing::{error, info, instrument, warn};
 use unified_bridge::TokenInfo;
 
 use super::error::RpcResult;
-use crate::{error::Error, rpc_middleware, JsonRpcService};
+use crate::{
+    error::Error,
+    rpc_middleware,
+    settlement_admin::{
+        build_job_summary, render_last_error, SettlementAttemptDetail, SettlementJobDetail,
+        SettlementJobResultDto, SettlementJobStatus, SettlementJobSummary,
+    },
+    JsonRpcService,
+};
 
 /// Controls whether the certificate is immediately submitted for reprocessing
 /// after edits are applied.
@@ -237,6 +245,27 @@ pub(crate) trait AdminAgglayer {
     /// unavailable.
     #[method(name = "reloadAndRestartSettlementTask")]
     async fn reload_and_restart_settlement_task(&self, job_id: SettlementJobId) -> RpcResult<()>;
+
+    /// List every settlement job known to storage.
+    ///
+    /// **JSON-RPC method:** `admin_listSettlementJobs`
+    ///
+    /// One summary per job: certificate link, storage-derived status,
+    /// live-task flag, attempt count, latest attempt, and the latest
+    /// error if any. A `pending` job with `hasLiveTask: false` is
+    /// wedged and needs `admin_reloadAndRestartSettlementTask`.
+    /// Performs a full scan with per-job lookups; intended for operator
+    /// use on the admin listener, not for polling at high frequency.
+    #[method(name = "listSettlementJobs")]
+    async fn list_settlement_jobs(&self) -> RpcResult<Vec<SettlementJobSummary>>;
+
+    /// Get one settlement job with its full attempt history.
+    ///
+    /// **JSON-RPC method:** `admin_getSettlementJob`
+    ///
+    /// Fails with resource-not-found when the job does not exist.
+    #[method(name = "getSettlementJob")]
+    async fn get_settlement_job(&self, job_id: SettlementJobId) -> RpcResult<SettlementJobDetail>;
 }
 
 /// The Admin RPC agglayer service implementation.
@@ -338,6 +367,38 @@ where
             .route("/", axum::routing::get_service(service.clone()))
             .route("/", axum::routing::post_service(service.clone()))
             .layer(middleware))
+    }
+
+    /// Read everything one list row needs from storage and the service.
+    async fn read_job_summary(
+        &self,
+        job_id: SettlementJobId,
+    ) -> Result<SettlementJobSummary, Error> {
+        let job_result = self
+            .state
+            .get_settlement_job_result(&job_id)
+            .map_err(|error| Error::internal(error.to_string()))?;
+        let attempts = self
+            .state
+            .list_settlement_attempts(&job_id)
+            .map_err(|error| Error::internal(error.to_string()))?;
+        let attempt_results = self
+            .state
+            .list_settlement_attempt_results(&job_id)
+            .map_err(|error| Error::internal(error.to_string()))?;
+        let certificate_id = self
+            .state
+            .get_settlement_job_certificate_id(&job_id)
+            .map_err(|error| Error::internal(error.to_string()))?;
+        let has_live_task = self.settlement_service.has_live_task(job_id).await;
+        Ok(build_job_summary(
+            job_id,
+            certificate_id,
+            has_live_task,
+            job_result.as_ref(),
+            &attempts,
+            &attempt_results,
+        ))
     }
 }
 
@@ -863,5 +924,73 @@ where
             .settlement_service
             .admin_reload_and_restart_task(job_id)
             .await?)
+    }
+
+    #[instrument(skip(self))]
+    async fn list_settlement_jobs(&self) -> RpcResult<Vec<SettlementJobSummary>> {
+        let job_ids = self
+            .state
+            .list_settlement_job_ids()
+            .map_err(|error| Error::internal(error.to_string()))?;
+        let mut jobs = Vec::with_capacity(job_ids.len());
+        for job_id in job_ids {
+            jobs.push(self.read_job_summary(job_id).await?);
+        }
+        Ok(jobs)
+    }
+
+    #[instrument(skip(self))]
+    async fn get_settlement_job(&self, job_id: SettlementJobId) -> RpcResult<SettlementJobDetail> {
+        let job = self
+            .state
+            .get_settlement_job(&job_id)
+            .map_err(|error| Error::internal(error.to_string()))?
+            .ok_or_else(|| Error::ResourceNotFound(format!("SettlementJob({job_id})")))?;
+        let job_result = self
+            .state
+            .get_settlement_job_result(&job_id)
+            .map_err(|error| Error::internal(error.to_string()))?;
+        let attempts = self
+            .state
+            .list_settlement_attempts(&job_id)
+            .map_err(|error| Error::internal(error.to_string()))?;
+        let attempt_results = self
+            .state
+            .list_settlement_attempt_results(&job_id)
+            .map_err(|error| Error::internal(error.to_string()))?;
+        let certificate_id = self
+            .state
+            .get_settlement_job_certificate_id(&job_id)
+            .map_err(|error| Error::internal(error.to_string()))?;
+        let has_live_task = self.settlement_service.has_live_task(job_id).await;
+
+        let attempts = attempts
+            .iter()
+            .map(|(number, attempt)| {
+                let result = attempt_results
+                    .iter()
+                    .find(|(result_number, _)| result_number == number)
+                    .map(|(_, result)| result);
+                SettlementAttemptDetail::new(*number, attempt, result)
+            })
+            .collect();
+
+        Ok(SettlementJobDetail {
+            job_id,
+            certificate_id,
+            status: if job_result.is_some() {
+                SettlementJobStatus::Completed
+            } else {
+                SettlementJobStatus::Pending
+            },
+            has_live_task,
+            contract_address: job.contract_address,
+            eth_value: job.eth_value,
+            gas_limit: job.gas_limit,
+            calldata: job.calldata,
+            attempts,
+            job_result: job_result.as_ref().map(SettlementJobResultDto::from),
+            last_error: render_last_error(&attempt_results),
+        })
     }
 }

--- a/crates/agglayer-jsonrpc-api/src/admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/admin.rs
@@ -256,6 +256,11 @@ pub(crate) trait AdminAgglayer {
     /// wedged and needs `admin_reloadAndRestartSettlementTask`.
     /// Performs a full scan with per-job lookups; intended for operator
     /// use on the admin listener, not for polling at high frequency.
+    ///
+    /// Fields are read point-in-time, not transactionally; a job
+    /// completing concurrently can briefly appear pending without a
+    /// live task. The mutation methods re-classify authoritatively, so
+    /// acting on a stale row is safe.
     #[method(name = "listSettlementJobs")]
     async fn list_settlement_jobs(&self) -> RpcResult<Vec<SettlementJobSummary>>;
 

--- a/crates/agglayer-jsonrpc-api/src/lib.rs
+++ b/crates/agglayer-jsonrpc-api/src/lib.rs
@@ -41,6 +41,7 @@ pub mod tests;
 pub mod testutils;
 
 pub mod admin;
+pub mod settlement_admin;
 
 #[rpc(server, namespace = "interop")]
 trait Agglayer {

--- a/crates/agglayer-jsonrpc-api/src/settlement_admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/settlement_admin.rs
@@ -210,9 +210,6 @@ impl From<&SettlementJobResult> for SettlementJobResultDto {
 
 /// Render the most recent attempt result as an operator-facing error
 /// string, or `None` when the latest recorded state is not a failure.
-// Only unit tests call this until the settlement admin read methods land
-// in the next commit.
-#[allow(dead_code)]
 pub(crate) fn render_last_error(results: &[(u64, SettlementAttemptResult)]) -> Option<String> {
     let (_, latest) = results.iter().max_by_key(|(number, _)| *number)?;
     match latest {
@@ -232,8 +229,6 @@ pub(crate) fn render_last_error(results: &[(u64, SettlementAttemptResult)]) -> O
 }
 
 /// Build one list row from its storage and service inputs.
-// Used by the settlement admin read methods in the next commit.
-#[allow(dead_code)]
 pub(crate) fn build_job_summary(
     job_id: SettlementJobId,
     certificate_id: Option<CertificateId>,

--- a/crates/agglayer-jsonrpc-api/src/settlement_admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/settlement_admin.rs
@@ -1,0 +1,238 @@
+//! Wire types for the settlement admin read methods.
+//!
+//! The settlement domain types in `agglayer-types` carry no serde; the
+//! JSON representation is owned here, at the RPC boundary (same pattern
+//! as `TokenBalanceEntry` for `admin_getTokenBalance`).
+
+use std::time::SystemTime;
+
+use agglayer_types::{
+    Address, CertificateId, ContractCallOutcome, SettlementAttempt, SettlementAttemptResult,
+    SettlementJobId, SettlementJobResult, SettlementTxHash, B256,
+};
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+mod tests;
+
+/// Storage-derived job state: pending while no terminal result row
+/// exists, completed once it does.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SettlementJobStatus {
+    Pending,
+    Completed,
+}
+
+/// One row of `admin_listSettlementJobs`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettlementJobSummary {
+    pub job_id: SettlementJobId,
+    /// Certificate linked to the job. Null for jobs created without a
+    /// certificate and for jobs linked before the reverse link existed.
+    pub certificate_id: Option<CertificateId>,
+    pub status: SettlementJobStatus,
+    /// Whether an in-memory task currently drives the job. A pending
+    /// job without a live task is wedged:
+    /// use `admin_reloadAndRestartSettlementTask`.
+    pub has_live_task: bool,
+    pub attempt_count: u64,
+    pub latest_attempt: Option<SettlementAttemptSummary>,
+    /// Human-readable rendering of the most recent attempt result when
+    /// it is a failure (client error or on-chain revert), null
+    /// otherwise.
+    pub last_error: Option<String>,
+}
+
+/// Attempt identification fields shown in the job list.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettlementAttemptSummary {
+    pub attempt_number: u64,
+    pub sender_wallet: Address,
+    pub nonce: u64,
+    pub tx_hash: SettlementTxHash,
+}
+
+impl From<(u64, &SettlementAttempt)> for SettlementAttemptSummary {
+    fn from((attempt_number, attempt): (u64, &SettlementAttempt)) -> Self {
+        Self {
+            attempt_number,
+            sender_wallet: attempt.sender_wallet,
+            nonce: attempt.nonce.0,
+            tx_hash: attempt.hash,
+        }
+    }
+}
+
+/// Full job detail returned by `admin_getSettlementJob`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettlementJobDetail {
+    pub job_id: SettlementJobId,
+    pub certificate_id: Option<CertificateId>,
+    pub status: SettlementJobStatus,
+    pub has_live_task: bool,
+    pub contract_address: Address,
+    /// Rendered in alloy's JSON form for `U256`: a hex quantity string.
+    pub eth_value: agglayer_types::U256,
+    pub gas_limit: u128,
+    /// Full settlement calldata, hex-encoded. Admin-only surface, so
+    /// the size is acceptable.
+    pub calldata: alloy::primitives::Bytes,
+    pub attempts: Vec<SettlementAttemptDetail>,
+    pub job_result: Option<SettlementJobResultDto>,
+    pub last_error: Option<String>,
+}
+
+/// One attempt with its recorded result, as returned in the job detail.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettlementAttemptDetail {
+    pub attempt_number: u64,
+    pub sender_wallet: Address,
+    pub nonce: u64,
+    pub tx_hash: SettlementTxHash,
+    pub submission_time_unix_secs: u64,
+    pub max_fee_per_gas: u128,
+    pub max_priority_fee_per_gas: u128,
+    pub result: Option<SettlementAttemptResultDto>,
+}
+
+impl SettlementAttemptDetail {
+    pub fn new(
+        attempt_number: u64,
+        attempt: &SettlementAttempt,
+        result: Option<&SettlementAttemptResult>,
+    ) -> Self {
+        Self {
+            attempt_number,
+            sender_wallet: attempt.sender_wallet,
+            nonce: attempt.nonce.0,
+            tx_hash: attempt.hash,
+            submission_time_unix_secs: attempt
+                .submission_time
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|duration| duration.as_secs())
+                .unwrap_or(0),
+            max_fee_per_gas: attempt.max_fee_per_gas,
+            max_priority_fee_per_gas: attempt.max_priority_fee_per_gas,
+            result: result.map(SettlementAttemptResultDto::from),
+        }
+    }
+}
+
+/// Recorded outcome of one attempt.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SettlementAttemptResultDto {
+    #[serde(rename_all = "camelCase")]
+    ClientError { kind: String, message: String },
+    #[serde(rename_all = "camelCase")]
+    ContractCall {
+        outcome: String,
+        tx_hash: SettlementTxHash,
+        block_number: u64,
+        block_hash: B256,
+    },
+}
+
+impl From<&SettlementAttemptResult> for SettlementAttemptResultDto {
+    fn from(result: &SettlementAttemptResult) -> Self {
+        match result {
+            SettlementAttemptResult::ClientError(client_error) => Self::ClientError {
+                kind: format!("{:?}", client_error.kind),
+                message: client_error.message.clone(),
+            },
+            SettlementAttemptResult::ContractCall(call) => Self::ContractCall {
+                outcome: match call.outcome {
+                    ContractCallOutcome::Success => "success".to_string(),
+                    ContractCallOutcome::Revert => "revert".to_string(),
+                },
+                tx_hash: call.tx_hash,
+                block_number: call.block_number,
+                block_hash: call.block_hash,
+            },
+        }
+    }
+}
+
+/// Terminal result of a completed job.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettlementJobResultDto {
+    pub wallet: Address,
+    pub nonce: u64,
+    pub attempt_number: u64,
+    pub outcome: String,
+    pub tx_hash: SettlementTxHash,
+    pub block_number: u64,
+}
+
+impl From<&SettlementJobResult> for SettlementJobResultDto {
+    fn from(result: &SettlementJobResult) -> Self {
+        Self {
+            wallet: result.wallet,
+            nonce: result.nonce.0,
+            attempt_number: result.attempt_number.0,
+            outcome: match result.contract_call_result.outcome {
+                ContractCallOutcome::Success => "success".to_string(),
+                ContractCallOutcome::Revert => "revert".to_string(),
+            },
+            tx_hash: result.contract_call_result.tx_hash,
+            block_number: result.contract_call_result.block_number,
+        }
+    }
+}
+
+/// Render the most recent attempt result as an operator-facing error
+/// string, or `None` when the latest recorded state is not a failure.
+// Only unit tests call this until the settlement admin read methods land
+// in the next commit.
+#[allow(dead_code)]
+pub(crate) fn render_last_error(results: &[(u64, SettlementAttemptResult)]) -> Option<String> {
+    let (_, latest) = results.iter().max_by_key(|(number, _)| *number)?;
+    match latest {
+        SettlementAttemptResult::ClientError(client_error) => {
+            Some(format!("{:?}: {}", client_error.kind, client_error.message))
+        }
+        SettlementAttemptResult::ContractCall(call) => match call.outcome {
+            ContractCallOutcome::Revert => Some(format!(
+                "Reverted on L1 in tx {} (block {})",
+                call.tx_hash, call.block_number
+            )),
+            ContractCallOutcome::Success => None,
+        },
+    }
+}
+
+/// Build one list row from its storage and service inputs.
+// Used by the settlement admin read methods in the next commit.
+#[allow(dead_code)]
+pub(crate) fn build_job_summary(
+    job_id: SettlementJobId,
+    certificate_id: Option<CertificateId>,
+    has_live_task: bool,
+    job_result: Option<&SettlementJobResult>,
+    attempts: &[(u64, SettlementAttempt)],
+    attempt_results: &[(u64, SettlementAttemptResult)],
+) -> SettlementJobSummary {
+    let latest_attempt = attempts
+        .iter()
+        .max_by_key(|(number, _)| *number)
+        .map(|(number, attempt)| SettlementAttemptSummary::from((*number, attempt)));
+    SettlementJobSummary {
+        job_id,
+        certificate_id,
+        status: if job_result.is_some() {
+            SettlementJobStatus::Completed
+        } else {
+            SettlementJobStatus::Pending
+        },
+        has_live_task,
+        attempt_count: attempts.len() as u64,
+        latest_attempt,
+        last_error: render_last_error(attempt_results),
+    }
+}

--- a/crates/agglayer-jsonrpc-api/src/settlement_admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/settlement_admin.rs
@@ -3,12 +3,17 @@
 //! The settlement domain types in `agglayer-types` carry no serde; the
 //! JSON representation is owned here, at the RPC boundary (same pattern
 //! as `TokenBalanceEntry` for `admin_getTokenBalance`).
+//!
+//! Data-carrying enums here are deliberately internally tagged
+//! (`#[serde(tag = "type")]`), unlike the error family in
+//! [`crate::error`], which keeps serde's default externally-tagged
+//! payloads.
 
 use std::time::SystemTime;
 
 use agglayer_types::{
-    Address, CertificateId, ContractCallOutcome, SettlementAttempt, SettlementAttemptResult,
-    SettlementJobId, SettlementJobResult, SettlementTxHash, B256,
+    Address, CertificateId, ClientErrorType, ContractCallOutcome, SettlementAttempt,
+    SettlementAttemptResult, SettlementJobId, SettlementJobResult, SettlementTxHash, B256,
 };
 use serde::{Deserialize, Serialize};
 
@@ -67,6 +72,9 @@ impl From<(u64, &SettlementAttempt)> for SettlementAttemptSummary {
 }
 
 /// Full job detail returned by `admin_getSettlementJob`.
+///
+/// `gas_limit` is rendered as a JSON number; realistic values stay far
+/// below 2^53, so this is safe for standard JSON tooling.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SettlementJobDetail {
@@ -87,6 +95,10 @@ pub struct SettlementJobDetail {
 }
 
 /// One attempt with its recorded result, as returned in the job detail.
+///
+/// `max_fee_per_gas` and `max_priority_fee_per_gas` are rendered as
+/// JSON numbers; realistic values stay far below 2^53, so this is safe
+/// for standard JSON tooling.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SettlementAttemptDetail {
@@ -138,11 +150,21 @@ pub enum SettlementAttemptResultDto {
     },
 }
 
+/// Stable wire tag for a client error kind. Exhaustive on purpose: a new
+/// `ClientErrorType` variant must pick its wire tag here.
+fn client_error_kind_tag(kind: ClientErrorType) -> &'static str {
+    match kind {
+        ClientErrorType::Unknown => "unknown",
+        ClientErrorType::NonceAlreadyUsed => "nonceAlreadyUsed",
+        ClientErrorType::SettlementSucceededElsewhere => "settlementSucceededElsewhere",
+    }
+}
+
 impl From<&SettlementAttemptResult> for SettlementAttemptResultDto {
     fn from(result: &SettlementAttemptResult) -> Self {
         match result {
             SettlementAttemptResult::ClientError(client_error) => Self::ClientError {
-                kind: format!("{:?}", client_error.kind),
+                kind: client_error_kind_tag(client_error.kind).to_string(),
                 message: client_error.message.clone(),
             },
             SettlementAttemptResult::ContractCall(call) => Self::ContractCall {
@@ -194,9 +216,11 @@ impl From<&SettlementJobResult> for SettlementJobResultDto {
 pub(crate) fn render_last_error(results: &[(u64, SettlementAttemptResult)]) -> Option<String> {
     let (_, latest) = results.iter().max_by_key(|(number, _)| *number)?;
     match latest {
-        SettlementAttemptResult::ClientError(client_error) => {
-            Some(format!("{:?}: {}", client_error.kind, client_error.message))
-        }
+        SettlementAttemptResult::ClientError(client_error) => Some(format!(
+            "{}: {}",
+            client_error_kind_tag(client_error.kind),
+            client_error.message
+        )),
         SettlementAttemptResult::ContractCall(call) => match call.outcome {
             ContractCallOutcome::Revert => Some(format!(
                 "Reverted on L1 in tx {} (block {})",

--- a/crates/agglayer-jsonrpc-api/src/settlement_admin/tests.rs
+++ b/crates/agglayer-jsonrpc-api/src/settlement_admin/tests.rs
@@ -2,7 +2,8 @@ use std::time::{Duration, SystemTime};
 
 use agglayer_types::{
     Address, ClientError, ClientErrorType, ContractCallOutcome, ContractCallResult, Digest, Nonce,
-    SettlementAttempt, SettlementAttemptResult, SettlementTxHash, B256,
+    SettlementAttempt, SettlementAttemptNumber, SettlementAttemptResult, SettlementJobResult,
+    SettlementTxHash, B256,
 };
 
 use super::*;
@@ -42,9 +43,11 @@ fn last_error_is_none_without_results() {
 
 #[test]
 fn last_error_renders_the_latest_client_error() {
+    // Descending on purpose: "latest" must follow the attempt number, not
+    // the position in the slice.
     let results = vec![
-        (0, client_error_result("older error")),
         (1, client_error_result("newer error")),
+        (0, client_error_result("older error")),
     ];
     let rendered = render_last_error(&results).expect("latest failure must render");
     assert!(rendered.contains("newer error"), "got: {rendered}");
@@ -64,6 +67,75 @@ fn last_error_renders_the_latest_revert() {
     let results = vec![(0, contract_call_result(ContractCallOutcome::Revert))];
     let rendered = render_last_error(&results).expect("revert must render");
     assert!(rendered.contains("Reverted"), "got: {rendered}");
+}
+
+#[test]
+fn build_job_summary_selects_latest_attempt_by_number() {
+    // Descending on purpose: selection must follow the attempt number.
+    let attempts = vec![(1u64, attempt(1)), (0u64, attempt(0))];
+    let results = vec![
+        (1u64, client_error_result("newest failure")),
+        (0u64, client_error_result("older failure")),
+    ];
+    let summary = build_job_summary(
+        agglayer_types::SettlementJobId::from(5u128),
+        None,
+        false,
+        None,
+        &attempts,
+        &results,
+    );
+    assert_eq!(summary.status, SettlementJobStatus::Pending);
+    assert_eq!(summary.attempt_count, 2);
+    assert_eq!(
+        summary
+            .latest_attempt
+            .expect("latest attempt must be set")
+            .attempt_number,
+        1
+    );
+    assert!(summary
+        .last_error
+        .expect("last error must be set")
+        .contains("newest failure"));
+
+    let job_result = SettlementJobResult {
+        wallet: Address::from([3u8; 20]),
+        nonce: Nonce(1),
+        attempt_number: SettlementAttemptNumber(1),
+        contract_call_result: ContractCallResult {
+            outcome: ContractCallOutcome::Success,
+            metadata: vec![].into(),
+            block_hash: B256::from([3u8; 32]),
+            block_number: 3,
+            tx_hash: SettlementTxHash::new(Digest::from([3u8; 32])),
+        },
+    };
+    let completed = build_job_summary(
+        agglayer_types::SettlementJobId::from(5u128),
+        None,
+        false,
+        Some(&job_result),
+        &attempts,
+        &results,
+    );
+    assert_eq!(completed.status, SettlementJobStatus::Completed);
+}
+
+#[test]
+fn attempt_result_dto_serializes_tagged_shapes() {
+    let client_error = SettlementAttemptResultDto::from(&client_error_result("boom"));
+    let json = serde_json::to_value(&client_error).expect("client error must serialize");
+    assert_eq!(json["type"], "clientError");
+    assert_eq!(json["kind"], "unknown");
+    assert_eq!(json["message"], "boom");
+
+    let call = SettlementAttemptResultDto::from(&contract_call_result(ContractCallOutcome::Revert));
+    let json = serde_json::to_value(&call).expect("contract call must serialize");
+    assert_eq!(json["type"], "contractCall");
+    assert_eq!(json["outcome"], "revert");
+    assert!(json.get("txHash").is_some());
+    assert!(json.get("blockNumber").is_some());
 }
 
 #[test]

--- a/crates/agglayer-jsonrpc-api/src/settlement_admin/tests.rs
+++ b/crates/agglayer-jsonrpc-api/src/settlement_admin/tests.rs
@@ -1,0 +1,85 @@
+use std::time::{Duration, SystemTime};
+
+use agglayer_types::{
+    Address, ClientError, ClientErrorType, ContractCallOutcome, ContractCallResult, Digest, Nonce,
+    SettlementAttempt, SettlementAttemptResult, SettlementTxHash, B256,
+};
+
+use super::*;
+
+fn attempt(seed: u64) -> SettlementAttempt {
+    SettlementAttempt {
+        sender_wallet: Address::from([seed as u8; 20]),
+        nonce: Nonce(seed),
+        hash: SettlementTxHash::new(Digest::from([seed as u8; 32])),
+        submission_time: SystemTime::UNIX_EPOCH + Duration::from_secs(seed),
+        max_fee_per_gas: 30_000_000_000,
+        max_priority_fee_per_gas: 1_000_000_000,
+    }
+}
+
+fn client_error_result(message: &str) -> SettlementAttemptResult {
+    SettlementAttemptResult::ClientError(ClientError {
+        kind: ClientErrorType::Unknown,
+        message: message.to_string(),
+    })
+}
+
+fn contract_call_result(outcome: ContractCallOutcome) -> SettlementAttemptResult {
+    SettlementAttemptResult::ContractCall(ContractCallResult {
+        outcome,
+        metadata: vec![].into(),
+        block_hash: B256::from([9u8; 32]),
+        block_number: 9,
+        tx_hash: SettlementTxHash::new(Digest::from([9u8; 32])),
+    })
+}
+
+#[test]
+fn last_error_is_none_without_results() {
+    assert_eq!(render_last_error(&[]), None);
+}
+
+#[test]
+fn last_error_renders_the_latest_client_error() {
+    let results = vec![
+        (0, client_error_result("older error")),
+        (1, client_error_result("newer error")),
+    ];
+    let rendered = render_last_error(&results).expect("latest failure must render");
+    assert!(rendered.contains("newer error"), "got: {rendered}");
+}
+
+#[test]
+fn last_error_is_none_when_latest_result_is_a_success() {
+    let results = vec![
+        (0, client_error_result("older error")),
+        (1, contract_call_result(ContractCallOutcome::Success)),
+    ];
+    assert_eq!(render_last_error(&results), None);
+}
+
+#[test]
+fn last_error_renders_the_latest_revert() {
+    let results = vec![(0, contract_call_result(ContractCallOutcome::Revert))];
+    let rendered = render_last_error(&results).expect("revert must render");
+    assert!(rendered.contains("Reverted"), "got: {rendered}");
+}
+
+#[test]
+fn job_summary_serializes_camel_case() {
+    let summary = SettlementJobSummary {
+        job_id: agglayer_types::SettlementJobId::from(1u128),
+        certificate_id: None,
+        status: SettlementJobStatus::Pending,
+        has_live_task: true,
+        attempt_count: 1,
+        latest_attempt: Some(SettlementAttemptSummary::from((0u64, &attempt(0)))),
+        last_error: None,
+    };
+    let json = serde_json::to_value(&summary).expect("summary must serialize");
+    assert!(json.get("hasLiveTask").is_some());
+    assert!(json.get("attemptCount").is_some());
+    assert_eq!(json["status"], "pending");
+    assert!(json["latestAttempt"].get("senderWallet").is_some());
+}

--- a/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
@@ -290,6 +290,30 @@ async fn get_settlement_job_returns_detail_with_attempts() {
 }
 
 #[test_log::test(tokio::test)]
+async fn get_settlement_job_returns_completed_detail() {
+    let context = TestContext::new_with_config(TestContext::get_default_config()).await;
+    let job_id = seed_completed_job(&context, 6);
+
+    let detail: SettlementJobDetail = context
+        .admin_client
+        .request("admin_getSettlementJob", rpc_params![job_id])
+        .await
+        .expect("get must succeed");
+    assert_eq!(detail.status, SettlementJobStatus::Completed);
+    let job_result = detail.job_result.expect("job result must be set");
+    assert_eq!(job_result.outcome, "success");
+    assert_eq!(job_result.nonce, 6);
+    assert_eq!(job_result.attempt_number, 6);
+    assert_eq!(job_result.block_number, 6);
+
+    // Pin the wire casing of the terminal result.
+    let json = serde_json::to_value(&job_result).expect("job result must serialize");
+    assert!(json.get("attemptNumber").is_some());
+    assert!(json.get("txHash").is_some());
+    assert!(json.get("blockNumber").is_some());
+}
+
+#[test_log::test(tokio::test)]
 async fn get_settlement_job_unknown_id_is_resource_not_found() {
     let context = TestContext::new_with_config(TestContext::get_default_config()).await;
     let error = context

--- a/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
@@ -1,13 +1,19 @@
 //! Tests for the settlement task admin RPC methods.
 
-use agglayer_storage::stores::SettlementWriter;
+use std::time::{Duration, SystemTime};
+
+use agglayer_storage::stores::{SettlementWriter, StateWriter};
 use agglayer_types::{
-    ContractCallOutcome, ContractCallResult, Digest, Nonce, SettlementAttemptNumber, SettlementJob,
+    CertificateId, ClientError, ClientErrorType, ContractCallOutcome, ContractCallResult, Digest,
+    Nonce, SettlementAttempt, SettlementAttemptNumber, SettlementAttemptResult, SettlementJob,
     SettlementJobId, SettlementJobResult, SettlementTxHash, B256, U256,
 };
 use jsonrpsee::{core::client::ClientT, rpc_params};
 
-use crate::testutils::TestContext;
+use crate::{
+    settlement_admin::{SettlementJobDetail, SettlementJobStatus, SettlementJobSummary},
+    testutils::TestContext,
+};
 
 fn mk_job_id(seed: u128) -> SettlementJobId {
     SettlementJobId::from(seed)
@@ -160,4 +166,136 @@ async fn settlement_task_controls_report_unknown_job() {
             .expect_err("unknown job must fail");
         assert_error_code(error, crate::error::code::RESOURCE_NOT_FOUND);
     }
+}
+
+fn mk_attempt(seed: u64) -> SettlementAttempt {
+    SettlementAttempt {
+        sender_wallet: agglayer_types::Address::from([seed as u8; 20]),
+        nonce: Nonce(seed),
+        hash: SettlementTxHash::new(Digest::from([seed as u8; 32])),
+        submission_time: SystemTime::UNIX_EPOCH + Duration::from_secs(seed),
+        max_fee_per_gas: 30_000_000_000,
+        max_priority_fee_per_gas: 1_000_000_000,
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn list_settlement_jobs_returns_seeded_jobs() {
+    let context = TestContext::new_with_config(TestContext::get_default_config()).await;
+
+    let empty: Vec<SettlementJobSummary> = context
+        .admin_client
+        .request("admin_listSettlementJobs", rpc_params![])
+        .await
+        .expect("empty list must succeed");
+    assert!(empty.is_empty());
+
+    // A pending job with one errored attempt, linked to a certificate.
+    let pending_id = seed_pending_job(&context, 2);
+    let certificate_id = CertificateId::new(Digest::from([2u8; 32]));
+    context
+        .state_store
+        .insert_certificate_settlement_job_id(&certificate_id, &pending_id)
+        .expect("link insert must succeed");
+    context
+        .state_store
+        .insert_settlement_attempt(&pending_id, 0, &mk_attempt(2))
+        .expect("attempt insert must succeed");
+    context
+        .state_store
+        .record_settlement_attempt_result(
+            &pending_id,
+            0,
+            &SettlementAttemptResult::ClientError(ClientError {
+                kind: ClientErrorType::Unknown,
+                message: "rpc flake".to_string(),
+            }),
+        )
+        .expect("attempt result insert must succeed");
+
+    // A completed job without attempts.
+    let completed_id = seed_completed_job(&context, 3);
+
+    let jobs: Vec<SettlementJobSummary> = context
+        .admin_client
+        .request("admin_listSettlementJobs", rpc_params![])
+        .await
+        .expect("list must succeed");
+    assert_eq!(jobs.len(), 2);
+
+    let pending = jobs
+        .iter()
+        .find(|job| job.job_id == pending_id)
+        .expect("pending job must be listed");
+    assert_eq!(pending.status, SettlementJobStatus::Pending);
+    assert_eq!(pending.certificate_id, Some(certificate_id));
+    assert!(!pending.has_live_task);
+    assert_eq!(pending.attempt_count, 1);
+    assert_eq!(
+        pending
+            .latest_attempt
+            .as_ref()
+            .expect("latest attempt must be set")
+            .attempt_number,
+        0
+    );
+    assert!(pending
+        .last_error
+        .as_ref()
+        .expect("last error must be set")
+        .contains("rpc flake"));
+
+    let completed = jobs
+        .iter()
+        .find(|job| job.job_id == completed_id)
+        .expect("completed job must be listed");
+    assert_eq!(completed.status, SettlementJobStatus::Completed);
+    assert_eq!(completed.certificate_id, None);
+    assert_eq!(completed.last_error, None);
+}
+
+#[test_log::test(tokio::test)]
+async fn get_settlement_job_returns_detail_with_attempts() {
+    let context = TestContext::new_with_config(TestContext::get_default_config()).await;
+    let job_id = seed_pending_job(&context, 4);
+    context
+        .state_store
+        .insert_settlement_attempt(&job_id, 0, &mk_attempt(4))
+        .expect("attempt insert must succeed");
+
+    let detail: SettlementJobDetail = context
+        .admin_client
+        .request("admin_getSettlementJob", rpc_params![job_id])
+        .await
+        .expect("get must succeed");
+    assert_eq!(detail.job_id, job_id);
+    assert_eq!(detail.status, SettlementJobStatus::Pending);
+    assert_eq!(detail.attempts.len(), 1);
+    assert_eq!(detail.attempts[0].nonce, 4);
+    assert!(detail.attempts[0].result.is_none());
+    assert!(detail.job_result.is_none());
+
+    // Live-task flag through the respawn path.
+    let () = context
+        .admin_client
+        .request("admin_reloadAndRestartSettlementTask", rpc_params![job_id])
+        .await
+        .expect("reload must respawn");
+    let detail: SettlementJobDetail = context
+        .admin_client
+        .request("admin_getSettlementJob", rpc_params![job_id])
+        .await
+        .expect("get must succeed");
+    assert!(detail.has_live_task);
+}
+
+#[test_log::test(tokio::test)]
+async fn get_settlement_job_unknown_id_is_resource_not_found() {
+    let context = TestContext::new_with_config(TestContext::get_default_config()).await;
+    let error = context
+        .admin_client
+        .request::<SettlementJobDetail, _>("admin_getSettlementJob", rpc_params![mk_job_id(98)])
+        .await
+        .expect_err("unknown job must fail");
+    assert_error_code(error, crate::error::code::RESOURCE_NOT_FOUND);
 }

--- a/docs/knowledge-base/src/SUMMARY.md
+++ b/docs/knowledge-base/src/SUMMARY.md
@@ -6,6 +6,7 @@
 - [Pessimistic Proof](pessimistic-proof.md)
 - [Protobuf and gRPC](protobuf-and-grpc.md)
 - [Storage](storage.md)
+- [Settlement Operations](settlement-operations.md)
 - [Observability](observability.md)
 - [AI Agent Configuration](ai-agents.md)
 - [Documentation Publishing](docs-publishing.md)

--- a/docs/knowledge-base/src/settlement-operations.md
+++ b/docs/knowledge-base/src/settlement-operations.md
@@ -75,10 +75,22 @@ the call detects the dead registration and respawns over it.
 ### A job must stop now
 
 Call `admin_abortSettlementTask` to stop the in-memory task.
-The abort is runtime-only.
-The job stays pending in storage and nothing is recorded,
-so the certificate waiting on the job stays blocked
-until a later `admin_reloadAndRestartSettlementTask`.
+The abort is runtime-only: the job stays pending in storage and nothing
+is recorded, so the settlement can be re-driven later with
+`admin_reloadAndRestartSettlementTask`.
+
+Abort does not preserve an in-flight certificate.
+A certificate task already waiting on this job through `wait_for_settlement`
+sees its watcher close when the task stops, which the orchestrator records
+as a settlement error on the certificate, before any reload runs.
+Recovering the settlement job afterwards does not un-error that certificate;
+the certificate itself must then be recovered separately
+(for example with `admin_forceEditCertificate`).
+If the goal is only to bounce a wedged task without disturbing a waiting
+certificate, use `admin_reloadAndRestartSettlementTask` directly instead:
+a reload of a live task reloads it in place and keeps the waiter connected,
+so the certificate resolves once the reloaded task settles.
+Reach for abort when the task must stop regardless of the waiting certificate.
 
 A reload chained immediately after an abort can be accepted and then dropped,
 because the task can exit on the cancellation

--- a/docs/knowledge-base/src/settlement-operations.md
+++ b/docs/knowledge-base/src/settlement-operations.md
@@ -95,7 +95,7 @@ Both need the mutation methods from the separate work stream
 2. Abort the task with `admin_abortSettlementTask`.
 3. Re-inspect until `hasLiveTask` is false.
 4. Restart with `admin_reloadAndRestartSettlementTask`.
-5. Re-inspect and confirm `hasLiveTask` is true.
+5. Re-inspect and confirm `hasLiveTask` is true (or `status` already `completed`).
 
 ## Worked examples
 
@@ -116,7 +116,7 @@ Get one job with its attempt history:
 ```bash
 curl -s -X POST http://127.0.0.1:9091/ \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"admin_getSettlementJob","params":["01K1ZDGVR1V0Q2EXAMPLEULID0"]}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"admin_getSettlementJob","params":["01K1ZDGVR1V0Q2EXA4P3E00000"]}'
 ```
 
 Abort the task of a job:
@@ -124,7 +124,7 @@ Abort the task of a job:
 ```bash
 curl -s -X POST http://127.0.0.1:9091/ \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"admin_abortSettlementTask","params":["01K1ZDGVR1V0Q2EXAMPLEULID0"]}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"admin_abortSettlementTask","params":["01K1ZDGVR1V0Q2EXA4P3E00000"]}'
 ```
 
 Reload a job from storage and restart its task:
@@ -132,16 +132,17 @@ Reload a job from storage and restart its task:
 ```bash
 curl -s -X POST http://127.0.0.1:9091/ \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"admin_reloadAndRestartSettlementTask","params":["01K1ZDGVR1V0Q2EXAMPLEULID0"]}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"admin_reloadAndRestartSettlementTask","params":["01K1ZDGVR1V0Q2EXA4P3E00000"]}'
 ```
 
 ## Error responses
 
 An unknown job id returns code `-10008` (resource not found).
-Every other settlement admin failure returns code `-10010`
+Every other failure of the two task-control methods returns code `-10010`
 with a machine-readable variant tag nested under `data.settlement-admin`:
 `job-completed`, `no-live-task`, `task-not-responding`,
 `reload-failed`, or `storage`.
+The read methods report storage failures as plain internal errors (`-32603`).
 Scripts should branch on the tag, not on the message,
 which is free text and can change.
 `crates/agglayer-jsonrpc-api/src/error.rs` defines the codes.
@@ -154,7 +155,7 @@ An abort without a live task, for example, fails with:
   "data": {
     "settlement-admin": {
       "no-live-task": {
-        "job-id": "01K1ZDGVR1V0Q2EXAMPLEULID0"
+        "job-id": "01K1ZDGVR1V0Q2EXA4P3E00000"
       }
     }
   },

--- a/docs/knowledge-base/src/settlement-operations.md
+++ b/docs/knowledge-base/src/settlement-operations.md
@@ -1,0 +1,163 @@
+# Settlement operations
+
+This chapter is a runbook for the settlement admin methods of the Agglayer node.
+
+A settlement job is the stored description of one L1 contract call
+that settles a [certificate](glossary.md#certificate).
+An in-memory settlement task drives the job:
+it submits transaction attempts
+and records a terminal result once [settlement](glossary.md#settlement) concludes.
+
+The settlement admin methods live on the private admin JSON-RPC listener,
+bound to `rpc.host`:`rpc.admin_port`.
+The port defaults to 9091 and the `AGGLAYER_ADMIN_PORT` environment variable
+overrides it (`crates/agglayer-config/src/rpc.rs`).
+The listener has no authentication beyond network placement:
+anyone who can reach the port can call every admin method.
+This is the same stance as the certificate admin methods,
+which share the listener.
+
+## The settlement admin surface
+
+| Method | Semantics |
+|---|---|
+| `admin_listSettlementJobs` | One summary row per job known to storage: status, live-task flag, attempt count, latest attempt, and latest error. |
+| `admin_getSettlementJob` | Full detail for one job, including the complete attempt history and the terminal result if any. |
+| `admin_abortSettlementTask` | Stop the in-memory task of a job; storage is untouched. |
+| `admin_reloadAndRestartSettlementTask` | Reload a job from storage and restart its task, or spawn a fresh task when none is live. |
+
+The method definitions live in `crates/agglayer-jsonrpc-api/src/admin.rs`
+and the wire types in `crates/agglayer-jsonrpc-api/src/settlement_admin.rs`.
+
+The mutation methods (insert an attempt, mark an attempt failed,
+and remove recorded results) are a separate work stream
+([PR 1663](https://github.com/agglayer/agglayer/pull/1663))
+and are not available yet.
+
+## Unstick a settlement job
+
+The scenarios below come from
+[issue 1675](https://github.com/agglayer/agglayer/issues/1675)
+and map each situation to the calls that resolve it.
+
+### A job looks stuck
+
+Start with `admin_listSettlementJobs` to see every job,
+then call `admin_getSettlementJob` on the suspicious one.
+
+Read a row as follows.
+`status` derives from storage:
+`pending` while no terminal result row exists, `completed` once one does.
+`hasLiveTask` reports whether an in-memory task currently drives the job.
+A `pending` job with `hasLiveTask: false` is wedged:
+no task is working on it and it will not make progress on its own.
+`lastError` renders the most recent attempt failure,
+and is null when the latest recorded attempt state is not a failure.
+
+Fields are read point-in-time, not transactionally,
+so a job completing concurrently can briefly appear pending without a live task;
+the mutation methods re-classify authoritatively,
+so acting on a stale row is safe.
+
+### Wedged for a transient reason
+
+Call `admin_reloadAndRestartSettlementTask` on the job.
+A live task drops its in-memory state and reloads the job from storage.
+A pending job without a live task, for example after an admin abort
+or a failed in-task reload, gets a fresh task spawned from storage.
+Repeating the call is harmless: reload-and-restart is idempotent recovery.
+
+### A job must stop now
+
+Call `admin_abortSettlementTask` to stop the in-memory task.
+The abort is runtime-only.
+The job stays pending in storage and nothing is recorded,
+so the certificate waiting on the job stays blocked
+until a later `admin_reloadAndRestartSettlementTask`.
+
+A reload chained immediately after an abort can be accepted and then dropped,
+because the task can exit on the cancellation
+without draining its command queue.
+Verify with `admin_getSettlementJob` that `hasLiveTask` is false
+before reloading.
+
+### External transaction or wrong recorded result
+
+Two scenarios are not covered yet:
+settling a job through a transaction sent outside the node,
+and correcting a wrong recorded result.
+Both need the mutation methods from the separate work stream
+([PR 1663](https://github.com/agglayer/agglayer/pull/1663)).
+
+### The abort and reload cycle
+
+1. Inspect the job with `admin_getSettlementJob`.
+2. Abort the task with `admin_abortSettlementTask`.
+3. Re-inspect until `hasLiveTask` is false.
+4. Restart with `admin_reloadAndRestartSettlementTask`.
+5. Re-inspect and confirm `hasLiveTask` is true.
+
+## Worked examples
+
+All examples target the default admin listener on port 9091.
+Job ids are ULID strings and parameters are positional arrays.
+Replace the example job id with a real one from the list output.
+
+List every job:
+
+```bash
+curl -s -X POST http://127.0.0.1:9091/ \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"admin_listSettlementJobs","params":[]}'
+```
+
+Get one job with its attempt history:
+
+```bash
+curl -s -X POST http://127.0.0.1:9091/ \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"admin_getSettlementJob","params":["01K1ZDGVR1V0Q2EXAMPLEULID0"]}'
+```
+
+Abort the task of a job:
+
+```bash
+curl -s -X POST http://127.0.0.1:9091/ \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"admin_abortSettlementTask","params":["01K1ZDGVR1V0Q2EXAMPLEULID0"]}'
+```
+
+Reload a job from storage and restart its task:
+
+```bash
+curl -s -X POST http://127.0.0.1:9091/ \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"admin_reloadAndRestartSettlementTask","params":["01K1ZDGVR1V0Q2EXAMPLEULID0"]}'
+```
+
+## Error responses
+
+An unknown job id returns code `-10008` (resource not found).
+Every other settlement admin failure returns code `-10010`
+with a machine-readable variant tag nested under `data.settlement-admin`:
+`job-completed`, `no-live-task`, `task-not-responding`,
+`reload-failed`, or `storage`.
+Scripts should branch on the tag, not on the message,
+which is free text and can change.
+`crates/agglayer-jsonrpc-api/src/error.rs` defines the codes.
+
+An abort without a live task, for example, fails with:
+
+```json
+{
+  "code": -10010,
+  "data": {
+    "settlement-admin": {
+      "no-live-task": {
+        "job-id": "01K1ZDGVR1V0Q2EXAMPLEULID0"
+      }
+    }
+  },
+  "message": "Settlement admin error: No live settlement task for job ..."
+}
+```

--- a/docs/knowledge-base/src/settlement-operations.md
+++ b/docs/knowledge-base/src/settlement-operations.md
@@ -67,6 +67,11 @@ A pending job without a live task, for example after an admin abort
 or a failed in-task reload, gets a fresh task spawned from storage.
 Repeating the call is harmless: reload-and-restart is idempotent recovery.
 
+A panicked task stays registered, so `hasLiveTask` keeps reporting true
+while the job makes no progress.
+Reload directly in that case:
+the call detects the dead registration and respawns over it.
+
 ### A job must stop now
 
 Call `admin_abortSettlementTask` to stop the in-memory task.
@@ -80,6 +85,9 @@ because the task can exit on the cancellation
 without draining its command queue.
 Verify with `admin_getSettlementJob` that `hasLiveTask` is false
 before reloading.
+If `hasLiveTask` never turns false and the job shows no progress,
+the task has likely panicked; reload directly, the call respawns over
+a dead registration.
 
 ### External transaction or wrong recorded result
 


### PR DESCRIPTION
## What

Third and final slice of the settlement admin floor for #1675, stacked on #1684. It adds the two read methods and the operator runbook:

- `admin_listSettlementJobs()` returns one summary per stored job: certificate link, pending or completed status, a live-task flag, attempt count, the latest attempt, and the latest error if any. A pending job with `hasLiveTask: false` is wedged and needs a reload.
- `admin_getSettlementJob(job_id)` returns the full picture: job parameters (contract address, value, gas limit, calldata), every attempt with its recorded result, and the terminal result once completed. Unknown ids return the standard resource-not-found error.

An operator can now run the whole unstick cycle from the issue over RPC: list, inspect, abort, verify the task is gone, reload, verify it is back.

## Wire contract

The JSON shapes live in a new `settlement_admin` module at the RPC boundary; the domain types in `agglayer-types` stay serde-free. Attempt results serialize as internally tagged objects (`"type": "clientError" | "contractCall"`), client error kinds map through an exhaustive helper to stable camelCase tags instead of Debug output, and every shape is pinned by unit tests. Status and terminal result derive from the same storage read, so a response can never claim `completed` without carrying the result.

Reads are point-in-time, not transactional: a job completing mid-read can briefly render as pending without a live task. The method docs state this, and the mutation methods re-classify authoritatively, so acting on a stale row yields a clean error.

## Runbook

`docs/knowledge-base/src/settlement-operations.md` maps the operator scenarios from #1675 to concrete calls, with curl examples (valid ULIDs, checked against the Crockford alphabet) and the error-code reference. Scenarios 4 and 5 (external transactions, wrong recorded results) point at the mutation slice from #1663, which stays out of the floor.

## Tests

88 crate tests pass, 13 of them new: DTO unit tests including descending-order regression traps for the latest-attempt selection, and API tests against the real admin HTTP server and RocksDB store covering the empty list, a pending job with an errored attempt and certificate link, a completed job's terminal result mapping, the live-task flag through an RPC respawn, and unknown ids.

## Follow-ups carried from review (pre-existing, not in this PR)

- Reload-arm token parenting in the settlement service: an abort racing an in-task reload can be silently ignored.
- RAII deregistration for panicked settlement tasks: a panicked task wedges its control entry until node restart.
- One-line Display reformat of agglayer-storage's `Unexpected` error, which leaks source indentation onto the wire.
- Optional: a single-lock liveness snapshot in the list handler for a consistent `hasLiveTask` column.

Refs #1675. With this stack landed, the floor from the issue (reads plus task controls) is complete.