### PR TITLE
feat(settlement): classify task-control admin errors with RpcErrorCode

### DIFF
--- a/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
@@ -453,7 +453,7 @@ where
             .settlement_service
             .wait_for_settlement(job_id)
             .await
-            .map_err(|error| CertificateStatusError::SettlementError(error.to_string()))?;
+            .map_err(|error| CertificateStatusError::SettlementError(format!("{error:?}")))?;
 
         // Success is the only happy path; revert (and any future outcome) is an
         // error, so we never accidentally settle on a non-success result.

--- a/crates/agglayer-settlement-service/src/settlement_service.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service.rs
@@ -2,13 +2,15 @@ use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 use agglayer_config::settlement_service::{SettlementServiceConfig, SettlementTransactionConfig};
 use agglayer_storage::stores::{SettlementReader, SettlementWriter, StateReader, StateWriter};
-use agglayer_types::{CertificateId, SettlementJob, SettlementJobId, SettlementJobResult};
+use agglayer_types::{
+    CertificateId, RpcErrorCode, SettlementJob, SettlementJobId, SettlementJobResult,
+};
 use alloy::providers::{Provider, WalletProvider};
 use educe::Educe;
 use eyre::Context as _;
-use tokio::sync::{watch, Mutex};
+use tokio::sync::{mpsc, watch, Mutex};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::{
     settlement_task::{
@@ -240,13 +242,43 @@ impl<
         result_receiver
     }
 
+    /// Classifies why no in-memory task control exists for `job_id`, by
+    /// reading storage. Only called on error paths (no task control entry, or
+    /// a TOCTOU race against a just-finished task), so the extra storage
+    /// reads are irrelevant for cost.
+    async fn classify_missing_task(&self, job_id: SettlementJobId) -> eyre::Report {
+        let job = match self.store.get_settlement_job(&job_id) {
+            Ok(job) => job,
+            Err(error) => {
+                return eyre::Report::new(error).wrap_err(format!(
+                    "Failed to check settlement job existence for id {job_id}"
+                ));
+            }
+        };
+
+        if job.is_none() {
+            return eyre::eyre!("no settlement job found for id {job_id}")
+                .wrap_err(RpcErrorCode::NotFound);
+        }
+
+        match self.store.get_settlement_job_result(&job_id) {
+            Ok(Some(_)) => eyre::eyre!("settlement job {job_id} already completed")
+                .wrap_err(RpcErrorCode::AlreadyCompleted),
+            Ok(None) => eyre::eyre!("no live settlement task for pending job {job_id}")
+                .wrap_err(RpcErrorCode::NoLiveTask),
+            Err(error) => eyre::Report::new(error).wrap_err(format!(
+                "Failed to read settlement job terminal result for id {job_id}"
+            )),
+        }
+    }
+
     #[tracing::instrument(skip_all)]
     async fn task_control(&self, job_id: SettlementJobId) -> eyre::Result<TaskControlHandle> {
-        let task_controls = self.task_controls.lock().await;
-        let Some(task_control) = task_controls.get(&job_id) else {
-            eyre::bail!("No task control found for settlement task {job_id}");
-        };
-        Ok(task_control.clone())
+        let task_control = self.task_controls.lock().await.get(&job_id).cloned();
+        match task_control {
+            Some(task_control) => Ok(task_control),
+            None => Err(self.classify_missing_task(job_id).await),
+        }
     }
 
     #[tracing::instrument(skip_all)]
@@ -255,16 +287,21 @@ impl<
         job_id: SettlementJobId,
         command: TaskAdminCommand,
     ) -> eyre::Result<()> {
-        self.task_control(job_id)
-            .await?
-            .try_send(command)
-            .wrap_err_with(|| {
-                format!(
-                    "Failed to forward admin command to settlement task {job_id}, did it already \
-                     complete?"
-                )
-            })?;
-        Ok(())
+        let task_control = self.task_control(job_id).await?;
+        match task_control.try_send(command) {
+            Ok(()) => Ok(()),
+            Err(error @ mpsc::error::TrySendError::Full(_)) => Err(eyre::Report::new(error)
+                .wrap_err(format!(
+                    "Failed to forward admin command to settlement task {job_id}: admin command \
+                     queue full"
+                ))
+                .wrap_err(RpcErrorCode::Unavailable)),
+            // The task completed or died between the `task_control` lookup above and this
+            // `try_send` call; classify the same way as a missing task control entry.
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                Err(self.classify_missing_task(job_id).await)
+            }
+        }
     }
 
     #[tracing::instrument(skip_all)]
@@ -343,7 +380,10 @@ impl<
             ?job_id,
             "Settlement service invariant broken: pending job exists without running task"
         );
-        eyre::bail!("Pending settlement job {job_id} exists without a running task");
+        Err(
+            eyre::eyre!("Pending settlement job {job_id} exists without a running task")
+                .wrap_err(RpcErrorCode::NoLiveTask),
+        )
     }
 }
 

--- a/crates/agglayer-settlement-service/src/settlement_service.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service.rs
@@ -10,7 +10,7 @@ use educe::Educe;
 use eyre::Context as _;
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use crate::{
     settlement_task::{

--- a/crates/agglayer-settlement-service/src/settlement_service/tests.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service/tests.rs
@@ -2,8 +2,9 @@ use std::sync::{Arc, Mutex};
 
 use agglayer_storage::tests::mocks::MockStateStore;
 use agglayer_types::{
-    CertificateId, ContractCallOutcome, ContractCallResult, Digest, Nonce, SettlementAttemptNumber,
-    SettlementJob, SettlementJobId, SettlementJobResult, SettlementTxHash, B256, U256,
+    CertificateId, ContractCallOutcome, ContractCallResult, Digest, Nonce, RpcErrorCode,
+    SettlementAttemptNumber, SettlementJob, SettlementJobId, SettlementJobResult, SettlementTxHash,
+    B256, U256,
 };
 use alloy::{
     network::EthereumWallet,
@@ -227,7 +228,14 @@ async fn retrieve_fails_when_pending_job_has_no_running_task() {
     );
     let error = result.err().expect("result should be an error");
 
-    assert!(error.to_string().contains("exists without a running task"));
+    // The `RpcErrorCode` tag is the outermost context layer, so `Display`
+    // (`to_string()`) now renders just the tag; the original message is still
+    // in the chain, which the default `Debug` output includes.
+    assert!(format!("{error:?}").contains("exists without a running task"));
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::NoLiveTask)
+    );
 }
 
 #[tokio::test]
@@ -374,6 +382,251 @@ async fn request_new_settlement_records_certificate_link_before_job() {
     assert_eq!(
         ordering.lock().unwrap().as_slice(),
         ["write_link", "write_job"]
+    );
+}
+
+#[tokio::test]
+async fn admin_abort_unknown_job_is_tagged_not_found() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(20);
+
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(|_| Ok(None));
+
+    let service = mk_service(Arc::new(store)).await;
+
+    let error = service
+        .admin_abort_task(job_id)
+        .await
+        .expect_err("abort on unknown job should fail");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::NotFound)
+    );
+}
+
+#[tokio::test]
+async fn admin_abort_completed_job_is_tagged_already_completed() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(21);
+    let job = mk_job(21);
+    let result = mk_result(21, ContractCallOutcome::Success);
+
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job)));
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(result)));
+
+    let service = mk_service(Arc::new(store)).await;
+
+    let error = service
+        .admin_abort_task(job_id)
+        .await
+        .expect_err("abort on completed job should fail");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::AlreadyCompleted)
+    );
+}
+
+#[tokio::test]
+async fn admin_abort_pending_job_without_task_is_tagged_no_live_task() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(22);
+    let job = mk_job(22);
+
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job)));
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(|_| Ok(None));
+
+    let service = mk_service(Arc::new(store)).await;
+
+    let error = service
+        .admin_abort_task(job_id)
+        .await
+        .expect_err("abort on pending job without a task should fail");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::NoLiveTask)
+    );
+}
+
+#[tokio::test]
+async fn admin_reload_unknown_job_is_tagged_not_found() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(23);
+
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(|_| Ok(None));
+
+    let service = mk_service(Arc::new(store)).await;
+
+    let error = service
+        .admin_reload_and_restart_task(job_id)
+        .await
+        .expect_err("reload on unknown job should fail");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::NotFound)
+    );
+}
+
+#[tokio::test]
+async fn admin_reload_completed_job_is_tagged_already_completed() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(24);
+    let job = mk_job(24);
+    let result = mk_result(24, ContractCallOutcome::Success);
+
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job)));
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(result)));
+
+    let service = mk_service(Arc::new(store)).await;
+
+    let error = service
+        .admin_reload_and_restart_task(job_id)
+        .await
+        .expect_err("reload on completed job should fail");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::AlreadyCompleted)
+    );
+}
+
+#[tokio::test]
+async fn admin_reload_pending_job_without_task_is_tagged_no_live_task() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(25);
+    let job = mk_job(25);
+
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job)));
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(|_| Ok(None));
+
+    let service = mk_service(Arc::new(store)).await;
+
+    let error = service
+        .admin_reload_and_restart_task(job_id)
+        .await
+        .expect_err("reload on pending job without a task should fail");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::NoLiveTask)
+    );
+}
+
+#[tokio::test]
+async fn admin_reload_with_full_admin_channel_is_tagged_unavailable() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(26);
+
+    let service = mk_service(Arc::new(store)).await;
+    let (task_control_handle, _task_control) = TaskControlHandle::new(&service.cancellation_token);
+    while task_control_handle
+        .try_send(TaskAdminCommand::ReloadAndRestart)
+        .is_ok()
+    {}
+    service
+        .task_controls
+        .lock()
+        .await
+        .insert(job_id, task_control_handle);
+
+    let error = service
+        .admin_reload_and_restart_task(job_id)
+        .await
+        .expect_err("reload with a full admin command channel should fail");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::Unavailable)
+    );
+}
+
+#[tokio::test]
+async fn admin_reload_with_closed_admin_channel_is_classified_via_storage() {
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(27);
+    let job = mk_job(27);
+
+    store
+        .expect_get_settlement_job()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(move |_| Ok(Some(job)));
+    store
+        .expect_get_settlement_job_result()
+        .once()
+        .withf(move |requested_job_id| requested_job_id == &job_id)
+        .return_once(|_| Ok(None));
+
+    let service = mk_service(Arc::new(store)).await;
+    let (task_control_handle, task_control) = TaskControlHandle::new(&service.cancellation_token);
+    // Drop the receiver side so the admin channel is closed rather than full,
+    // simulating the task completing/dying between the lookup and the send.
+    drop(task_control);
+    service
+        .task_controls
+        .lock()
+        .await
+        .insert(job_id, task_control_handle);
+
+    let error = service
+        .admin_reload_and_restart_task(job_id)
+        .await
+        .expect_err("reload with a closed admin command channel should fail");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::NoLiveTask)
     );
 }
 

--- a/crates/agglayer-types/src/lib.rs
+++ b/crates/agglayer-types/src/lib.rs
@@ -11,6 +11,7 @@ mod error;
 mod local_network_state;
 pub mod network_info;
 mod proof_modes;
+mod rpc_error_code;
 mod settlement;
 
 #[cfg(feature = "testutils")]
@@ -28,6 +29,7 @@ pub use error::{CertificateStatusError, Error, SignerError};
 pub use local_network_state::{L1WitnessCtx, LocalNetworkStateData, PessimisticRootInput};
 pub use network_info::{NetworkInfo, NetworkStatus, NetworkType, SettledClaim};
 pub use proof_modes::{ExecutionMode, GenerationType};
+pub use rpc_error_code::RpcErrorCode;
 pub use settlement::{
     ClientError, ClientErrorType, ContractCallOutcome, ContractCallResult, Nonce,
     SettlementAttempt, SettlementAttemptNumber, SettlementAttemptResult, SettlementJob,

--- a/crates/agglayer-types/src/rpc_error_code.rs
+++ b/crates/agglayer-types/src/rpc_error_code.rs
@@ -1,0 +1,57 @@
+/// Semantic RPC error codes, tagged into `eyre` error chains at the point
+/// where a failure is classified, and mapped to wire error codes once,
+/// generically, at the RPC boundary (`report.downcast_ref::<RpcErrorCode>()`).
+///
+/// The `Display` strings are readable fragments — they render inside error
+/// chains ("failed to abort task: no live task: …"), so keep them lowercase
+/// prose, not mnemonics. Each variant corresponds to one distinct operator
+/// reaction; do not add a variant without one.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RpcErrorCode {
+    /// The referenced resource (job, attempt, attempt result, L1 tx) does
+    /// not exist — check the id.
+    #[error("not found")]
+    NotFound,
+
+    /// The job already has a terminal result and the operation was not
+    /// forced — pass force, or stop.
+    #[error("already completed")]
+    AlreadyCompleted,
+
+    /// The job has no terminal result but the operation requires one.
+    #[error("not completed")]
+    NotCompleted,
+
+    /// No in-memory task exists for this pending job. In the current stack
+    /// the recovery is a node restart (startup recovery respawns pending
+    /// jobs).
+    #[error("no live task")]
+    NoLiveTask,
+
+    /// The operation requires the job's task to be gone, but one is live —
+    /// wait for completion or abort first.
+    #[error("task still live")]
+    TaskStillLive,
+
+    /// Transient condition (task command queue full, L1 RPC unreachable) —
+    /// retry later.
+    #[error("unavailable")]
+    Unavailable,
+}
+
+impl RpcErrorCode {
+    /// Stable machine-readable tag for wire payloads.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Self::NotFound => "not-found",
+            Self::AlreadyCompleted => "already-completed",
+            Self::NotCompleted => "not-completed",
+            Self::NoLiveTask => "no-live-task",
+            Self::TaskStillLive => "task-still-live",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/agglayer-types/src/rpc_error_code/tests.rs
+++ b/crates/agglayer-types/src/rpc_error_code/tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+#[test]
+fn display_and_tag_are_pinned() {
+    let cases = [
+        (RpcErrorCode::NotFound, "not found", "not-found"),
+        (
+            RpcErrorCode::AlreadyCompleted,
+            "already completed",
+            "already-completed",
+        ),
+        (RpcErrorCode::NotCompleted, "not completed", "not-completed"),
+        (RpcErrorCode::NoLiveTask, "no live task", "no-live-task"),
+        (
+            RpcErrorCode::TaskStillLive,
+            "task still live",
+            "task-still-live",
+        ),
+        (RpcErrorCode::Unavailable, "unavailable", "unavailable"),
+    ];
+
+    for (code, expected_display, expected_tag) in cases {
+        assert_eq!(code.to_string(), expected_display);
+        assert_eq!(code.tag(), expected_tag);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the stack's error-classification backbone: a new `RpcErrorCode`
in `agglayer-types`, tagged into `eyre` chains at the point a failure is
classified (`.wrap_err(code)`) and discoverable anywhere downstream via
`report.downcast_ref::<RpcErrorCode>()` — when a report carries two tags,
the outermost wins. A later PR in this stack adds one generic mapper at the
JSON-RPC boundary from tag to wire code; untagged errors fall through to
internal error (fail-closed). Replaces the per-service `SettlementAdminError`
enum approach raised and rejected in the #1681 review discussion, per #838.

Applies the tag to the settlement service's *existing* admin task-control
paths (no RPC changes yet):

- Missing task control (`task_control`) is now classified by reading
  storage instead of a single generic bail: `NotFound` (no such job),
  `AlreadyCompleted` (terminal result recorded), or `NoLiveTask` (pending,
  no running task).
- The reload path's `try_send` failure is split by mpsc error kind:
  `Full` → tagged `Unavailable` (task alive, command queue saturated,
  safe to retry; the original mpsc error is kept in the chain), `Closed`
  → the task completed or died between the lookup and the send (TOCTOU),
  classified the same way as a missing task control entry.
- `retrieve_settlement_result`'s "pending job, no live task" invariant-break
  path is now tagged `NoLiveTask` too (message unchanged).

`NotCompleted` and `TaskStillLive` are defined now (so the vocabulary is
reviewed once) but get their first users in a later PR (force-remove).

Service layer + types only — no RPC changes, no new dependencies, no
storage changes. PR 3 of the stack consumes these tags at the RPC boundary.

Stacked on #1694.

Part of #1675. Refs #838.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy -p agglayer-types -p agglayer-settlement-service --all-targets -- -D warnings`
- [x] `cargo nextest run -p agglayer-types -p agglayer-settlement-service` (106/106)
- [x] `cargo check --workspace --tests --all-features`
- [x] `cargo nextest run --workspace --tests --all-features` (858/858, 11 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)