### PR TITLE
refactor(rpc): centralize application error codes

### DIFF
--- a/crates/agglayer-jsonrpc-api/src/error.rs
+++ b/crates/agglayer-jsonrpc-api/src/error.rs
@@ -2,41 +2,12 @@
 
 use agglayer_rate_limiting::RateLimited as RateLimitedError;
 use agglayer_rpc::CertificateSubmissionError;
+use agglayer_types::RpcErrorCode;
 use alloy::primitives::B256;
 use jsonrpsee::types::error::ErrorObjectOwned;
 use serde::Serialize;
 
 use crate::service::{self, SendTxError, TxStatusError};
-
-/// JsonRPC error codes.
-pub mod code {
-    /// Rollup is not registered.
-    pub const ROLLUP_NOT_REGISTERED: i32 = -10001;
-
-    /// Rollup signature verification failure.
-    pub const SIGNATURE_MISMATCH: i32 = -10002;
-
-    /// Proof or state validation failed.
-    pub const VALIDATION_FAILURE: i32 = -10003;
-
-    /// L1 settlement failure.
-    pub const SETTLEMENT_ERROR: i32 = -10004;
-
-    /// Transaction status retrieval error.
-    pub const STATUS_ERROR: i32 = -10005;
-
-    /// Error submitting a certificate.
-    pub const SEND_CERTIFICATE: i32 = -10006;
-
-    /// Transaction settlement has been rate limited.
-    pub const RATE_LIMITED: i32 = -10007;
-
-    /// Resource not found.
-    pub const RESOURCE_NOT_FOUND: i32 = -10008;
-
-    /// Method permanently disabled.
-    pub const METHOD_DISABLED: i32 = -10009;
-}
 
 #[derive(PartialEq, Eq, Serialize, Debug, Clone, thiserror::Error)]
 #[serde(rename_all = "kebab-case")]
@@ -165,15 +136,15 @@ impl Error {
         match self {
             Self::InvalidArgument(_) => jsonrpsee::types::error::INVALID_PARAMS_CODE,
             Self::Internal(_) => jsonrpsee::types::error::INTERNAL_ERROR_CODE,
-            Self::ResourceNotFound { .. } => code::RESOURCE_NOT_FOUND,
-            Self::RollupNotRegistered { .. } => code::ROLLUP_NOT_REGISTERED,
-            Self::SignatureMismatch { .. } => code::SIGNATURE_MISMATCH,
-            Self::Validation(_) => code::VALIDATION_FAILURE,
-            Self::Settlement(_) => code::SETTLEMENT_ERROR,
-            Self::Status(_) => code::STATUS_ERROR,
-            Self::SendCertificate { .. } => code::SEND_CERTIFICATE,
-            Self::RateLimited { .. } => code::RATE_LIMITED,
-            Self::MethodDisabled { .. } => code::METHOD_DISABLED,
+            Self::ResourceNotFound { .. } => RpcErrorCode::NotFound.code(),
+            Self::RollupNotRegistered { .. } => RpcErrorCode::RollupNotRegistered.code(),
+            Self::SignatureMismatch { .. } => RpcErrorCode::SignatureMismatch.code(),
+            Self::Validation(_) => RpcErrorCode::ValidationFailure.code(),
+            Self::Settlement(_) => RpcErrorCode::SettlementError.code(),
+            Self::Status(_) => RpcErrorCode::StatusError.code(),
+            Self::SendCertificate { .. } => RpcErrorCode::SendCertificate.code(),
+            Self::RateLimited { .. } => RpcErrorCode::RateLimited.code(),
+            Self::MethodDisabled { .. } => RpcErrorCode::MethodDisabled.code(),
         }
     }
 }

--- a/crates/agglayer-types/src/rpc_error_code.rs
+++ b/crates/agglayer-types/src/rpc_error_code.rs
@@ -1,49 +1,96 @@
-/// Semantic RPC error codes, tagged into `eyre` error chains at the point
-/// where a failure is classified, and mapped to wire error codes once,
-/// generically, at the RPC boundary (`report.downcast_ref::<RpcErrorCode>()`).
+/// Stable RPC error codes, usable both as wire values and as `eyre` tags.
 ///
 /// The `Display` strings are readable fragments — they render inside error
 /// chains ("failed to abort task: no live task: …"), so keep them lowercase
 /// prose, not mnemonics. Each variant corresponds to one distinct operator
-/// reaction; do not add a variant without one.
+/// reaction; do not add a variant without one. The `-10001..=-10009` range
+/// predates this rule: those variants mirror the historical public-API codes
+/// verbatim for wire compatibility.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[repr(i32)]
 pub enum RpcErrorCode {
-    /// The referenced resource (job, attempt, attempt result, L1 tx) does
-    /// not exist — check the id.
+    /// Rollup is not registered.
+    #[error("rollup not registered")]
+    RollupNotRegistered = -10001,
+
+    /// Rollup signature verification failed.
+    #[error("signature mismatch")]
+    SignatureMismatch = -10002,
+
+    /// Proof or state validation failed.
+    #[error("validation failure")]
+    ValidationFailure = -10003,
+
+    /// L1 settlement failed.
+    #[error("settlement error")]
+    SettlementError = -10004,
+
+    /// Transaction status retrieval failed.
+    #[error("status error")]
+    StatusError = -10005,
+
+    /// Certificate submission failed.
+    #[error("certificate submission failed")]
+    SendCertificate = -10006,
+
+    /// Transaction settlement was rate limited.
+    #[error("rate limited")]
+    RateLimited = -10007,
+
+    /// The referenced resource does not exist — check the id. Covers both
+    /// the admin task-control API (job, attempt, attempt result, L1 tx) and
+    /// the public API (certificate header).
     #[error("not found")]
-    NotFound,
+    NotFound = -10008,
+
+    /// Method is permanently disabled.
+    #[error("method disabled")]
+    MethodDisabled = -10009,
 
     /// The job already has a terminal result and the operation was not
     /// forced — pass force, or stop.
     #[error("already completed")]
-    AlreadyCompleted,
+    AlreadyCompleted = -10010,
 
     /// The job has no terminal result but the operation requires one.
     #[error("not completed")]
-    NotCompleted,
+    NotCompleted = -10011,
 
     /// No in-memory task exists for this pending job. In the current stack
     /// the recovery is a node restart (startup recovery respawns pending
     /// jobs).
     #[error("no live task")]
-    NoLiveTask,
+    NoLiveTask = -10012,
 
     /// The operation requires the job's task to be gone, but one is live —
     /// wait for completion or abort first.
     #[error("task still live")]
-    TaskStillLive,
+    TaskStillLive = -10013,
 
     /// Transient condition (task command queue full, L1 RPC unreachable) —
     /// retry later.
     #[error("unavailable")]
-    Unavailable,
+    Unavailable = -10014,
 }
 
 impl RpcErrorCode {
+    /// Stable numeric JSON-RPC error code.
+    pub const fn code(self) -> i32 {
+        self as i32
+    }
+
     /// Stable machine-readable tag for wire payloads.
-    pub fn tag(&self) -> &'static str {
+    pub const fn tag(&self) -> &'static str {
         match self {
+            Self::RollupNotRegistered => "rollup-not-registered",
+            Self::SignatureMismatch => "signature-mismatch",
+            Self::ValidationFailure => "validation-failure",
+            Self::SettlementError => "settlement-error",
+            Self::StatusError => "status-error",
+            Self::SendCertificate => "send-certificate",
+            Self::RateLimited => "rate-limited",
             Self::NotFound => "not-found",
+            Self::MethodDisabled => "method-disabled",
             Self::AlreadyCompleted => "already-completed",
             Self::NotCompleted => "not-completed",
             Self::NoLiveTask => "no-live-task",

--- a/crates/agglayer-types/src/rpc_error_code/tests.rs
+++ b/crates/agglayer-types/src/rpc_error_code/tests.rs
@@ -3,24 +3,90 @@ use super::*;
 #[test]
 fn display_and_tag_are_pinned() {
     let cases = [
-        (RpcErrorCode::NotFound, "not found", "not-found"),
+        (
+            RpcErrorCode::RollupNotRegistered,
+            "rollup not registered",
+            "rollup-not-registered",
+            -10001,
+        ),
+        (
+            RpcErrorCode::SignatureMismatch,
+            "signature mismatch",
+            "signature-mismatch",
+            -10002,
+        ),
+        (
+            RpcErrorCode::ValidationFailure,
+            "validation failure",
+            "validation-failure",
+            -10003,
+        ),
+        (
+            RpcErrorCode::SettlementError,
+            "settlement error",
+            "settlement-error",
+            -10004,
+        ),
+        (
+            RpcErrorCode::StatusError,
+            "status error",
+            "status-error",
+            -10005,
+        ),
+        (
+            RpcErrorCode::SendCertificate,
+            "certificate submission failed",
+            "send-certificate",
+            -10006,
+        ),
+        (
+            RpcErrorCode::RateLimited,
+            "rate limited",
+            "rate-limited",
+            -10007,
+        ),
+        (RpcErrorCode::NotFound, "not found", "not-found", -10008),
+        (
+            RpcErrorCode::MethodDisabled,
+            "method disabled",
+            "method-disabled",
+            -10009,
+        ),
         (
             RpcErrorCode::AlreadyCompleted,
             "already completed",
             "already-completed",
+            -10010,
         ),
-        (RpcErrorCode::NotCompleted, "not completed", "not-completed"),
-        (RpcErrorCode::NoLiveTask, "no live task", "no-live-task"),
+        (
+            RpcErrorCode::NotCompleted,
+            "not completed",
+            "not-completed",
+            -10011,
+        ),
+        (
+            RpcErrorCode::NoLiveTask,
+            "no live task",
+            "no-live-task",
+            -10012,
+        ),
         (
             RpcErrorCode::TaskStillLive,
             "task still live",
             "task-still-live",
+            -10013,
         ),
-        (RpcErrorCode::Unavailable, "unavailable", "unavailable"),
+        (
+            RpcErrorCode::Unavailable,
+            "unavailable",
+            "unavailable",
+            -10014,
+        ),
     ];
 
-    for (code, expected_display, expected_tag) in cases {
+    for (code, expected_display, expected_tag, expected_code) in cases {
         assert_eq!(code.to_string(), expected_display);
         assert_eq!(code.tag(), expected_tag);
+        assert_eq!(code.code(), expected_code);
     }
 }


### PR DESCRIPTION
Centralizes application JSON-RPC error-code ownership in
`agglayer-types::RpcErrorCode`.

Moves the historical `-10001..=-10009` values out of
`agglayer-jsonrpc-api`, preserves their existing wire mappings, and assigns
the settlement task-control classifications distinct values from `-10010`
through `-10014`.

Pins each code's numeric value, display text, and wire tag for use by the
follow-up admin RPC adapters.