### PR TITLE
fix: redact configured L1 RPC endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "tower 0.4.13",
  "tower-http",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5719,7 +5719,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "test-log",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/crates/agglayer-config/src/l1.rs
+++ b/crates/agglayer-config/src/l1.rs
@@ -8,6 +8,8 @@ use url::Url;
 ///
 /// Formatting never exposes the endpoint because any URL component may contain
 /// credentials. Use [`Self::expose_url`] only when constructing a transport.
+// Serde stays transparent so configuration files preserve the endpoint;
+// Display and Debug are the redaction boundary for formatted values.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct L1RpcUrl(Url);

--- a/crates/agglayer-config/src/l1.rs
+++ b/crates/agglayer-config/src/l1.rs
@@ -7,9 +7,11 @@ use url::Url;
 /// A configured L1 RPC endpoint.
 ///
 /// Formatting never exposes the endpoint because any URL component may contain
-/// credentials. Use [`Self::expose_url`] only when constructing a transport.
-// Serde stays transparent so configuration files preserve the endpoint;
-// Display and Debug are the redaction boundary for formatted values.
+/// credentials. [`Display`](std::fmt::Display) and [`Debug`](std::fmt::Debug)
+/// are redacted; serialization intentionally preserves the raw endpoint for
+/// configuration compatibility and must be treated as secret-bearing. Use
+/// [`Self::expose_url`] only when constructing a transport, and do not log
+/// serialized configuration.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct L1RpcUrl(Url);

--- a/crates/agglayer-config/src/l1.rs
+++ b/crates/agglayer-config/src/l1.rs
@@ -1,17 +1,58 @@
-use std::{num::NonZeroU64, time::Duration};
+use std::{fmt, num::NonZeroU64, str::FromStr, time::Duration};
 
 use agglayer_primitives::Address;
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+/// A configured L1 RPC endpoint.
+///
+/// Formatting never exposes the endpoint because any URL component may contain
+/// credentials. Use [`Self::expose_url`] only when constructing a transport.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct L1RpcUrl(Url);
+
+impl L1RpcUrl {
+    /// Exposes the endpoint for transport construction.
+    pub fn expose_url(&self) -> &Url {
+        &self.0
+    }
+}
+
+impl fmt::Display for L1RpcUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+impl fmt::Debug for L1RpcUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl FromStr for L1RpcUrl {
+    type Err = url::ParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value.parse().map(Self)
+    }
+}
+
+impl From<Url> for L1RpcUrl {
+    fn from(value: Url) -> Self {
+        Self(value)
+    }
+}
 
 /// The L1 configuration.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct L1 {
     pub chain_id: u64,
-    pub node_url: Url,
+    pub node_url: L1RpcUrl,
     #[serde(default = "default_ws_node_url")]
-    pub ws_node_url: Url,
+    pub ws_node_url: L1RpcUrl,
     #[serde(
         default = "default_connect_attempt_timeout",
         with = "crate::with::HumanDuration"
@@ -63,10 +104,68 @@ impl Default for L1 {
     }
 }
 
-fn default_ws_node_url() -> Url {
+fn default_ws_node_url() -> L1RpcUrl {
     "ws://zkevm-mock-l1-network:8546".parse().unwrap()
 }
 
 const fn default_connect_attempt_timeout() -> Duration {
     Duration::from_secs(3)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOKENS: [&str; 6] = [
+        "user-secret-803",
+        "password-secret-803",
+        "host-secret-803",
+        "path-secret-803",
+        "query-secret-803",
+        "fragment-secret-803",
+    ];
+
+    fn secret_url(scheme: &str) -> L1RpcUrl {
+        Url::parse(&format!(
+            "{scheme}://{}:{}@{}.example/{}/?key={}#{}",
+            TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3], TOKENS[4], TOKENS[5]
+        ))
+        .unwrap()
+        .into()
+    }
+
+    #[test]
+    fn l1_rpc_url_formatting_is_redacted() {
+        let node_url = secret_url("https");
+        assert_eq!(node_url.to_string(), "<redacted>");
+        assert_eq!(format!("{node_url:?}"), "<redacted>");
+
+        let mut l1 = L1::default();
+        l1.node_url = node_url;
+        l1.ws_node_url = secret_url("wss");
+
+        let l1_debug = format!("{l1:?}");
+        let mut config = crate::Config::default();
+        config.l1 = l1;
+        let config_debug = format!("{config:?}");
+
+        for token in TOKENS {
+            assert!(!l1_debug.contains(token));
+            assert!(!config_debug.contains(token));
+        }
+    }
+
+    #[test]
+    fn l1_rpc_url_serde_is_transparent() {
+        let mut l1 = L1::default();
+        l1.node_url = secret_url("https");
+        l1.ws_node_url = secret_url("wss");
+
+        let serialized = toml::to_string(&l1).unwrap();
+        assert!(serialized.contains(l1.node_url.expose_url().as_str()));
+        assert!(serialized.contains(l1.ws_node_url.expose_url().as_str()));
+
+        let deserialized: L1 = toml::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, l1);
+    }
 }

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -36,7 +36,7 @@ mod with;
 
 pub use auth::{AuthConfig, GcpKmsConfig, LocalConfig, PrivateKey};
 pub use epoch::Epoch;
-pub use l1::L1;
+pub use l1::{L1RpcUrl, L1};
 pub use l2::L2;
 pub use log::Log;
 pub use multiplier::Multiplier;

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -34,6 +34,7 @@ tonic.workspace = true
 tower-http = { version = "0.6.8", features = ["full"] }
 tower.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+tracing-log = "0.2"
 tracing.workspace = true
 
 agglayer-aggregator-notifier.workspace = true
@@ -66,7 +67,6 @@ rstest.workspace = true
 serde_json.workspace = true
 test-log.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
-tracing-log = "0.2"
 
 agglayer-jsonrpc-api = { workspace = true, features = ["testutils"] }
 agglayer-config = { workspace = true, features = ["testutils"] }

--- a/crates/agglayer-node/Cargo.toml
+++ b/crates/agglayer-node/Cargo.toml
@@ -66,6 +66,7 @@ rstest.workspace = true
 serde_json.workspace = true
 test-log.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
+tracing-log = "0.2"
 
 agglayer-jsonrpc-api = { workspace = true, features = ["testutils"] }
 agglayer-config = { workspace = true, features = ["testutils"] }

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -26,6 +26,9 @@ use url_redact::UrlRedactLayer;
 /// Logging initialization is process-wide: the first successful logging
 /// initialization owns the configuration, later starts reuse it, and startup
 /// fails if Agglayer cannot install its endpoint-redaction policy.
+/// Embedding callers must not race this initialization with another
+/// process-global tracing subscriber or `log` logger; those one-shot globals
+/// are independent, and pre-existing ownership is rejected.
 ///
 /// This function returns on fatal error or after graceful shutdown has
 /// completed.

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -23,6 +23,10 @@ use url_redact::UrlRedactLayer;
 /// Starting by a Tokio runtime which can be used by the different components.
 /// The configuration file is parsed and used to configure the node.
 ///
+/// Logging initialization is process-wide: the first successful logging
+/// initialization owns the configuration, later starts reuse it, and startup
+/// fails if Agglayer cannot install its endpoint-redaction policy.
+///
 /// This function returns on fatal error or after graceful shutdown has
 /// completed.
 pub fn main(
@@ -55,10 +59,15 @@ pub fn main(
 
     // Initialize the logger. The logging module permits repeated starts only
     // after Agglayer has installed its endpoint-redaction policy itself.
-    if let Err(error) = logging::tracing(&config.log) {
+    let dispatch = logging::tracing(&config.log).map_err(|error| {
         eprintln!("Failed to initialize logger: {error:?}");
-        return Err(error);
-    }
+        error
+    })?;
+
+    // The global subscriber is only a fallback. Keep Agglayer's dispatcher active
+    // while this thread polls the startup and shutdown futures so an embedding
+    // caller's thread-local subscriber cannot bypass endpoint redaction.
+    let _dispatch_guard = tracing::dispatcher::set_default(&dispatch);
     info!("Tracing initialized successfully.");
 
     if let Some(outbound) = &config.outbound {

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -53,24 +53,13 @@ pub fn main(
         bail!("Received cancellation signal before starting the node.");
     }
 
-    // Initialize the logger
-    match logging::tracing(&config.log) {
-        Ok(()) => {
-            info!("Tracing initialized successfully.");
-        }
-        Err(e)
-            if e.to_string()
-                .contains("trace dispatcher has already been set") =>
-        {
-            // This is a common case in integration tests where the logger is initialized
-            // multiple times. We can safely ignore this error.
-            debug!("Logger already initialized, ignoring error: {e}");
-        }
-        Err(e) => {
-            eprintln!("Failed to initialize logger: {e:?}");
-            return Err(e);
-        }
+    // Initialize the logger. The logging module permits repeated starts only
+    // after Agglayer has installed its endpoint-redaction policy itself.
+    if let Err(error) = logging::tracing(&config.log) {
+        eprintln!("Failed to initialize logger: {error:?}");
+        return Err(error);
     }
+    info!("Tracing initialized successfully.");
 
     if let Some(outbound) = &config.outbound {
         warn!("{}", outbound.ignored_config_warning());

--- a/crates/agglayer-node/src/lib.rs
+++ b/crates/agglayer-node/src/lib.rs
@@ -28,7 +28,10 @@ use url_redact::UrlRedactLayer;
 /// fails if Agglayer cannot install its endpoint-redaction policy.
 /// Embedding callers must not race this initialization with another
 /// process-global tracing subscriber or `log` logger; those one-shot globals
-/// are independent, and pre-existing ownership is rejected.
+/// are independent, and pre-existing ownership is rejected. Agglayer claims
+/// the tracing dispatcher before installing its `log` bridge; if the bridge is
+/// already owned, startup still fails closed and Agglayer's tracing policy
+/// remains installed for the process.
 ///
 /// This function returns on fatal error or after graceful shutdown has
 /// completed.

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -356,15 +356,8 @@ mod tests {
         let _ = tracing_log::LogTracer::init();
         tracing_log::log::set_max_level(tracing_log::log::LevelFilter::Trace);
 
-        let filter = || {
-            EnvFilter::new(
-                "off,alloy_transport_http::reqwest_transport=debug,\
-                 tungstenite::handshake::client=trace,reqwest::connect=debug,\
-                 hyper_util::client::legacy::connect::http=trace,\
-                 hyper_util::client::legacy::pool=trace,agglayer_node::node=error",
-            )
-        };
-        let secrets = [
+        let filter = || EnvFilter::new("trace");
+        let baseline_observed_leaks = [
             HTTP_HOST_SECRET,
             HTTP_PATH_SECRET,
             HTTP_QUERY_SECRET,
@@ -372,7 +365,9 @@ mod tests {
             WS_QUERY_SECRET,
             WS_BASIC_AUTH,
         ];
-        let sensitive_components = [
+        // Tungstenite encodes userinfo in `WS_BASIC_AUTH`; the raw values remain
+        // absence-only checks for a future dependency regression.
+        let all_sensitive_endpoint_components = [
             HTTP_HOST_SECRET,
             HTTP_PATH_SECRET,
             HTTP_QUERY_SECRET,
@@ -398,7 +393,7 @@ mod tests {
                 filter(),
             );
             let output = capture_actual_dependency_records(unfiltered, capture).await;
-            for secret in secrets {
+            for secret in baseline_observed_leaks {
                 assert!(output.contains(secret), "missing {secret:?} in {output}");
             }
             for target in sensitive_targets {
@@ -412,7 +407,7 @@ mod tests {
             let capture = Capture::default();
             let filtered = subscriber(format, BoxMakeWriter::new(capture.clone()), filter());
             let output = capture_actual_dependency_records(filtered, capture).await;
-            for secret in sensitive_components {
+            for secret in all_sensitive_endpoint_components {
                 assert!(!output.contains(secret), "found {secret:?} in {output}");
             }
             assert!(

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -34,8 +34,8 @@ impl InitializationState {
 // Reject pinned records that expose a full endpoint, HTTP authority, WebSocket
 // handshake request, or TLS server name before any user-configurable formatting
 // layer. The dependencies do not give every sensitive and benign record
-// distinct metadata, so same-target records at the filtered levels are also
-// suppressed.
+// distinct metadata, so same-target records at the filtered levels—including
+// Hyper legacy-client WARN events—are also suppressed.
 fn is_dependency_record_allowed(metadata: &Metadata<'_>) -> bool {
     let alloy_url_span = metadata.is_span()
         && metadata.target() == "alloy_transport_http::reqwest_transport"
@@ -111,6 +111,19 @@ fn subscriber(
     tracing_subscriber::Registry::default().with(layer)
 }
 
+fn global_tracing_subscriber_is_installed() -> bool {
+    // `has_been_set` also reports thread-local defaults. Probe from a fresh
+    // thread so an embedding caller's scoped subscriber does not prevent
+    // Agglayer from installing its global fallback.
+    std::thread::spawn(|| {
+        tracing::dispatcher::get_default(|dispatch| {
+            !dispatch.is::<tracing::subscriber::NoSubscriber>()
+        })
+    })
+    .join()
+    .expect("global tracing subscriber probe thread panicked")
+}
+
 pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<tracing::Dispatch> {
     if let Some(state) = SUBSCRIBER_STATE.get() {
         return state.dispatch();
@@ -128,6 +141,18 @@ pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<tracing::Di
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| config.level.into());
     let dispatch =
         tracing::Dispatch::new(subscriber(config.format, writer.as_make_writer(), filter));
+
+    if global_tracing_subscriber_is_installed() {
+        let error = String::from(
+            "Agglayer logging requires its endpoint-redaction policy, but the global tracing \
+             subscriber is already initialized",
+        );
+        let _ = SUBSCRIBER_STATE.set(InitializationState::TracingSubscriberConflict { error });
+        return SUBSCRIBER_STATE
+            .get()
+            .expect("logging initialization state was just stored")
+            .dispatch();
+    }
 
     // Initialize the log bridge before mutating the global tracing dispatcher.
     // This keeps a pre-existing log logger from leaving an Agglayer subscriber
@@ -519,12 +544,18 @@ mod tests {
         match env::var(CHILD_MODE).as_deref() {
             Ok("preinstalled") => {
                 tracing::subscriber::set_global_default(tracing_subscriber::registry()).unwrap();
+                tracing_log::log::set_max_level(tracing_log::log::LevelFilter::Off);
                 let error = tracing(&agglayer_config::Log::default()).unwrap_err();
                 assert!(error
                     .to_string()
                     .contains("global tracing subscriber is already initialized"));
                 let retry = tracing(&agglayer_config::Log::default()).unwrap_err();
                 assert_eq!(error.to_string(), retry.to_string());
+                assert!(tracing_log::log::set_logger(&PREINSTALLED_LOGGER).is_ok());
+                assert_eq!(
+                    tracing_log::log::max_level(),
+                    tracing_log::log::LevelFilter::Off
+                );
             }
             Ok("preinstalled_log") => {
                 tracing_log::log::set_logger(&PREINSTALLED_LOGGER).unwrap();
@@ -535,6 +566,34 @@ mod tests {
                 let retry = tracing(&agglayer_config::Log::default()).unwrap_err();
                 assert_eq!(error.to_string(), retry.to_string());
                 assert!(!tracing::dispatcher::has_been_set());
+            }
+            Ok("main_scoped") => {
+                let metrics_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+                let metrics_addr = metrics_listener.local_addr().unwrap();
+                let config_path = env::temp_dir()
+                    .join(format!("agglayer-main-scoped-{}.toml", std::process::id()));
+                std::fs::write(
+                    &config_path,
+                    format!("[telemetry]\nprometheus-addr = \"{metrics_addr}\"\n"),
+                )
+                .unwrap();
+
+                let capture = Capture::default();
+                let outer = tracing::Dispatch::new(subscriber_without_endpoint_policy(
+                    LogFormat::Pretty,
+                    BoxMakeWriter::new(capture.clone()),
+                    EnvFilter::new("trace"),
+                ));
+                let outer_guard = tracing::dispatcher::set_default(&outer);
+                let error = crate::main(config_path.clone(), "test", None).unwrap_err();
+                drop(outer_guard);
+                drop(metrics_listener);
+                _ = std::fs::remove_file(config_path);
+
+                assert!(error.to_string().contains("Unable to bind metrics server"));
+                let output = capture.output();
+                assert!(!output.contains("Tracing initialized successfully"));
+                assert!(!output.contains("Starting metrics server"));
             }
             Ok("repeated") => {
                 env::remove_var("RUST_LOG");
@@ -601,7 +660,13 @@ mod tests {
                 });
             }
             _ => {
-                for mode in ["preinstalled", "preinstalled_log", "repeated", "scoped"] {
+                for mode in [
+                    "preinstalled",
+                    "preinstalled_log",
+                    "main_scoped",
+                    "repeated",
+                    "scoped",
+                ] {
                     let status = Command::new(env::current_exe().unwrap())
                         .arg("--exact")
                         .arg("logging::tests::global_subscriber_contract_is_enforced")

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -14,8 +14,16 @@ static SUBSCRIBER_INIT: Mutex<()> = Mutex::new(());
 
 enum InitializationState {
     Installed(tracing::Dispatch),
-    LogBridgeConflict { error: String },
-    TracingSubscriberConflict { error: String },
+    // The tracing dispatcher is process-global and cannot be rolled back when
+    // installing the independent `log` bridge fails. Retain it so the sticky
+    // failure state reflects the resources Agglayer actually owns.
+    LogBridgeConflict {
+        _dispatch: tracing::Dispatch,
+        error: String,
+    },
+    TracingSubscriberConflict {
+        error: String,
+    },
 }
 
 static SUBSCRIBER_STATE: OnceLock<InitializationState> = OnceLock::new();
@@ -24,7 +32,7 @@ impl InitializationState {
     fn dispatch(&self) -> eyre::Result<tracing::Dispatch> {
         match self {
             Self::Installed(dispatch) => Ok(dispatch.clone()),
-            Self::LogBridgeConflict { error } | Self::TracingSubscriberConflict { error } => {
+            Self::LogBridgeConflict { error, .. } | Self::TracingSubscriberConflict { error } => {
                 Err(eyre::eyre!("{error}"))
             }
         }
@@ -111,19 +119,6 @@ fn subscriber(
     tracing_subscriber::Registry::default().with(layer)
 }
 
-fn global_tracing_subscriber_is_installed() -> bool {
-    // `has_been_set` also reports thread-local defaults. Probe from a fresh
-    // thread so an embedding caller's scoped subscriber does not prevent
-    // Agglayer from installing its global fallback.
-    std::thread::spawn(|| {
-        tracing::dispatcher::get_default(|dispatch| {
-            !dispatch.is::<tracing::subscriber::NoSubscriber>()
-        })
-    })
-    .join()
-    .expect("global tracing subscriber probe thread panicked")
-}
-
 pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<tracing::Dispatch> {
     if let Some(state) = SUBSCRIBER_STATE.get() {
         return state.dispatch();
@@ -142,36 +137,11 @@ pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<tracing::Di
     let dispatch =
         tracing::Dispatch::new(subscriber(config.format, writer.as_make_writer(), filter));
 
-    if global_tracing_subscriber_is_installed() {
-        let error = String::from(
-            "Agglayer logging requires its endpoint-redaction policy, but the global tracing \
-             subscriber is already initialized",
-        );
-        let _ = SUBSCRIBER_STATE.set(InitializationState::TracingSubscriberConflict { error });
-        return SUBSCRIBER_STATE
-            .get()
-            .expect("logging initialization state was just stored")
-            .dispatch();
-    }
-
-    // Initialize the log bridge before mutating the global tracing dispatcher.
-    // This keeps a pre-existing log logger from leaving an Agglayer subscriber
-    // permanently installed after initialization reports an error.
-    if let Err(error) = tracing_log::LogTracer::builder()
-        .with_max_level(tracing_log::log::LevelFilter::Trace)
-        .init()
-    {
-        let error = format!(
-            "Agglayer logging requires its endpoint-redaction policy, but the global log logger \
-             is already initialized: {error}"
-        );
-        let _ = SUBSCRIBER_STATE.set(InitializationState::LogBridgeConflict { error });
-        return SUBSCRIBER_STATE
-            .get()
-            .expect("logging initialization state was just stored")
-            .dispatch();
-    }
-
+    // Claim the tracing dispatcher first. Unlike a fresh-thread probe, this
+    // correctly rejects every pre-existing global subscriber, including an
+    // explicitly installed `NoSubscriber`, without rejecting a caller's
+    // thread-local default. This ordering also preserves a host-owned `log`
+    // facade when tracing ownership is already taken.
     if let Err(error) = tracing::dispatcher::set_global_default(dispatch.clone()) {
         let error = format!(
             "Agglayer logging requires its endpoint-redaction policy, but the global tracing \
@@ -184,9 +154,32 @@ pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<tracing::Di
             .dispatch();
     }
 
+    // The two process-global facilities are not transactional. If the host
+    // already owns `log`, retain the Agglayer-owned tracing dispatch in the
+    // sticky failure state rather than retrying as if initialization were
+    // untouched. Startup still fails closed because the host logger may route
+    // `log` records outside the endpoint-redaction policy.
+    if let Err(error) = tracing_log::LogTracer::builder()
+        .with_max_level(tracing_log::log::LevelFilter::Trace)
+        .init()
+    {
+        let error = format!(
+            "Agglayer logging requires its endpoint-redaction policy, but the global log logger \
+             is already initialized: {error}"
+        );
+        let _ = SUBSCRIBER_STATE.set(InitializationState::LogBridgeConflict {
+            _dispatch: dispatch,
+            error,
+        });
+        return SUBSCRIBER_STATE
+            .get()
+            .expect("logging initialization state was just stored")
+            .dispatch();
+    }
+
     tracing_log::log::set_max_level(tracing::level_filters::LevelFilter::current().as_log());
 
-    let _ = SUBSCRIBER_STATE.set(InitializationState::Installed(dispatch.clone()));
+    let _ = SUBSCRIBER_STATE.set(InitializationState::Installed(dispatch));
 
     Ok(dispatch)
 }
@@ -559,13 +552,34 @@ mod tests {
             }
             Ok("preinstalled_log") => {
                 tracing_log::log::set_logger(&PREINSTALLED_LOGGER).unwrap();
+                tracing_log::log::set_max_level(tracing_log::log::LevelFilter::Off);
                 let error = tracing(&agglayer_config::Log::default()).unwrap_err();
                 assert!(error
                     .to_string()
                     .contains("global log logger is already initialized"));
                 let retry = tracing(&agglayer_config::Log::default()).unwrap_err();
                 assert_eq!(error.to_string(), retry.to_string());
-                assert!(!tracing::dispatcher::has_been_set());
+                assert!(tracing::dispatcher::has_been_set());
+                assert_eq!(
+                    tracing_log::log::max_level(),
+                    tracing_log::log::LevelFilter::Off
+                );
+            }
+            Ok("preinstalled_no_subscriber") => {
+                tracing::subscriber::set_global_default(tracing::subscriber::NoSubscriber::new())
+                    .unwrap();
+                tracing_log::log::set_max_level(tracing_log::log::LevelFilter::Off);
+                let error = tracing(&agglayer_config::Log::default()).unwrap_err();
+                assert!(error
+                    .to_string()
+                    .contains("global tracing subscriber is already initialized"));
+                let retry = tracing(&agglayer_config::Log::default()).unwrap_err();
+                assert_eq!(error.to_string(), retry.to_string());
+                assert!(tracing_log::log::set_logger(&PREINSTALLED_LOGGER).is_ok());
+                assert_eq!(
+                    tracing_log::log::max_level(),
+                    tracing_log::log::LevelFilter::Off
+                );
             }
             Ok("main_scoped") => {
                 let metrics_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -663,6 +677,7 @@ mod tests {
                 for mode in [
                     "preinstalled",
                     "preinstalled_log",
+                    "preinstalled_no_subscriber",
                     "main_scoped",
                     "repeated",
                     "scoped",

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -179,7 +179,7 @@ pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<tracing::Di
 
     tracing_log::log::set_max_level(tracing::level_filters::LevelFilter::current().as_log());
 
-    let _ = SUBSCRIBER_STATE.set(InitializationState::Installed(dispatch));
+    let _ = SUBSCRIBER_STATE.set(InitializationState::Installed(dispatch.clone()));
 
     Ok(dispatch)
 }
@@ -553,17 +553,38 @@ mod tests {
             Ok("preinstalled_log") => {
                 tracing_log::log::set_logger(&PREINSTALLED_LOGGER).unwrap();
                 tracing_log::log::set_max_level(tracing_log::log::LevelFilter::Off);
-                let error = tracing(&agglayer_config::Log::default()).unwrap_err();
+                env::set_var("RUST_LOG", "trace");
+                let output_path = env::temp_dir().join(format!(
+                    "agglayer-preinstalled-log-{}.log",
+                    std::process::id()
+                ));
+                let config = agglayer_config::Log {
+                    level: agglayer_config::log::LogLevel::Trace,
+                    outputs: vec![agglayer_config::log::LogOutput::File(output_path.clone())],
+                    ..Default::default()
+                };
+                let error = tracing(&config).unwrap_err();
                 assert!(error
                     .to_string()
                     .contains("global log logger is already initialized"));
-                let retry = tracing(&agglayer_config::Log::default()).unwrap_err();
+                let retry = tracing(&config).unwrap_err();
                 assert_eq!(error.to_string(), retry.to_string());
                 assert!(tracing::dispatcher::has_been_set());
                 assert_eq!(
                     tracing_log::log::max_level(),
                     tracing_log::log::LevelFilter::Off
                 );
+
+                tracing::debug!(
+                    target: "reqwest::connect",
+                    host = HTTP_HOST_SECRET,
+                    "preinstalled-log-sensitive"
+                );
+                tracing::info!(target: "safe_control", "preinstalled-log-control");
+                let output = std::fs::read_to_string(&output_path).unwrap();
+                assert!(!output.contains(HTTP_HOST_SECRET));
+                assert!(output.contains("preinstalled-log-control"));
+                _ = std::fs::remove_file(output_path);
             }
             Ok("preinstalled_no_subscriber") => {
                 tracing::subscriber::set_global_default(tracing::subscriber::NoSubscriber::new())

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -278,6 +278,16 @@ mod tests {
         }
     }
 
+    fn remove_stale_log_output(path: &std::path::Path) {
+        if let Err(error) = std::fs::remove_file(path) {
+            assert_eq!(
+                error.kind(),
+                std::io::ErrorKind::NotFound,
+                "failed to remove stale log output {path:?}: {error}"
+            );
+        }
+    }
+
     // Mirrors pinned dependency callsites; re-audit these identities on upgrade.
     fn emit_dependency_records() {
         let span = tracing::debug_span!(
@@ -558,6 +568,7 @@ mod tests {
                     "agglayer-preinstalled-log-{}.log",
                     std::process::id()
                 ));
+                remove_stale_log_output(&output_path);
                 let config = agglayer_config::Log {
                     level: agglayer_config::log::LogLevel::Trace,
                     outputs: vec![agglayer_config::log::LogOutput::File(output_path.clone())],
@@ -636,6 +647,7 @@ mod tests {
                     "agglayer-logging-first-config-{}.log",
                     std::process::id()
                 ));
+                remove_stale_log_output(&output_path);
                 let first = agglayer_config::Log {
                     level: agglayer_config::log::LogLevel::Error,
                     outputs: vec![agglayer_config::log::LogOutput::File(output_path.clone())],

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -72,12 +72,13 @@ pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<()> {
 mod tests {
     use std::{
         io,
+        num::NonZeroU64,
         sync::{Arc, Mutex},
         time::Duration,
     };
 
+    use agglayer_clock::BlockClock;
     use alloy::{
-        pubsub::PubSubConnect,
         rpc::json_rpc::{Id, Request, RequestPacket},
         transports::{http::Http, ws::WsConnect},
     };
@@ -96,9 +97,12 @@ mod tests {
     const TUNGSTENITE_SECRET: &str = "tungstenite-request-secret-803";
     const HTTP_PATH_SECRET: &str = "http-path-secret-803";
     const HTTP_QUERY_SECRET: &str = "http-query-secret-803";
+    const WS_USERNAME: &str = "ws-user-803";
+    const WS_PASSWORD: &str = "ws-pass-803";
     const WS_PATH_SECRET: &str = "ws-path-secret-803";
     const WS_QUERY_SECRET: &str = "ws-query-secret-803";
     const WS_BASIC_AUTH: &str = "Basic d3MtdXNlci04MDM6d3MtcGFzcy04MDM=";
+    const BLOCK_CLOCK_FAILURE: &str = "Failed to start BlockClock";
 
     #[derive(Clone, Default)]
     struct Capture(Arc<Mutex<Vec<u8>>>);
@@ -311,10 +315,24 @@ mod tests {
                 .unwrap();
         });
 
-        let ws = WsConnect::new(format!(
-            "ws://ws-user-803:ws-pass-803@127.0.0.1:{port}/{WS_PATH_SECRET}?key={WS_QUERY_SECRET}"
-        ));
-        let _ = ws.connect().await;
+        let Err(error) = BlockClock::new_with_ws(
+            WsConnect::new(format!(
+                "ws://{WS_USERNAME}:{WS_PASSWORD}@127.0.0.1:{port}/{WS_PATH_SECRET}?\
+                 key={WS_QUERY_SECRET}"
+            )),
+            0,
+            NonZeroU64::new(1).unwrap(),
+            Duration::from_secs(1),
+        )
+        .await
+        else {
+            panic!("test server accepted WebSocket upgrade");
+        };
+        tracing::error!(
+            target: "agglayer_node::node",
+            "Failed to start BlockClock: {:?}",
+            error
+        );
         server.await.unwrap();
     }
 
@@ -331,22 +349,35 @@ mod tests {
         capture.output()
     }
 
-    #[tokio::test(flavor = "current_thread")]
+    #[test_log::test(tokio::test(flavor = "current_thread"))]
     async fn actual_dependency_transports_do_not_log_endpoint_credentials() {
-        tracing_log::LogTracer::init().expect("test process must own the log bridge");
+        // test-log may have already installed the process-wide bridge with a lower max
+        // level.
+        let _ = tracing_log::LogTracer::init();
+        tracing_log::log::set_max_level(tracing_log::log::LevelFilter::Trace);
 
         let filter = || {
             EnvFilter::new(
                 "off,alloy_transport_http::reqwest_transport=debug,\
                  tungstenite::handshake::client=trace,reqwest::connect=debug,\
                  hyper_util::client::legacy::connect::http=trace,\
-                 hyper_util::client::legacy::pool=trace",
+                 hyper_util::client::legacy::pool=trace,agglayer_node::node=error",
             )
         };
         let secrets = [
             HTTP_HOST_SECRET,
             HTTP_PATH_SECRET,
             HTTP_QUERY_SECRET,
+            WS_PATH_SECRET,
+            WS_QUERY_SECRET,
+            WS_BASIC_AUTH,
+        ];
+        let sensitive_components = [
+            HTTP_HOST_SECRET,
+            HTTP_PATH_SECRET,
+            HTTP_QUERY_SECRET,
+            WS_USERNAME,
+            WS_PASSWORD,
             WS_PATH_SECRET,
             WS_QUERY_SECRET,
             WS_BASIC_AUTH,
@@ -373,13 +404,21 @@ mod tests {
             for target in sensitive_targets {
                 assert!(output.contains(target), "missing {target:?} in {output}");
             }
+            assert!(
+                output.contains(BLOCK_CLOCK_FAILURE),
+                "missing {BLOCK_CLOCK_FAILURE:?} in {output}"
+            );
 
             let capture = Capture::default();
             let filtered = subscriber(format, BoxMakeWriter::new(capture.clone()), filter());
             let output = capture_actual_dependency_records(filtered, capture).await;
-            for secret in secrets {
+            for secret in sensitive_components {
                 assert!(!output.contains(secret), "found {secret:?} in {output}");
             }
+            assert!(
+                output.contains(BLOCK_CLOCK_FAILURE),
+                "missing {BLOCK_CLOCK_FAILURE:?} in {output}"
+            );
         }
     }
 }

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -1,33 +1,176 @@
 use agglayer_config::log::LogFormat;
-use tracing_subscriber::{prelude::*, util::SubscriberInitExt, EnvFilter};
+use tracing::{Level, Metadata};
+use tracing_subscriber::{
+    filter::filter_fn, fmt::writer::BoxMakeWriter, prelude::*, util::SubscriberInitExt, EnvFilter,
+};
+
+// Reject the pinned dependency records that serialize a full endpoint or
+// WebSocket handshake request before any user-configurable formatting layer.
+fn is_dependency_record_allowed(metadata: &Metadata<'_>) -> bool {
+    let alloy_url_span = metadata.is_span()
+        && metadata.target() == "alloy_transport_http::reqwest_transport"
+        && metadata.name() == "ReqwestTransport";
+    let tungstenite_client_trace = metadata.is_event()
+        && metadata.target() == "tungstenite::handshake::client"
+        && *metadata.level() == Level::TRACE;
+
+    !alloy_url_span && !tungstenite_client_trace
+}
+
+fn subscriber(
+    format: LogFormat,
+    writer: BoxMakeWriter,
+    filter: EnvFilter,
+) -> impl tracing::Subscriber + Send + Sync {
+    let layer = match format {
+        LogFormat::Pretty => tracing_subscriber::fmt::layer()
+            .pretty()
+            .with_writer(writer)
+            .with_filter(filter)
+            .boxed(),
+
+        LogFormat::Json => tracing_subscriber::fmt::layer()
+            .json()
+            .with_writer(writer)
+            .with_filter(filter)
+            .boxed(),
+    };
+
+    tracing_subscriber::Registry::default()
+        .with(filter_fn(is_dependency_record_allowed))
+        .with(layer)
+}
 
 pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<()> {
     // TODO: Support multiple outputs.
     let writer = config.outputs.first().cloned().unwrap_or_default();
-
-    let layer = match config.format {
-        LogFormat::Pretty => {
-            let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| config.level.into());
-
-            tracing_subscriber::fmt::layer()
-                .pretty()
-                .with_writer(writer.as_make_writer())
-                .with_filter(filter)
-                .boxed()
-        }
-
-        LogFormat::Json => tracing_subscriber::fmt::layer()
-            .json()
-            .with_writer(writer.as_make_writer())
-            .with_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| config.level.into()))
-            .boxed(),
-    };
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| config.level.into());
 
     // We are using try_init because integration test may try to initialize this
     // multiple times.
-    tracing_subscriber::Registry::default()
-        .with(layer)
-        .try_init()?;
+    subscriber(config.format, writer.as_make_writer(), filter).try_init()?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io,
+        sync::{Arc, Mutex},
+    };
+
+    use tracing_subscriber::fmt::MakeWriter;
+
+    use super::*;
+
+    const ALLOY_SECRET: &str = "alloy-url-secret-803";
+    const TUNGSTENITE_SECRET: &str = "tungstenite-request-secret-803";
+
+    #[derive(Clone, Default)]
+    struct Capture(Arc<Mutex<Vec<u8>>>);
+
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for Capture {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CaptureWriter(self.0.clone())
+        }
+    }
+
+    impl Capture {
+        fn output(&self) -> String {
+            String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+        }
+    }
+
+    // Mirrors pinned dependency callsites; re-audit these identities on upgrade.
+    fn emit_dependency_records() {
+        let span = tracing::debug_span!(
+            target: "alloy_transport_http::reqwest_transport",
+            "ReqwestTransport",
+            url = ALLOY_SECRET
+        );
+        let _entered = span.enter();
+        tracing::debug!(
+            target: "alloy_transport_http::reqwest_transport",
+            "alloy-request-control"
+        );
+        drop(_entered);
+        tracing::debug!(
+            name: "ReqwestTransport",
+            target: "alloy_transport_http::reqwest_transport",
+            marker = "same-alloy-name-event-control"
+        );
+
+        tracing::trace!(
+            target: "tungstenite::handshake::client",
+            request = TUNGSTENITE_SECRET,
+            "Request"
+        );
+        tracing::debug!(
+            target: "tungstenite::handshake::client",
+            "same-target-debug-control"
+        );
+        tracing::trace!(target: "safe_control", "unrelated-trace-control");
+        let span = tracing::trace_span!(
+            target: "tungstenite::handshake::client",
+            "TungsteniteTraceSpan",
+            marker = "tungstenite-trace-span-control"
+        );
+        let _entered = span.enter();
+        tracing::debug!(target: "safe_control", "tungstenite-trace-span-event-control");
+        drop(_entered);
+
+        let span = tracing::debug_span!(
+            target: "alloy_transport_http::reqwest_transport",
+            "OtherTransportSpan",
+            marker = "other-alloy-span-field-control"
+        );
+        let _entered = span.enter();
+        tracing::debug!(target: "safe_control", "other-alloy-event-control");
+    }
+
+    #[test]
+    fn pinned_endpoint_metadata_is_filtered() {
+        for format in [LogFormat::Pretty, LogFormat::Json] {
+            let capture = Capture::default();
+            let filter = EnvFilter::new(
+                "off,alloy_transport_http::reqwest_transport=debug,\
+                 tungstenite::handshake::client=trace,safe_control=trace",
+            );
+            let subscriber = subscriber(format, BoxMakeWriter::new(capture.clone()), filter);
+
+            tracing::subscriber::with_default(subscriber, emit_dependency_records);
+            let output = capture.output();
+
+            assert!(!output.contains(ALLOY_SECRET));
+            assert!(!output.contains(TUNGSTENITE_SECRET));
+            for control in [
+                "alloy-request-control",
+                "same-alloy-name-event-control",
+                "same-target-debug-control",
+                "unrelated-trace-control",
+                "tungstenite-trace-span-control",
+                "tungstenite-trace-span-event-control",
+                "other-alloy-span-field-control",
+                "other-alloy-event-control",
+            ] {
+                assert!(output.contains(control), "missing {control:?} in {output}");
+            }
+        }
+    }
 }

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -1,3 +1,5 @@
+use std::sync::{Mutex, OnceLock};
+
 use agglayer_config::log::LogFormat;
 use tracing::{Level, Metadata};
 use tracing_subscriber::{
@@ -7,6 +9,9 @@ use tracing_subscriber::{
     util::SubscriberInitExt,
     EnvFilter,
 };
+
+static SUBSCRIBER_INIT: Mutex<()> = Mutex::new(());
+static SUBSCRIBER_INSTALLED: OnceLock<()> = OnceLock::new();
 
 // Reject pinned records that expose a full endpoint, HTTP authority, WebSocket
 // handshake request, or TLS server name before any user-configurable formatting
@@ -18,28 +23,49 @@ fn is_dependency_record_allowed(metadata: &Metadata<'_>) -> bool {
         && metadata.target() == "alloy_transport_http::reqwest_transport"
         && metadata.name() == "ReqwestTransport"
         && *metadata.level() == Level::DEBUG;
+    let alloy_hyper_url_span = metadata.is_span()
+        && metadata.target() == "alloy_transport_http::hyper_transport"
+        && metadata.name() == "HyperTransport"
+        && *metadata.level() == Level::DEBUG;
     let reqwest_connect = metadata.is_event()
         && metadata.target() == "reqwest::connect"
-        && *metadata.level() == Level::DEBUG;
+        && matches!(*metadata.level(), Level::DEBUG | Level::TRACE);
     let hyper_connector = metadata.is_event()
         && metadata.target() == "hyper_util::client::legacy::connect::http"
-        && *metadata.level() == Level::TRACE;
+        && matches!(*metadata.level(), Level::DEBUG | Level::TRACE);
     let hyper_pool = metadata.is_event()
         && metadata.target() == "hyper_util::client::legacy::pool"
         && matches!(*metadata.level(), Level::DEBUG | Level::TRACE);
+    let hyper_client = metadata.is_event()
+        && metadata.target() == "hyper_util::client::legacy::client"
+        && matches!(*metadata.level(), Level::DEBUG | Level::WARN);
+    let tungstenite_client = metadata.is_event()
+        && metadata.target() == "tungstenite::client"
+        && *metadata.level() == Level::DEBUG;
     let tungstenite_client_trace = metadata.is_event()
         && metadata.target() == "tungstenite::handshake::client"
         && *metadata.level() == Level::TRACE;
+    let jsonrpsee_client = metadata.is_event()
+        && metadata.target() == "jsonrpsee-client"
+        && *metadata.level() == Level::DEBUG;
     let rustls_client_handshake = metadata.is_event()
         && metadata.target() == "rustls::client::hs"
         && matches!(*metadata.level(), Level::DEBUG | Level::TRACE);
+    let rustls_client_tls12 = metadata.is_event()
+        && metadata.target() == "rustls::client::tls12"
+        && matches!(*metadata.level(), Level::DEBUG | Level::TRACE);
 
     !alloy_url_span
+        && !alloy_hyper_url_span
         && !reqwest_connect
         && !hyper_connector
         && !hyper_pool
+        && !hyper_client
+        && !tungstenite_client
         && !tungstenite_client_trace
+        && !jsonrpsee_client
         && !rustls_client_handshake
+        && !rustls_client_tls12
 }
 
 fn subscriber(
@@ -47,7 +73,8 @@ fn subscriber(
     writer: BoxMakeWriter,
     filter: EnvFilter,
 ) -> impl tracing::Subscriber + Send + Sync {
-    // Keep both filters on the formatting layer so disabled callsites retain `Interest::never`.
+    // Keep both filters on the formatting layer so disabled callsites retain
+    // `Interest::never`.
     let filter = filter.and(filter_fn(is_dependency_record_allowed));
     let layer = match format {
         LogFormat::Pretty => tracing_subscriber::fmt::layer()
@@ -67,13 +94,33 @@ fn subscriber(
 }
 
 pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<()> {
+    if SUBSCRIBER_INSTALLED.get().is_some() {
+        return Ok(());
+    }
+
+    let _init_guard = SUBSCRIBER_INIT
+        .lock()
+        .expect("Agglayer logging subscriber initialization lock was poisoned");
+    if SUBSCRIBER_INSTALLED.get().is_some() {
+        return Ok(());
+    }
+
     // TODO: Support multiple outputs.
     let writer = config.outputs.first().cloned().unwrap_or_default();
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| config.level.into());
 
-    // We are using try_init because integration test may try to initialize this
-    // multiple times.
-    subscriber(config.format, writer.as_make_writer(), filter).try_init()?;
+    // Repeated node starts may reuse the subscriber installed by Agglayer. A
+    // subscriber installed by another component is rejected: continuing would
+    // leave dependency endpoint records outside this redaction policy.
+    subscriber(config.format, writer.as_make_writer(), filter)
+        .try_init()
+        .map_err(|error| {
+            eyre::eyre!(
+                "Agglayer logging requires its endpoint-redaction policy, but the global tracing \
+                 subscriber is already initialized: {error}"
+            )
+        })?;
+    let _ = SUBSCRIBER_INSTALLED.set(());
 
     Ok(())
 }
@@ -81,8 +128,9 @@ pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<()> {
 #[cfg(test)]
 mod tests {
     use std::{
-        io,
+        env, io,
         num::NonZeroU64,
+        process::Command,
         sync::{Arc, Mutex},
         time::Duration,
     };
@@ -105,6 +153,7 @@ mod tests {
     const ALLOY_SECRET: &str = "alloy-url-secret-803";
     const HTTP_HOST_SECRET: &str = "http-host-secret-803.invalid";
     const TLS_HOST_SECRET: &str = "tls-host-secret-803.localhost";
+    const JSONRPSEE_SECRET: &str = "jsonrpsee-url-secret-803";
     const TUNGSTENITE_SECRET: &str = "tungstenite-request-secret-803";
     const HTTP_PATH_SECRET: &str = "http-path-secret-803";
     const HTTP_QUERY_SECRET: &str = "http-query-secret-803";
@@ -185,6 +234,23 @@ mod tests {
             marker = "same-alloy-name-event-control"
         );
 
+        let span = tracing::debug_span!(
+            target: "alloy_transport_http::hyper_transport",
+            "HyperTransport",
+            url = ALLOY_SECRET
+        );
+        let _entered = span.enter();
+        tracing::debug!(target: "safe_control", "hyper-alloy-event-control");
+        drop(_entered);
+        let span = tracing::info_span!(
+            target: "alloy_transport_http::hyper_transport",
+            "HyperTransport",
+            marker = "hyper-alloy-info-span-control"
+        );
+        let _entered = span.enter();
+        tracing::debug!(target: "safe_control", "hyper-alloy-info-span-event-control");
+        drop(_entered);
+
         tracing::trace!(
             target: "tungstenite::handshake::client",
             request = TUNGSTENITE_SECRET,
@@ -196,9 +262,38 @@ mod tests {
             "reqwest-host-secret"
         );
         tracing::trace!(
+            target: "reqwest::connect",
+            request = HTTP_QUERY_SECRET,
+            "reqwest-trace-secret"
+        );
+        tracing::info!(target: "reqwest::connect", "reqwest-info-control");
+        tracing::trace!(
             target: "hyper_util::client::legacy::connect::http",
             host = HTTP_HOST_SECRET,
             "hyper-connector-host-secret"
+        );
+        tracing::debug!(
+            target: "hyper_util::client::legacy::connect::http",
+            host = HTTP_HOST_SECRET,
+            "hyper-connector-debug-secret"
+        );
+        tracing::info!(
+            target: "hyper_util::client::legacy::connect::http",
+            "hyper-connector-info-control"
+        );
+        tracing::warn!(
+            target: "hyper_util::client::legacy::client",
+            path = HTTP_PATH_SECRET,
+            "hyper-client-connect-path"
+        );
+        tracing::debug!(
+            target: "hyper_util::client::legacy::client",
+            uri = HTTP_QUERY_SECRET,
+            "hyper-client-uri"
+        );
+        tracing::info!(
+            target: "hyper_util::client::legacy::client",
+            "hyper-client-info-control"
         );
         tracing::debug!(
             target: "hyper_util::client::legacy::pool",
@@ -214,10 +309,23 @@ mod tests {
             target: "tungstenite::handshake::client",
             "same-target-debug-control"
         );
-        tracing::trace!(target: "reqwest::connect", "reqwest-trace-control");
         tracing::debug!(
-            target: "hyper_util::client::legacy::connect::http",
-            "hyper-connector-debug-control"
+            target: "tungstenite::client",
+            uri = JSONRPSEE_SECRET,
+            "tungstenite-client-secret"
+        );
+        tracing::info!(
+            target: "tungstenite::client",
+            "tungstenite-client-info-control"
+        );
+        tracing::debug!(
+            target: "jsonrpsee-client",
+            target_url = JSONRPSEE_SECRET,
+            "jsonrpsee-target-secret"
+        );
+        tracing::info!(
+            target: "jsonrpsee-client",
+            "jsonrpsee-info-control"
         );
         tracing::info!(
             target: "hyper_util::client::legacy::pool",
@@ -234,6 +342,20 @@ mod tests {
             "rustls-client-hello"
         );
         tracing::info!(target: "rustls::client::hs", "rustls-info-control");
+        tracing::debug!(
+            target: "rustls::client::tls12",
+            server_name = TLS_HOST_SECRET,
+            "rustls-tls12-server-name"
+        );
+        tracing::trace!(
+            target: "rustls::client::tls12",
+            server_certificate = TLS_HOST_SECRET,
+            "rustls-tls12-certificate"
+        );
+        tracing::info!(
+            target: "rustls::client::tls12",
+            "rustls-tls12-info-control"
+        );
         tracing::debug!(
             target: "rustls::client::common",
             "rustls-nearby-target-control"
@@ -272,10 +394,11 @@ mod tests {
             let capture = Capture::default();
             let filter = EnvFilter::new(
                 "off,alloy_transport_http::reqwest_transport=debug,\
-                 tungstenite::handshake::client=trace,reqwest::connect=trace,\
-                 hyper_util::client::legacy::connect::http=trace,\
-                 hyper_util::client::legacy::pool=trace,rustls::client::hs=trace,\
-                 rustls::client::common=debug,safe_control=trace",
+                 alloy_transport_http::hyper_transport=debug,tungstenite::handshake::client=trace,\
+                 reqwest::connect=trace,hyper_util::client::legacy::connect::http=trace,\
+                 hyper_util::client::legacy::pool=trace,hyper_util::client::legacy::client=debug,\
+                 tungstenite::client=debug,jsonrpsee-client=debug,rustls::client::hs=trace,\
+                 rustls::client::tls12=trace,rustls::client::common=debug,safe_control=trace",
             );
             let subscriber = subscriber(format, BoxMakeWriter::new(capture.clone()), filter);
 
@@ -284,18 +407,28 @@ mod tests {
 
             assert!(!output.contains(ALLOY_SECRET));
             assert!(!output.contains(HTTP_HOST_SECRET));
+            assert!(!output.contains(HTTP_PATH_SECRET));
+            assert!(!output.contains(HTTP_QUERY_SECRET));
             assert!(!output.contains(TUNGSTENITE_SECRET));
             assert!(!output.contains(TLS_HOST_SECRET));
+            assert!(!output.contains(JSONRPSEE_SECRET));
             for control in [
                 "alloy-request-control",
                 "alloy-info-span-control",
                 "alloy-info-span-event-control",
                 "same-alloy-name-event-control",
+                "hyper-alloy-event-control",
+                "hyper-alloy-info-span-control",
+                "hyper-alloy-info-span-event-control",
                 "same-target-debug-control",
-                "reqwest-trace-control",
-                "hyper-connector-debug-control",
+                "reqwest-info-control",
+                "hyper-connector-info-control",
+                "hyper-client-info-control",
                 "hyper-pool-info-control",
+                "tungstenite-client-info-control",
+                "jsonrpsee-info-control",
                 "rustls-info-control",
+                "rustls-tls12-info-control",
                 "rustls-nearby-target-control",
                 "unrelated-trace-control",
                 "tungstenite-trace-span-control",
@@ -322,6 +455,37 @@ mod tests {
             tracing::Subscriber::register_callsite(&subscriber, &UNRELATED_DEBUG_METADATA)
                 .is_never()
         );
+    }
+
+    #[test]
+    fn global_subscriber_contract_is_enforced() {
+        const CHILD_MODE: &str = "AGGLAYER_LOGGING_TEST_CHILD";
+
+        match env::var(CHILD_MODE).as_deref() {
+            Ok("preinstalled") => {
+                tracing::subscriber::set_global_default(tracing_subscriber::registry()).unwrap();
+                let error = tracing(&agglayer_config::Log::default()).unwrap_err();
+                assert!(error
+                    .to_string()
+                    .contains("requires its endpoint-redaction policy"));
+            }
+            Ok("repeated") => {
+                let config = agglayer_config::Log::default();
+                tracing(&config).unwrap();
+                tracing(&config).unwrap();
+            }
+            _ => {
+                for mode in ["preinstalled", "repeated"] {
+                    let status = Command::new(env::current_exe().unwrap())
+                        .arg("--exact")
+                        .arg("logging::tests::global_subscriber_contract_is_enforced")
+                        .env(CHILD_MODE, mode)
+                        .status()
+                        .unwrap();
+                    assert!(status.success(), "isolated {mode} logging test failed");
+                }
+            }
+        }
     }
 
     fn subscriber_without_endpoint_policy(

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -4,17 +4,32 @@ use tracing_subscriber::{
     filter::filter_fn, fmt::writer::BoxMakeWriter, prelude::*, util::SubscriberInitExt, EnvFilter,
 };
 
-// Reject the pinned dependency records that serialize a full endpoint or
+// Reject pinned records that expose a full endpoint, HTTP authority, or
 // WebSocket handshake request before any user-configurable formatting layer.
+// The dependencies do not give every sensitive and benign record distinct
+// metadata, so same-target records at the filtered levels are also suppressed.
 fn is_dependency_record_allowed(metadata: &Metadata<'_>) -> bool {
     let alloy_url_span = metadata.is_span()
         && metadata.target() == "alloy_transport_http::reqwest_transport"
         && metadata.name() == "ReqwestTransport";
+    let reqwest_connect = metadata.is_event()
+        && metadata.target() == "reqwest::connect"
+        && *metadata.level() == Level::DEBUG;
+    let hyper_connector = metadata.is_event()
+        && metadata.target() == "hyper_util::client::legacy::connect::http"
+        && *metadata.level() == Level::TRACE;
+    let hyper_pool = metadata.is_event()
+        && metadata.target() == "hyper_util::client::legacy::pool"
+        && matches!(*metadata.level(), Level::DEBUG | Level::TRACE);
     let tungstenite_client_trace = metadata.is_event()
         && metadata.target() == "tungstenite::handshake::client"
         && *metadata.level() == Level::TRACE;
 
-    !alloy_url_span && !tungstenite_client_trace
+    !alloy_url_span
+        && !reqwest_connect
+        && !hyper_connector
+        && !hyper_pool
+        && !tungstenite_client_trace
 }
 
 fn subscriber(
@@ -58,14 +73,32 @@ mod tests {
     use std::{
         io,
         sync::{Arc, Mutex},
+        time::Duration,
     };
 
+    use alloy::{
+        pubsub::PubSubConnect,
+        rpc::json_rpc::{Id, Request, RequestPacket},
+        transports::{http::Http, ws::WsConnect},
+    };
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+        time::timeout,
+    };
+    use tower::Service;
     use tracing_subscriber::fmt::MakeWriter;
 
     use super::*;
 
     const ALLOY_SECRET: &str = "alloy-url-secret-803";
+    const HTTP_HOST_SECRET: &str = "http-host-secret-803.invalid";
     const TUNGSTENITE_SECRET: &str = "tungstenite-request-secret-803";
+    const HTTP_PATH_SECRET: &str = "http-path-secret-803";
+    const HTTP_QUERY_SECRET: &str = "http-query-secret-803";
+    const WS_PATH_SECRET: &str = "ws-path-secret-803";
+    const WS_QUERY_SECRET: &str = "ws-query-secret-803";
+    const WS_BASIC_AUTH: &str = "Basic d3MtdXNlci04MDM6d3MtcGFzcy04MDM=";
 
     #[derive(Clone, Default)]
     struct Capture(Arc<Mutex<Vec<u8>>>);
@@ -122,8 +155,37 @@ mod tests {
             "Request"
         );
         tracing::debug!(
+            target: "reqwest::connect",
+            host = HTTP_HOST_SECRET,
+            "reqwest-host-secret"
+        );
+        tracing::trace!(
+            target: "hyper_util::client::legacy::connect::http",
+            host = HTTP_HOST_SECRET,
+            "hyper-connector-host-secret"
+        );
+        tracing::debug!(
+            target: "hyper_util::client::legacy::pool",
+            authority = HTTP_HOST_SECRET,
+            "hyper-pool-debug-secret"
+        );
+        tracing::trace!(
+            target: "hyper_util::client::legacy::pool",
+            authority = HTTP_HOST_SECRET,
+            "hyper-pool-trace-secret"
+        );
+        tracing::debug!(
             target: "tungstenite::handshake::client",
             "same-target-debug-control"
+        );
+        tracing::trace!(target: "reqwest::connect", "reqwest-trace-control");
+        tracing::debug!(
+            target: "hyper_util::client::legacy::connect::http",
+            "hyper-connector-debug-control"
+        );
+        tracing::info!(
+            target: "hyper_util::client::legacy::pool",
+            "hyper-pool-info-control"
         );
         tracing::trace!(target: "safe_control", "unrelated-trace-control");
         let span = tracing::trace_span!(
@@ -150,7 +212,9 @@ mod tests {
             let capture = Capture::default();
             let filter = EnvFilter::new(
                 "off,alloy_transport_http::reqwest_transport=debug,\
-                 tungstenite::handshake::client=trace,safe_control=trace",
+                 tungstenite::handshake::client=trace,reqwest::connect=trace,\
+                 hyper_util::client::legacy::connect::http=trace,\
+                 hyper_util::client::legacy::pool=trace,safe_control=trace",
             );
             let subscriber = subscriber(format, BoxMakeWriter::new(capture.clone()), filter);
 
@@ -158,11 +222,15 @@ mod tests {
             let output = capture.output();
 
             assert!(!output.contains(ALLOY_SECRET));
+            assert!(!output.contains(HTTP_HOST_SECRET));
             assert!(!output.contains(TUNGSTENITE_SECRET));
             for control in [
                 "alloy-request-control",
                 "same-alloy-name-event-control",
                 "same-target-debug-control",
+                "reqwest-trace-control",
+                "hyper-connector-debug-control",
+                "hyper-pool-info-control",
                 "unrelated-trace-control",
                 "tungstenite-trace-span-control",
                 "tungstenite-trace-span-event-control",
@@ -170,6 +238,147 @@ mod tests {
                 "other-alloy-event-control",
             ] {
                 assert!(output.contains(control), "missing {control:?} in {output}");
+            }
+        }
+    }
+
+    fn subscriber_without_endpoint_policy(
+        format: LogFormat,
+        writer: BoxMakeWriter,
+        filter: EnvFilter,
+    ) -> impl tracing::Subscriber + Send + Sync {
+        let layer = match format {
+            LogFormat::Pretty => tracing_subscriber::fmt::layer()
+                .pretty()
+                .with_writer(writer)
+                .with_filter(filter)
+                .boxed(),
+            LogFormat::Json => tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(writer)
+                .with_filter(filter)
+                .boxed(),
+        };
+
+        tracing_subscriber::Registry::default().with(layer)
+    }
+
+    async fn emit_actual_dependency_records() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).await.unwrap();
+            let body = r#"{"jsonrpc":"2.0","id":1,"result":"0x1"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
+                 {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let client = reqwest13::Client::builder()
+            .no_proxy()
+            .resolve(HTTP_HOST_SECRET, address)
+            .build()
+            .unwrap();
+        let url = format!(
+            "http://{HTTP_HOST_SECRET}:{}/{HTTP_PATH_SECRET}?key={HTTP_QUERY_SECRET}",
+            address.port()
+        )
+        .parse()
+        .unwrap();
+        let request = Request::new("eth_blockNumber", Id::Number(1), ())
+            .serialize()
+            .unwrap();
+        let mut transport = Http::with_client(client, url);
+        let _ = transport.call(RequestPacket::Single(request)).await;
+        server.await.unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let ws = WsConnect::new(format!(
+            "ws://ws-user-803:ws-pass-803@127.0.0.1:{port}/{WS_PATH_SECRET}?key={WS_QUERY_SECRET}"
+        ));
+        let _ = ws.connect().await;
+        server.await.unwrap();
+    }
+
+    async fn capture_actual_dependency_records<S>(subscriber: S, capture: Capture) -> String
+    where
+        S: tracing::Subscriber + Send + Sync + 'static,
+    {
+        let dispatch = tracing::Dispatch::new(subscriber);
+        let guard = tracing::dispatcher::set_default(&dispatch);
+        timeout(Duration::from_secs(5), emit_actual_dependency_records())
+            .await
+            .expect("dependency transports did not finish");
+        drop(guard);
+        capture.output()
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn actual_dependency_transports_do_not_log_endpoint_credentials() {
+        tracing_log::LogTracer::init().expect("test process must own the log bridge");
+
+        let filter = || {
+            EnvFilter::new(
+                "off,alloy_transport_http::reqwest_transport=debug,\
+                 tungstenite::handshake::client=trace,reqwest::connect=debug,\
+                 hyper_util::client::legacy::connect::http=trace,\
+                 hyper_util::client::legacy::pool=trace",
+            )
+        };
+        let secrets = [
+            HTTP_HOST_SECRET,
+            HTTP_PATH_SECRET,
+            HTTP_QUERY_SECRET,
+            WS_PATH_SECRET,
+            WS_QUERY_SECRET,
+            WS_BASIC_AUTH,
+        ];
+        let sensitive_targets = [
+            "alloy_transport_http::reqwest_transport",
+            "reqwest::connect",
+            "hyper_util::client::legacy::connect::http",
+            "hyper_util::client::legacy::pool",
+            "tungstenite::handshake::client",
+        ];
+
+        for format in [LogFormat::Pretty, LogFormat::Json] {
+            let capture = Capture::default();
+            let unfiltered = subscriber_without_endpoint_policy(
+                format,
+                BoxMakeWriter::new(capture.clone()),
+                filter(),
+            );
+            let output = capture_actual_dependency_records(unfiltered, capture).await;
+            for secret in secrets {
+                assert!(output.contains(secret), "missing {secret:?} in {output}");
+            }
+            for target in sensitive_targets {
+                assert!(output.contains(target), "missing {target:?} in {output}");
+            }
+
+            let capture = Capture::default();
+            let filtered = subscriber(format, BoxMakeWriter::new(capture.clone()), filter());
+            let output = capture_actual_dependency_records(filtered, capture).await;
+            for secret in secrets {
+                assert!(!output.contains(secret), "found {secret:?} in {output}");
             }
         }
     }

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -4,10 +4,11 @@ use tracing_subscriber::{
     filter::filter_fn, fmt::writer::BoxMakeWriter, prelude::*, util::SubscriberInitExt, EnvFilter,
 };
 
-// Reject pinned records that expose a full endpoint, HTTP authority, or
-// WebSocket handshake request before any user-configurable formatting layer.
-// The dependencies do not give every sensitive and benign record distinct
-// metadata, so same-target records at the filtered levels are also suppressed.
+// Reject pinned records that expose a full endpoint, HTTP authority, WebSocket
+// handshake request, or TLS server name before any user-configurable formatting
+// layer. The dependencies do not give every sensitive and benign record
+// distinct metadata, so same-target records at the filtered levels are also
+// suppressed.
 fn is_dependency_record_allowed(metadata: &Metadata<'_>) -> bool {
     let alloy_url_span = metadata.is_span()
         && metadata.target() == "alloy_transport_http::reqwest_transport"
@@ -24,12 +25,16 @@ fn is_dependency_record_allowed(metadata: &Metadata<'_>) -> bool {
     let tungstenite_client_trace = metadata.is_event()
         && metadata.target() == "tungstenite::handshake::client"
         && *metadata.level() == Level::TRACE;
+    let rustls_client_handshake = metadata.is_event()
+        && metadata.target() == "rustls::client::hs"
+        && matches!(*metadata.level(), Level::DEBUG | Level::TRACE);
 
     !alloy_url_span
         && !reqwest_connect
         && !hyper_connector
         && !hyper_pool
         && !tungstenite_client_trace
+        && !rustls_client_handshake
 }
 
 fn subscriber(
@@ -94,6 +99,7 @@ mod tests {
 
     const ALLOY_SECRET: &str = "alloy-url-secret-803";
     const HTTP_HOST_SECRET: &str = "http-host-secret-803.invalid";
+    const TLS_HOST_SECRET: &str = "tls-host-secret-803.localhost";
     const TUNGSTENITE_SECRET: &str = "tungstenite-request-secret-803";
     const HTTP_PATH_SECRET: &str = "http-path-secret-803";
     const HTTP_QUERY_SECRET: &str = "http-query-secret-803";
@@ -191,6 +197,21 @@ mod tests {
             target: "hyper_util::client::legacy::pool",
             "hyper-pool-info-control"
         );
+        tracing::debug!(
+            target: "rustls::client::hs",
+            server_name = TLS_HOST_SECRET,
+            "rustls-server-name"
+        );
+        tracing::trace!(
+            target: "rustls::client::hs",
+            client_hello = TLS_HOST_SECRET,
+            "rustls-client-hello"
+        );
+        tracing::info!(target: "rustls::client::hs", "rustls-info-control");
+        tracing::debug!(
+            target: "rustls::client::common",
+            "rustls-nearby-target-control"
+        );
         tracing::trace!(target: "safe_control", "unrelated-trace-control");
         let span = tracing::trace_span!(
             target: "tungstenite::handshake::client",
@@ -199,6 +220,15 @@ mod tests {
         );
         let _entered = span.enter();
         tracing::debug!(target: "safe_control", "tungstenite-trace-span-event-control");
+        drop(_entered);
+
+        let span = tracing::debug_span!(
+            target: "rustls::client::hs",
+            "RustlsHandshakeSpan",
+            marker = "rustls-debug-span-control"
+        );
+        let _entered = span.enter();
+        tracing::debug!(target: "safe_control", "rustls-debug-span-event-control");
         drop(_entered);
 
         let span = tracing::debug_span!(
@@ -218,7 +248,8 @@ mod tests {
                 "off,alloy_transport_http::reqwest_transport=debug,\
                  tungstenite::handshake::client=trace,reqwest::connect=trace,\
                  hyper_util::client::legacy::connect::http=trace,\
-                 hyper_util::client::legacy::pool=trace,safe_control=trace",
+                 hyper_util::client::legacy::pool=trace,rustls::client::hs=trace,\
+                 rustls::client::common=debug,safe_control=trace",
             );
             let subscriber = subscriber(format, BoxMakeWriter::new(capture.clone()), filter);
 
@@ -228,6 +259,7 @@ mod tests {
             assert!(!output.contains(ALLOY_SECRET));
             assert!(!output.contains(HTTP_HOST_SECRET));
             assert!(!output.contains(TUNGSTENITE_SECRET));
+            assert!(!output.contains(TLS_HOST_SECRET));
             for control in [
                 "alloy-request-control",
                 "same-alloy-name-event-control",
@@ -235,9 +267,13 @@ mod tests {
                 "reqwest-trace-control",
                 "hyper-connector-debug-control",
                 "hyper-pool-info-control",
+                "rustls-info-control",
+                "rustls-nearby-target-control",
                 "unrelated-trace-control",
                 "tungstenite-trace-span-control",
                 "tungstenite-trace-span-event-control",
+                "rustls-debug-span-control",
+                "rustls-debug-span-event-control",
                 "other-alloy-span-field-control",
                 "other-alloy-event-control",
             ] {
@@ -334,6 +370,63 @@ mod tests {
             error
         );
         server.await.unwrap();
+
+        // Rustls logs the SNI while producing ClientHello, before any peer response, so
+        // a loopback TCP peer exercises the real TLS logging path without a
+        // test certificate.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut client_hello = [0_u8; 2048];
+            let _ = stream.read(&mut client_hello).await.unwrap();
+        });
+
+        let client = reqwest13::Client::builder()
+            .no_proxy()
+            .resolve(TLS_HOST_SECRET, address)
+            .build()
+            .unwrap();
+        let url = format!(
+            "https://{TLS_HOST_SECRET}:{}/{HTTP_PATH_SECRET}?key={HTTP_QUERY_SECRET}",
+            address.port()
+        )
+        .parse()
+        .unwrap();
+        let request = Request::new("eth_blockNumber", Id::Number(1), ())
+            .serialize()
+            .unwrap();
+        let mut transport = Http::with_client(client, url);
+        let _ = transport.call(RequestPacket::Single(request)).await;
+        server.await.unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut client_hello = [0_u8; 2048];
+            let _ = stream.read(&mut client_hello).await.unwrap();
+        });
+
+        let Err(error) = BlockClock::new_with_ws(
+            WsConnect::new(format!(
+                "wss://{WS_USERNAME}:{WS_PASSWORD}@{TLS_HOST_SECRET}:{port}/{WS_PATH_SECRET}?\
+                 key={WS_QUERY_SECRET}"
+            )),
+            0,
+            NonZeroU64::new(1).unwrap(),
+            Duration::from_secs(1),
+        )
+        .await
+        else {
+            panic!("test server accepted WebSocket upgrade");
+        };
+        tracing::error!(
+            target: "agglayer_node::node",
+            "Failed to start BlockClock: {:?}",
+            error
+        );
+        server.await.unwrap();
     }
 
     async fn capture_actual_dependency_records<S>(subscriber: S, capture: Capture) -> String
@@ -359,6 +452,7 @@ mod tests {
         let filter = || EnvFilter::new("trace");
         let baseline_observed_leaks = [
             HTTP_HOST_SECRET,
+            TLS_HOST_SECRET,
             HTTP_PATH_SECRET,
             HTTP_QUERY_SECRET,
             WS_PATH_SECRET,
@@ -369,6 +463,7 @@ mod tests {
         // absence-only checks for a future dependency regression.
         let all_sensitive_endpoint_components = [
             HTTP_HOST_SECRET,
+            TLS_HOST_SECRET,
             HTTP_PATH_SECRET,
             HTTP_QUERY_SECRET,
             WS_USERNAME,
@@ -383,6 +478,7 @@ mod tests {
             "hyper_util::client::legacy::connect::http",
             "hyper_util::client::legacy::pool",
             "tungstenite::handshake::client",
+            "rustls::client::hs",
         ];
 
         for format in [LogFormat::Pretty, LogFormat::Json] {

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -1,7 +1,11 @@
 use agglayer_config::log::LogFormat;
 use tracing::{Level, Metadata};
 use tracing_subscriber::{
-    filter::filter_fn, fmt::writer::BoxMakeWriter, prelude::*, util::SubscriberInitExt, EnvFilter,
+    filter::{filter_fn, FilterExt},
+    fmt::writer::BoxMakeWriter,
+    prelude::*,
+    util::SubscriberInitExt,
+    EnvFilter,
 };
 
 // Reject pinned records that expose a full endpoint, HTTP authority, WebSocket
@@ -12,7 +16,8 @@ use tracing_subscriber::{
 fn is_dependency_record_allowed(metadata: &Metadata<'_>) -> bool {
     let alloy_url_span = metadata.is_span()
         && metadata.target() == "alloy_transport_http::reqwest_transport"
-        && metadata.name() == "ReqwestTransport";
+        && metadata.name() == "ReqwestTransport"
+        && *metadata.level() == Level::DEBUG;
     let reqwest_connect = metadata.is_event()
         && metadata.target() == "reqwest::connect"
         && *metadata.level() == Level::DEBUG;
@@ -42,6 +47,8 @@ fn subscriber(
     writer: BoxMakeWriter,
     filter: EnvFilter,
 ) -> impl tracing::Subscriber + Send + Sync {
+    // Keep both filters on the formatting layer so disabled callsites retain `Interest::never`.
+    let filter = filter.and(filter_fn(is_dependency_record_allowed));
     let layer = match format {
         LogFormat::Pretty => tracing_subscriber::fmt::layer()
             .pretty()
@@ -56,9 +63,7 @@ fn subscriber(
             .boxed(),
     };
 
-    tracing_subscriber::Registry::default()
-        .with(filter_fn(is_dependency_record_allowed))
-        .with(layer)
+    tracing_subscriber::Registry::default().with(layer)
 }
 
 pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<()> {
@@ -110,6 +115,17 @@ mod tests {
     const WS_BASIC_AUTH: &str = "Basic d3MtdXNlci04MDM6d3MtcGFzcy04MDM=";
     const BLOCK_CLOCK_FAILURE: &str = "Failed to start BlockClock";
 
+    static UNRELATED_DEBUG_CALLSITE: tracing::callsite::DefaultCallsite =
+        tracing::callsite::DefaultCallsite::new(&UNRELATED_DEBUG_METADATA);
+    static UNRELATED_DEBUG_METADATA: tracing::Metadata<'static> = tracing::metadata! {
+        name: "unrelated_debug_callsite",
+        target: "unrelated_target",
+        level: tracing::Level::DEBUG,
+        fields: tracing::fieldset!(),
+        callsite: &UNRELATED_DEBUG_CALLSITE,
+        kind: tracing::metadata::Kind::EVENT,
+    };
+
     #[derive(Clone, Default)]
     struct Capture(Arc<Mutex<Vec<u8>>>);
 
@@ -153,6 +169,16 @@ mod tests {
             "alloy-request-control"
         );
         drop(_entered);
+
+        let span = tracing::info_span!(
+            target: "alloy_transport_http::reqwest_transport",
+            "ReqwestTransport",
+            marker = "alloy-info-span-control"
+        );
+        let _entered = span.enter();
+        tracing::debug!(target: "safe_control", "alloy-info-span-event-control");
+        drop(_entered);
+
         tracing::debug!(
             name: "ReqwestTransport",
             target: "alloy_transport_http::reqwest_transport",
@@ -262,6 +288,8 @@ mod tests {
             assert!(!output.contains(TLS_HOST_SECRET));
             for control in [
                 "alloy-request-control",
+                "alloy-info-span-control",
+                "alloy-info-span-event-control",
                 "same-alloy-name-event-control",
                 "same-target-debug-control",
                 "reqwest-trace-control",
@@ -280,6 +308,20 @@ mod tests {
                 assert!(output.contains(control), "missing {control:?} in {output}");
             }
         }
+    }
+
+    #[test]
+    fn disabled_callsites_keep_interest_never() {
+        let subscriber = subscriber(
+            LogFormat::Pretty,
+            BoxMakeWriter::new(Capture::default()),
+            EnvFilter::new("info"),
+        );
+
+        assert!(
+            tracing::Subscriber::register_callsite(&subscriber, &UNRELATED_DEBUG_METADATA)
+                .is_never()
+        );
     }
 
     fn subscriber_without_endpoint_policy(
@@ -398,34 +440,6 @@ mod tests {
             .unwrap();
         let mut transport = Http::with_client(client, url);
         let _ = transport.call(RequestPacket::Single(request)).await;
-        server.await.unwrap();
-
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let server = tokio::spawn(async move {
-            let (mut stream, _) = listener.accept().await.unwrap();
-            let mut client_hello = [0_u8; 2048];
-            let _ = stream.read(&mut client_hello).await.unwrap();
-        });
-
-        let Err(error) = BlockClock::new_with_ws(
-            WsConnect::new(format!(
-                "wss://{WS_USERNAME}:{WS_PASSWORD}@{TLS_HOST_SECRET}:{port}/{WS_PATH_SECRET}?\
-                 key={WS_QUERY_SECRET}"
-            )),
-            0,
-            NonZeroU64::new(1).unwrap(),
-            Duration::from_secs(1),
-        )
-        .await
-        else {
-            panic!("test server accepted WebSocket upgrade");
-        };
-        tracing::error!(
-            target: "agglayer_node::node",
-            "Failed to start BlockClock: {:?}",
-            error
-        );
         server.await.unwrap();
     }
 

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -816,6 +816,37 @@ mod tests {
         );
         server.await.unwrap();
 
+        // Exercise the real WSS branch as far as the TLS handshake. The loopback peer
+        // intentionally stops after ClientHello, so the preceding plain-WS case remains
+        // the handshake-request producer for the path, query, and Authorization checks.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut client_hello = [0_u8; 2048];
+            let _ = stream.read(&mut client_hello).await.unwrap();
+        });
+
+        let Err(error) = BlockClock::new_with_ws(
+            WsConnect::new(format!(
+                "wss://{WS_USERNAME}:{WS_PASSWORD}@127.0.0.1:{port}/{WS_PATH_SECRET}?\
+                 key={WS_QUERY_SECRET}"
+            )),
+            0,
+            NonZeroU64::new(1).unwrap(),
+            Duration::from_secs(1),
+        )
+        .await
+        else {
+            panic!("test server completed an unexpected WSS handshake");
+        };
+        tracing::error!(
+            target: "agglayer_node::node",
+            "Failed to start BlockClock: {:?}",
+            error
+        );
+        server.await.unwrap();
+
         // Rustls logs the SNI while producing ClientHello, before any peer response, so
         // a loopback TCP peer exercises the real TLS logging path without a
         // test certificate.
@@ -861,8 +892,8 @@ mod tests {
 
     #[test_log::test(tokio::test(flavor = "current_thread"))]
     async fn actual_dependency_transports_do_not_log_endpoint_credentials() {
-        // test-log may have already installed the process-wide bridge with a lower max
-        // level.
+        // The test-log macro initializes tracing for the test; install the log bridge
+        // explicitly so log-based dependency records reach the current dispatcher.
         let _ = tracing_log::LogTracer::init();
         tracing_log::log::set_max_level(tracing_log::log::LevelFilter::Trace);
 

--- a/crates/agglayer-node/src/logging.rs
+++ b/crates/agglayer-node/src/logging.rs
@@ -2,16 +2,34 @@ use std::sync::{Mutex, OnceLock};
 
 use agglayer_config::log::LogFormat;
 use tracing::{Level, Metadata};
+use tracing_log::AsLog;
 use tracing_subscriber::{
     filter::{filter_fn, FilterExt},
     fmt::writer::BoxMakeWriter,
     prelude::*,
-    util::SubscriberInitExt,
     EnvFilter,
 };
 
 static SUBSCRIBER_INIT: Mutex<()> = Mutex::new(());
-static SUBSCRIBER_INSTALLED: OnceLock<()> = OnceLock::new();
+
+enum InitializationState {
+    Installed(tracing::Dispatch),
+    LogBridgeConflict { error: String },
+    TracingSubscriberConflict { error: String },
+}
+
+static SUBSCRIBER_STATE: OnceLock<InitializationState> = OnceLock::new();
+
+impl InitializationState {
+    fn dispatch(&self) -> eyre::Result<tracing::Dispatch> {
+        match self {
+            Self::Installed(dispatch) => Ok(dispatch.clone()),
+            Self::LogBridgeConflict { error } | Self::TracingSubscriberConflict { error } => {
+                Err(eyre::eyre!("{error}"))
+            }
+        }
+    }
+}
 
 // Reject pinned records that expose a full endpoint, HTTP authority, WebSocket
 // handshake request, or TLS server name before any user-configurable formatting
@@ -93,36 +111,59 @@ fn subscriber(
     tracing_subscriber::Registry::default().with(layer)
 }
 
-pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<()> {
-    if SUBSCRIBER_INSTALLED.get().is_some() {
-        return Ok(());
+pub(crate) fn tracing(config: &agglayer_config::Log) -> eyre::Result<tracing::Dispatch> {
+    if let Some(state) = SUBSCRIBER_STATE.get() {
+        return state.dispatch();
     }
 
     let _init_guard = SUBSCRIBER_INIT
         .lock()
         .expect("Agglayer logging subscriber initialization lock was poisoned");
-    if SUBSCRIBER_INSTALLED.get().is_some() {
-        return Ok(());
+    if let Some(state) = SUBSCRIBER_STATE.get() {
+        return state.dispatch();
     }
 
     // TODO: Support multiple outputs.
     let writer = config.outputs.first().cloned().unwrap_or_default();
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| config.level.into());
+    let dispatch =
+        tracing::Dispatch::new(subscriber(config.format, writer.as_make_writer(), filter));
 
-    // Repeated node starts may reuse the subscriber installed by Agglayer. A
-    // subscriber installed by another component is rejected: continuing would
-    // leave dependency endpoint records outside this redaction policy.
-    subscriber(config.format, writer.as_make_writer(), filter)
-        .try_init()
-        .map_err(|error| {
-            eyre::eyre!(
-                "Agglayer logging requires its endpoint-redaction policy, but the global tracing \
-                 subscriber is already initialized: {error}"
-            )
-        })?;
-    let _ = SUBSCRIBER_INSTALLED.set(());
+    // Initialize the log bridge before mutating the global tracing dispatcher.
+    // This keeps a pre-existing log logger from leaving an Agglayer subscriber
+    // permanently installed after initialization reports an error.
+    if let Err(error) = tracing_log::LogTracer::builder()
+        .with_max_level(tracing_log::log::LevelFilter::Trace)
+        .init()
+    {
+        let error = format!(
+            "Agglayer logging requires its endpoint-redaction policy, but the global log logger \
+             is already initialized: {error}"
+        );
+        let _ = SUBSCRIBER_STATE.set(InitializationState::LogBridgeConflict { error });
+        return SUBSCRIBER_STATE
+            .get()
+            .expect("logging initialization state was just stored")
+            .dispatch();
+    }
 
-    Ok(())
+    if let Err(error) = tracing::dispatcher::set_global_default(dispatch.clone()) {
+        let error = format!(
+            "Agglayer logging requires its endpoint-redaction policy, but the global tracing \
+             subscriber is already initialized: {error}"
+        );
+        let _ = SUBSCRIBER_STATE.set(InitializationState::TracingSubscriberConflict { error });
+        return SUBSCRIBER_STATE
+            .get()
+            .expect("logging initialization state was just stored")
+            .dispatch();
+    }
+
+    tracing_log::log::set_max_level(tracing::level_filters::LevelFilter::current().as_log());
+
+    let _ = SUBSCRIBER_STATE.set(InitializationState::Installed(dispatch.clone()));
+
+    Ok(dispatch)
 }
 
 #[cfg(test)]
@@ -163,6 +204,20 @@ mod tests {
     const WS_QUERY_SECRET: &str = "ws-query-secret-803";
     const WS_BASIC_AUTH: &str = "Basic d3MtdXNlci04MDM6d3MtcGFzcy04MDM=";
     const BLOCK_CLOCK_FAILURE: &str = "Failed to start BlockClock";
+
+    struct PreinstalledLogger;
+
+    static PREINSTALLED_LOGGER: PreinstalledLogger = PreinstalledLogger;
+
+    impl tracing_log::log::Log for PreinstalledLogger {
+        fn enabled(&self, _: &tracing_log::log::Metadata<'_>) -> bool {
+            false
+        }
+
+        fn log(&self, _: &tracing_log::log::Record<'_>) {}
+
+        fn flush(&self) {}
+    }
 
     static UNRELATED_DEBUG_CALLSITE: tracing::callsite::DefaultCallsite =
         tracing::callsite::DefaultCallsite::new(&UNRELATED_DEBUG_METADATA);
@@ -467,15 +522,86 @@ mod tests {
                 let error = tracing(&agglayer_config::Log::default()).unwrap_err();
                 assert!(error
                     .to_string()
-                    .contains("requires its endpoint-redaction policy"));
+                    .contains("global tracing subscriber is already initialized"));
+                let retry = tracing(&agglayer_config::Log::default()).unwrap_err();
+                assert_eq!(error.to_string(), retry.to_string());
+            }
+            Ok("preinstalled_log") => {
+                tracing_log::log::set_logger(&PREINSTALLED_LOGGER).unwrap();
+                let error = tracing(&agglayer_config::Log::default()).unwrap_err();
+                assert!(error
+                    .to_string()
+                    .contains("global log logger is already initialized"));
+                let retry = tracing(&agglayer_config::Log::default()).unwrap_err();
+                assert_eq!(error.to_string(), retry.to_string());
+                assert!(!tracing::dispatcher::has_been_set());
             }
             Ok("repeated") => {
-                let config = agglayer_config::Log::default();
-                tracing(&config).unwrap();
-                tracing(&config).unwrap();
+                env::remove_var("RUST_LOG");
+                let output_path = env::temp_dir().join(format!(
+                    "agglayer-logging-first-config-{}.log",
+                    std::process::id()
+                ));
+                let first = agglayer_config::Log {
+                    level: agglayer_config::log::LogLevel::Error,
+                    outputs: vec![agglayer_config::log::LogOutput::File(output_path.clone())],
+                    ..Default::default()
+                };
+                let second = agglayer_config::Log {
+                    level: agglayer_config::log::LogLevel::Trace,
+                    outputs: vec![agglayer_config::log::LogOutput::File(output_path.clone())],
+                    ..Default::default()
+                };
+                let dispatch = tracing(&first).unwrap();
+                let second_dispatch = tracing(&second).unwrap();
+                tracing::dispatcher::with_default(&second_dispatch, || {
+                    tracing::info!(target: "agglayer", "first-config-wins");
+                });
+                let output = std::fs::read_to_string(&output_path).unwrap_or_default();
+                assert!(!output.contains("first-config-wins"));
+                drop(dispatch);
+                _ = std::fs::remove_file(output_path);
+            }
+            Ok("scoped") => {
+                env::set_var("RUST_LOG", "trace");
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                runtime.block_on(async {
+                    let capture = Capture::default();
+                    let outer = tracing::Dispatch::new(subscriber_without_endpoint_policy(
+                        LogFormat::Pretty,
+                        BoxMakeWriter::new(capture.clone()),
+                        EnvFilter::new("trace"),
+                    ));
+                    let outer_guard = tracing::dispatcher::set_default(&outer);
+                    let inner = tracing(&agglayer_config::Log::default()).unwrap();
+                    let inner_guard = tracing::dispatcher::set_default(&inner);
+                    timeout(Duration::from_secs(5), emit_actual_dependency_records())
+                        .await
+                        .expect("dependency transports did not finish");
+                    drop(inner_guard);
+                    drop(outer_guard);
+
+                    let output = capture.output();
+                    for secret in [
+                        HTTP_HOST_SECRET,
+                        TLS_HOST_SECRET,
+                        HTTP_PATH_SECRET,
+                        HTTP_QUERY_SECRET,
+                        WS_USERNAME,
+                        WS_PASSWORD,
+                        WS_PATH_SECRET,
+                        WS_QUERY_SECRET,
+                        WS_BASIC_AUTH,
+                    ] {
+                        assert!(!output.contains(secret), "found {secret:?} in {output}");
+                    }
+                });
             }
             _ => {
-                for mode in ["preinstalled", "repeated"] {
+                for mode in ["preinstalled", "preinstalled_log", "repeated", "scoped"] {
                     let status = Command::new(env::current_exe().unwrap())
                         .arg("--exact")
                         .arg("logging::tests::global_subscriber_contract_is_enforced")

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -126,13 +126,10 @@ impl Node {
         // Spawn the TimeClock.
         let clock_ref = match &config.epoch {
             Epoch::BlockClock(cfg) => {
-                info!(
-                    "Starting BlockClock with provider: {}",
-                    config.l1.ws_node_url
-                );
+                info!("Starting BlockClock");
 
                 let clock = BlockClock::new_with_ws(
-                    WsConnect::new(config.l1.ws_node_url.as_str()),
+                    WsConnect::new(config.l1.ws_node_url.expose_url().as_str()),
                     cfg.genesis_block,
                     cfg.epoch_duration,
                     config.l1.connect_attempt_timeout,
@@ -192,7 +189,7 @@ impl Node {
                             alloy::rpc::client::RpcClient::builder()
                                 .layer(crate::L1TraceLayer)
                                 .layer(crate::UrlRedactLayer)
-                                .http(config.l1.node_url.clone()),
+                                .http(config.l1.node_url.expose_url().clone()),
                         ),
                 )
             };

--- a/tests/integrations/Cargo.toml
+++ b/tests/integrations/Cargo.toml
@@ -54,7 +54,6 @@ agglayer-types.workspace = true
 pessimistic-proof-test-suite.workspace = true
 pessimistic-proof.workspace = true
 prover-config.workspace = true
-test-log.workspace = true
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["prover-config"]

--- a/tests/integrations/tests/settlement_service/transactions.rs
+++ b/tests/integrations/tests/settlement_service/transactions.rs
@@ -18,7 +18,7 @@ use tracing::info;
 
 const TEST_ROLLUP_MANAGER_ADDRESS: &str = "0x0B306BF915C4d645ff596e518fAf3F9669b97016";
 
-#[test_log::test(tokio::test)]
+#[tokio::test]
 async fn start_l1_network() {
     // Test l1 node start and block production
     // Check if we can run l1 node and produce blocks properly,


### PR DESCRIPTION
Prevent configured L1 endpoint credentials from entering operational logs through first-party formatting and pinned transport diagnostics, complementing the Alloy error redaction from #1432.

Store endpoints in a Serde-transparent type whose `Display` and `Debug` are always redacted. Current Agglayer runtime code exposes raw values explicitly only at its two transport constructors. Reject pinned endpoint-bearing dependency records at their affected metadata levels, including Hyper legacy-client `WARN` records. Because dependency metadata does not distinguish every sensitive and benign same-target record, some adjacent records at the pinned levels are intentionally suppressed.

Logging initialization owns the process-wide redaction policy: the first successful configuration wins, pre-existing process-global tracing or `log` ownership is rejected, and embedding callers must not race those one-shot initializers. Agglayer claims tracing before installing its `log` bridge so a tracing conflict leaves the host logger untouched; if the bridge is already owned, startup fails closed and Agglayer's tracing policy remains installed. The owned dispatch remains active while the public node entrypoint polls startup and shutdown futures.

Validation:

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Local builds and tests were intentionally not run; focused and full CI are pending.

BREAKING-CHANGE: `agglayer_config::L1::{node_url, ws_node_url}` now use `L1RpcUrl` instead of `url::Url`. Their TOML representation is unchanged.
BREAKING-CHANGE: `agglayer_node::main` now requires ownership of the process-global tracing dispatcher and `log` logger. Embedding callers that preinstall either global receive a startup error. If the `log` logger is already owned, Agglayer's tracing policy remains installed because the tracing and `log` globals cannot be updated transactionally. Embedding callers must leave those one-shot globals available and must not race initialization; a thread-local scoped subscriber remains supported.

CONFIG-CHANGE: None. Existing L1 TOML configuration remains unchanged.

Fixes #803.
