### PR TITLE
feat(settlement): insert-settlement-attempt admin mutation

### DIFF
--- a/crates/agglayer-jsonrpc-api/src/admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/admin.rs
@@ -25,7 +25,9 @@ use super::error::RpcResult;
 use crate::{
     error::Error,
     rpc_middleware,
-    settlement_admin::{edit_even_if_completed, map_admin_error, Force, MutationResponse},
+    settlement_admin::{
+        edit_even_if_completed, map_admin_error, Force, InsertAttemptParams, MutationResponse,
+    },
     JsonRpcService,
 };
 
@@ -245,6 +247,32 @@ pub(crate) trait AdminAgglayer {
     /// queue returns `RpcErrorCode::Unavailable`'s code.
     #[method(name = "reloadSettlementTask")]
     async fn reload_settlement_task(&self, job_id: SettlementJobId) -> RpcResult<()>;
+
+    /// Append one new settlement attempt to a settlement job.
+    ///
+    /// **JSON-RPC method:** `admin_insertSettlementAttempt`
+    ///
+    /// Registers a settlement transaction the service does not know about
+    /// (for example, one submitted out of band or ported from the legacy
+    /// settlement path) so the settlement task tracks it like its own
+    /// attempts. Only `txHash` is mandatory. The transaction is always queried
+    /// on L1: its sender and nonce are authoritative when found, so explicit
+    /// values must match and missing values are resolved from it. An unknown
+    /// transaction is accepted with a warning only when both identity fields
+    /// are explicit; otherwise it is rejected.
+    ///
+    /// This always appends one new attempt under the next unused attempt
+    /// number, never overwrites an existing attempt, and returns the
+    /// store-assigned number. It fails if the job does not exist, or if it
+    /// already has a terminal result and `force` is not `"force=true"` (see
+    /// [`Force`]).
+    #[method(name = "insertSettlementAttempt")]
+    async fn insert_settlement_attempt(
+        &self,
+        job_id: SettlementJobId,
+        attempt: InsertAttemptParams,
+        force: Option<Force>,
+    ) -> RpcResult<MutationResponse>;
 
     /// Record that this settlement attempt will never land on L1.
     ///
@@ -923,6 +951,25 @@ where
             .admin_reload_and_restart_task(job_id)
             .await
             .map_err(map_admin_error)
+    }
+
+    #[instrument(skip(self))]
+    async fn insert_settlement_attempt(
+        &self,
+        job_id: SettlementJobId,
+        attempt: InsertAttemptParams,
+        force: Option<Force>,
+    ) -> RpcResult<MutationResponse> {
+        warn!("(ADMIN) Inserting settlement attempt for job {job_id}");
+        let (attempt_number, live_task) = self
+            .settlement_service
+            .admin_insert_settlement_attempt(job_id, attempt.into(), edit_even_if_completed(force))
+            .await
+            .map_err(map_admin_error)?;
+        Ok(MutationResponse {
+            attempt_number,
+            live_task,
+        })
     }
 
     #[instrument(skip(self))]

--- a/crates/agglayer-jsonrpc-api/src/settlement_admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/settlement_admin.rs
@@ -1,11 +1,66 @@
 //! Shared types and error handling for settlement administration RPC methods.
 
-use agglayer_settlement_service::LiveTaskNotification;
+use std::time::{Duration, SystemTime};
+
+use agglayer_settlement_service::{LiveTaskNotification, NewSettlementAttempt};
 use agglayer_storage::stores::EditEvenIfCompleted;
-use agglayer_types::RpcErrorCode;
+use agglayer_types::{Address, Nonce, RpcErrorCode, SettlementTxHash};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
+
+/// A settlement attempt as accepted by `admin_insertSettlementAttempt`.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InsertAttemptParams {
+    /// Hash of the settlement transaction. The only mandatory field. When L1
+    /// knows the transaction, its identity fields are authoritative; otherwise
+    /// both `senderWallet` and `nonce` must be provided.
+    pub tx_hash: SettlementTxHash,
+
+    /// Wallet the settlement transaction was sent from. Resolved from L1 when
+    /// omitted, and validated against L1 when explicit.
+    #[serde(default)]
+    pub sender_wallet: Option<Address>,
+
+    /// L1 nonce of the settlement transaction. Resolved from L1 when omitted,
+    /// and validated against L1 when explicit.
+    #[serde(default)]
+    pub nonce: Option<u64>,
+
+    /// Unix timestamp (in seconds) at which the transaction was submitted to
+    /// L1. Defaults to now. The settlement task uses it as the base of its
+    /// retry backoff for this attempt.
+    #[serde(default)]
+    pub submission_time_unix_secs: Option<u64>,
+
+    /// `max_fee_per_gas` (wei) of the transaction. A fee-bumping retry
+    /// outbids this baseline. When omitted, taken from the L1 transaction if
+    /// it was fetched, else 0 (which makes a retry start over from freshly
+    /// estimated fees).
+    #[serde(default)]
+    pub max_fee_per_gas: Option<u128>,
+
+    /// `max_priority_fee_per_gas` (wei) of the transaction. Defaulted like
+    /// `maxFeePerGas`.
+    #[serde(default)]
+    pub max_priority_fee_per_gas: Option<u128>,
+}
+
+impl From<InsertAttemptParams> for NewSettlementAttempt {
+    fn from(params: InsertAttemptParams) -> Self {
+        Self {
+            tx_hash: params.tx_hash,
+            sender_wallet: params.sender_wallet,
+            nonce: params.nonce.map(Nonce),
+            submission_time: params
+                .submission_time_unix_secs
+                .map(|seconds| SystemTime::UNIX_EPOCH + Duration::from_secs(seconds)),
+            max_fee_per_gas: params.max_fee_per_gas,
+            max_priority_fee_per_gas: params.max_priority_fee_per_gas,
+        }
+    }
+}
 
 /// Controls whether a settlement attempt mutation may touch a job that
 /// already has a terminal result.

--- a/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
@@ -6,6 +6,11 @@ use agglayer_types::{
     Nonce, RpcErrorCode, SettlementAttempt, SettlementAttemptNumber, SettlementAttemptResult,
     SettlementJob, SettlementJobId, SettlementJobResult, SettlementTxHash, B256, U256,
 };
+use alloy::{
+    network::EthereumWallet,
+    providers::{mock::Asserter, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+};
 use jsonrpsee::{
     core::{client::ClientT, ClientError},
     rpc_params,
@@ -80,6 +85,65 @@ fn settlement_attempt() -> SettlementAttempt {
         max_fee_per_gas: 10,
         max_priority_fee_per_gas: 1,
     }
+}
+
+fn l1_transaction(seed: u8) -> alloy::rpc::types::Transaction {
+    let transaction =
+        alloy::consensus::TxEnvelope::Eip1559(alloy::consensus::Signed::new_unhashed(
+            alloy::consensus::TxEip1559 {
+                chain_id: 1,
+                nonce: seed as u64,
+                gas_limit: 21_000,
+                max_fee_per_gas: seed as u128 + 30,
+                max_priority_fee_per_gas: seed as u128 + 3,
+                ..Default::default()
+            },
+            alloy::primitives::Signature::new(U256::from(1), U256::from(2), false),
+        ));
+
+    alloy::rpc::types::Transaction {
+        inner: alloy::consensus::transaction::Recovered::new_unchecked(
+            transaction,
+            Address::from([seed; 20]).into(),
+        ),
+        block_hash: None,
+        block_number: None,
+        transaction_index: None,
+        effective_gas_price: Some(seed as u128 + 30),
+    }
+}
+
+fn insert_attempt_params(seed: u8) -> serde_json::Value {
+    let transaction = l1_transaction(seed);
+    serde_json::json!({
+        "txHash": SettlementTxHash::from(
+            alloy::network::TransactionResponse::tx_hash(&transaction)
+        ),
+        "senderWallet": Address::from([seed; 20]),
+        "nonce": seed as u64,
+        "submissionTimeUnixSecs": seed as u64 + 1_700_000_000,
+        "maxFeePerGas": seed as u128 + 30,
+        "maxPriorityFeePerGas": seed as u128 + 3,
+    })
+}
+
+async fn context_with_settlement_transactions(
+    transactions: impl IntoIterator<Item = Option<alloy::rpc::types::Transaction>>,
+) -> TestContext {
+    let asserter = Asserter::new();
+    for transaction in transactions {
+        asserter.push_success(&transaction);
+    }
+    let settlement_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(
+            PrivateKeySigner::from_slice(&[0x11; 32]).expect("valid test signing key"),
+        ))
+        .connect_mocked_client(asserter);
+    TestContext::new_with_settlement_provider(
+        TestContext::get_default_config(),
+        settlement_provider,
+    )
+    .await
 }
 
 fn error_payload(error: ClientError, expected: RpcErrorCode) -> String {
@@ -210,6 +274,162 @@ async fn admin_reload_settlement_task_errors_are_classified() {
         RpcErrorCode::AlreadyCompleted,
     );
     insta::assert_snapshot!("admin_reload_settlement_task__completed_job", error);
+}
+
+#[test_log::test(tokio::test)]
+async fn admin_insert_settlement_attempt_round_trips_over_http() {
+    let context =
+        context_with_settlement_transactions([Some(l1_transaction(1)), Some(l1_transaction(2))])
+            .await;
+    let job_id = SettlementJobId::from(10_u128);
+
+    context
+        .state_store
+        .insert_settlement_job(&job_id, &settlement_job())
+        .unwrap();
+
+    // All identity fields are explicit, but the service still queries L1 and
+    // verifies that sender and nonce match the authoritative transaction.
+    let first_response: serde_json::Value = context
+        .admin_client
+        .request(
+            "admin_insertSettlementAttempt",
+            rpc_params![job_id, insert_attempt_params(1)],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        first_response,
+        serde_json::json!({"attemptNumber": 0, "liveTask": "absent"})
+    );
+
+    let second_response: serde_json::Value = context
+        .admin_client
+        .request(
+            "admin_insertSettlementAttempt",
+            rpc_params![job_id, insert_attempt_params(2)],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        second_response,
+        serde_json::json!({"attemptNumber": 1, "liveTask": "absent"})
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn admin_insert_settlement_attempt_rejects_invalid_attempt_params() {
+    let context = TestContext::new_with_config(TestContext::get_default_config()).await;
+    let job_id = SettlementJobId::from(11_u128);
+    let missing_tx_hash = serde_json::json!({
+        "senderWallet": Address::from([0x11; 20]),
+        "nonce": 1,
+        "submissionTimeUnixSecs": 1_700_000_001_u64,
+        "maxFeePerGas": 31,
+        "maxPriorityFeePerGas": 4,
+    });
+    let mut unknown_field = insert_attempt_params(3);
+    unknown_field
+        .as_object_mut()
+        .expect("attempt params should be an object")
+        .insert("unexpected".to_owned(), serde_json::Value::Bool(true));
+
+    for attempt in [missing_tx_hash, unknown_field] {
+        let error = context
+            .admin_client
+            .request::<serde_json::Value, _>(
+                "admin_insertSettlementAttempt",
+                rpc_params![job_id, attempt],
+            )
+            .await
+            .expect_err("invalid attempt parameters should be rejected");
+
+        match error {
+            ClientError::Call(error) => {
+                assert_eq!(error.code(), jsonrpsee::types::error::INVALID_PARAMS_CODE);
+            }
+            error => panic!("expected JSON-RPC call error, got {error}"),
+        }
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn admin_insert_settlement_attempt_errors_are_classified() {
+    let context = context_with_settlement_transactions([None, None]).await;
+
+    let unknown_job_id = SettlementJobId::from(12_u128);
+    let unknown_error = mutation_error(
+        context
+            .admin_client
+            .request::<serde_json::Value, _>(
+                "admin_insertSettlementAttempt",
+                rpc_params![unknown_job_id, insert_attempt_params(4)],
+            )
+            .await,
+        RpcErrorCode::NotFound,
+    );
+    insta::assert_snapshot!(
+        "admin_insert_settlement_attempt__unknown_job",
+        unknown_error
+    );
+
+    let completed_job_id = SettlementJobId::from(13_u128);
+    context
+        .state_store
+        .insert_settlement_job(&completed_job_id, &settlement_job())
+        .unwrap();
+    context
+        .state_store
+        .insert_settlement_job_result(&completed_job_id, &settlement_result())
+        .unwrap();
+    let completed_error = mutation_error(
+        context
+            .admin_client
+            .request::<serde_json::Value, _>(
+                "admin_insertSettlementAttempt",
+                rpc_params![completed_job_id, insert_attempt_params(5)],
+            )
+            .await,
+        RpcErrorCode::AlreadyCompleted,
+    );
+    insta::assert_snapshot!(
+        "admin_insert_settlement_attempt__completed_job",
+        completed_error
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn admin_insert_settlement_attempt_identity_mismatch_is_invalid_params() {
+    let context = context_with_settlement_transactions([Some(l1_transaction(6))]).await;
+    let job_id = SettlementJobId::from(14_u128);
+    context
+        .state_store
+        .insert_settlement_job(&job_id, &settlement_job())
+        .unwrap();
+    let mut attempt = insert_attempt_params(6);
+    attempt
+        .as_object_mut()
+        .expect("attempt params should be an object")
+        .insert(
+            "senderWallet".to_owned(),
+            serde_json::json!(Address::from([0xff; 20])),
+        );
+
+    let error = context
+        .admin_client
+        .request::<serde_json::Value, _>(
+            "admin_insertSettlementAttempt",
+            rpc_params![job_id, attempt],
+        )
+        .await
+        .expect_err("an identity mismatch should be rejected");
+
+    match error {
+        ClientError::Call(error) => {
+            assert_eq!(error.code(), RpcErrorCode::InvalidParams.code());
+        }
+        error => panic!("expected JSON-RPC call error, got {error}"),
+    }
 }
 
 #[test_log::test(tokio::test)]

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__settlement_admin__admin_insert_settlement_attempt__completed_job.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__settlement_admin__admin_insert_settlement_attempt__completed_job.snap
@@ -1,0 +1,14 @@
+---
+source: crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
+expression: completed_error
+---
+{
+  "code": -10010,
+  "data": {
+    "classified": {
+      "code": "already-completed",
+      "message": "Failed to insert settlement attempt for job 0000000000000000000000000D\n\nCaused by:\n   0: already completed\n   1: Settlement job 0000000000000000000000000D already has a terminal result; pass force to edit its attempts anyway\n\nLocation:\n    crates/agglayer-settlement-service/src/settlement_service.rs:<line>:<column>"
+    }
+  },
+  "message": "Failed to insert settlement attempt for job 0000000000000000000000000D\n\nCaused by:\n   0: already completed\n   1: Settlement job 0000000000000000000000000D already has a terminal result; pass force to edit its attempts anyway\n\nLocation:\n    crates/agglayer-settlement-service/src/settlement_service.rs:<line>:<column>"
+}

--- a/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__settlement_admin__admin_insert_settlement_attempt__unknown_job.snap
+++ b/crates/agglayer-jsonrpc-api/src/tests/snapshots/agglayer_jsonrpc_api__tests__settlement_admin__admin_insert_settlement_attempt__unknown_job.snap
@@ -1,0 +1,14 @@
+---
+source: crates/agglayer-jsonrpc-api/src/tests/settlement_admin.rs
+expression: unknown_error
+---
+{
+  "code": -10008,
+  "data": {
+    "classified": {
+      "code": "not-found",
+      "message": "Failed to insert settlement attempt for job 0000000000000000000000000C\n\nCaused by:\n   0: not found\n   1: Settlement job 0000000000000000000000000C does not exist\n\nLocation:\n    crates/agglayer-settlement-service/src/settlement_service.rs:<line>:<column>"
+    }
+  },
+  "message": "Failed to insert settlement attempt for job 0000000000000000000000000C\n\nCaused by:\n   0: not found\n   1: Settlement job 0000000000000000000000000C does not exist\n\nLocation:\n    crates/agglayer-settlement-service/src/settlement_service.rs:<line>:<column>"
+}

--- a/crates/agglayer-jsonrpc-api/src/testutils.rs
+++ b/crates/agglayer-jsonrpc-api/src/testutils.rs
@@ -17,7 +17,7 @@ use alloy::{
     providers::{
         fillers::{BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller},
         mock::Asserter,
-        Identity, ProviderBuilder, RootProvider,
+        Identity, Provider, ProviderBuilder, RootProvider, WalletProvider,
     },
     signers::local::PrivateKeySigner,
     transports::mock::MockTransport,
@@ -96,7 +96,37 @@ impl TestContext {
     /// Common implementation for creating TestContext with any provider
     pub async fn new_with_provider<P>(config: Config, provider: P) -> Self
     where
-        P: alloy::providers::Provider + Clone + 'static,
+        P: Provider + Clone + 'static,
+    {
+        // Give the settlement service a wallet-carrying provider pointed at a
+        // dead endpoint. Tests that exercise settlement L1 reads inject a
+        // mocked provider through `new_with_settlement_provider`.
+        let settlement_provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(
+                PrivateKeySigner::from_slice(&[0x11; 32]).expect("valid test signing key"),
+            ))
+            .connect_http(
+                "http://127.0.0.1:0"
+                    .parse()
+                    .expect("test provider URL should parse"),
+            );
+        Self::new_with_providers(config, provider, settlement_provider).await
+    }
+
+    /// Create a [`TestContext`] with a custom settlement L1 provider.
+    pub async fn new_with_settlement_provider<S>(config: Config, settlement_provider: S) -> Self
+    where
+        S: Provider + WalletProvider + 'static,
+    {
+        let asserter = Asserter::new();
+        let mock_provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        Self::new_with_providers(config, mock_provider, settlement_provider).await
+    }
+
+    async fn new_with_providers<P, S>(config: Config, provider: P, settlement_provider: S) -> Self
+    where
+        P: Provider + Clone + 'static,
+        S: Provider + WalletProvider + 'static,
     {
         let cancellation_token = CancellationToken::new();
         let config = Arc::new(config);
@@ -154,19 +184,6 @@ impl TestContext {
         // Create AgglayerImpl
         let agglayer_impl = crate::AgglayerImpl::new(v0_service, rpc_service);
 
-        // A settlement service over the (empty) state store, with its own
-        // wallet-carrying provider pointed at a dead endpoint: startup
-        // recovery finds no jobs, and admin methods that reach L1 error out
-        // instead of hanging.
-        let settlement_provider = ProviderBuilder::new()
-            .wallet(EthereumWallet::from(
-                PrivateKeySigner::from_slice(&[0x11; 32]).expect("valid test signing key"),
-            ))
-            .connect_http(
-                "http://127.0.0.1:0"
-                    .parse()
-                    .expect("test provider URL should parse"),
-            );
         let settlement_service = SettlementService::start(
             SettlementServiceConfig::default(),
             Arc::new(SettlementTransactionConfig::default()),

--- a/crates/agglayer-settlement-service/src/lib.rs
+++ b/crates/agglayer-settlement-service/src/lib.rs
@@ -15,7 +15,7 @@ mod settlement_task;
 mod utils;
 mod wallet_nonce_locks;
 
-pub use settlement_service::{LiveTaskNotification, SettlementService};
+pub use settlement_service::{LiveTaskNotification, NewSettlementAttempt, SettlementService};
 #[cfg(feature = "testutils")]
 pub use settlement_service_trait::MockSettlementServiceTrait;
 pub use settlement_service_trait::SettlementServiceTrait;

--- a/crates/agglayer-settlement-service/src/settlement_service.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service.rs
@@ -1,14 +1,18 @@
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::SystemTime};
 
 use agglayer_config::settlement_service::{SettlementServiceConfig, SettlementTransactionConfig};
 use agglayer_storage::stores::{
     EditEvenIfCompleted, SettlementReader, SettlementWriter, StateReader, StateWriter,
 };
 use agglayer_types::{
-    CertificateId, ClientError, RpcErrorCode, SettlementAttemptResult, SettlementJob,
-    SettlementJobId, SettlementJobResult,
+    Address, CertificateId, ClientError, Nonce, RpcErrorCode, SettlementAttempt,
+    SettlementAttemptResult, SettlementJob, SettlementJobId, SettlementJobResult, SettlementTxHash,
 };
-use alloy::providers::{Provider, WalletProvider};
+use alloy::{
+    consensus::Transaction as _,
+    network::TransactionResponse as _,
+    providers::{Provider, WalletProvider},
+};
 use educe::Educe;
 use eyre::Context as _;
 use tokio::sync::{mpsc, watch, Mutex};
@@ -59,6 +63,24 @@ pub enum LiveTaskNotification {
     /// which case occurred. Use `admin_reloadSettlementTask` as the escape
     /// hatch, or abort the task and restart the node.
     NotifyFailed,
+}
+
+/// A settlement attempt to register through the admin surface.
+///
+/// Only the transaction hash is mandatory. The transaction is fetched from L1
+/// by hash when available: explicit sender and nonce values must match it, and
+/// missing values are resolved from it. An unknown transaction is accepted
+/// only when both identity fields are explicit, with a warning. Missing fees
+/// fall back to the fetched transaction's fees, or 0 when it is unknown. A
+/// missing submission time defaults to now.
+#[derive(Clone, Debug)]
+pub struct NewSettlementAttempt {
+    pub tx_hash: SettlementTxHash,
+    pub sender_wallet: Option<Address>,
+    pub nonce: Option<Nonce>,
+    pub submission_time: Option<SystemTime>,
+    pub max_fee_per_gas: Option<u128>,
+    pub max_priority_fee_per_gas: Option<u128>,
 }
 
 fn tag_admin_storage_error(error: agglayer_storage::error::Error) -> eyre::Report {
@@ -412,6 +434,125 @@ impl<
                 LiveTaskNotification::NotifyFailed
             }
         }
+    }
+
+    /// Resolves an admin-provided attempt into a full [`SettlementAttempt`].
+    ///
+    /// The transaction is always queried on L1. When found, its sender and
+    /// nonce are authoritative: explicit values must match, and missing values
+    /// are filled from it. When it is unknown, both values must be explicit and
+    /// are trusted with a warning. Fees use explicit values, then fetched
+    /// values, then `0`; zero makes a fee-bumping retry start over from freshly
+    /// estimated fees. Submission time uses the explicit value or the current
+    /// time, seeding the task's retry backoff for this attempt.
+    async fn resolve_new_settlement_attempt(
+        &self,
+        attempt: NewSettlementAttempt,
+    ) -> eyre::Result<SettlementAttempt> {
+        let tx_hash = attempt.tx_hash;
+        let fetched_tx = self
+            .provider
+            .get_transaction_by_hash(tx_hash.into())
+            .await
+            .wrap_err(RpcErrorCode::Unavailable)
+            .wrap_err_with(|| {
+                format!("Failed to fetch settlement transaction {tx_hash} from L1")
+            })?;
+
+        let (sender_wallet, nonce) = match fetched_tx.as_ref() {
+            Some(transaction) => {
+                let l1_sender_wallet = transaction.from().into();
+                let l1_nonce = Nonce(transaction.nonce());
+
+                if let Some(provided_sender_wallet) = attempt.sender_wallet {
+                    if provided_sender_wallet != l1_sender_wallet {
+                        return Err(eyre::eyre!(
+                            "Explicit sender wallet {provided_sender_wallet} does not match L1 \
+                             sender wallet {l1_sender_wallet} for settlement transaction {tx_hash}"
+                        )
+                        .wrap_err(RpcErrorCode::InvalidParams));
+                    }
+                }
+                if let Some(provided_nonce) = attempt.nonce {
+                    if provided_nonce != l1_nonce {
+                        return Err(eyre::eyre!(
+                            "Explicit nonce {provided_nonce} does not match L1 nonce {l1_nonce} \
+                             for settlement transaction {tx_hash}"
+                        )
+                        .wrap_err(RpcErrorCode::InvalidParams));
+                    }
+                }
+
+                (l1_sender_wallet, l1_nonce)
+            }
+            None => match (attempt.sender_wallet, attempt.nonce) {
+                (Some(sender_wallet), Some(nonce)) => {
+                    warn!(
+                        %tx_hash,
+                        %sender_wallet,
+                        %nonce,
+                        "Settlement transaction is not known to the L1 RPC; trusting explicitly \
+                         provided sender wallet and nonce"
+                    );
+                    (sender_wallet, nonce)
+                }
+                _ => {
+                    return Err(eyre::eyre!(
+                        "Settlement transaction {tx_hash} is not known to the L1 RPC; provide \
+                         sender_wallet and nonce explicitly"
+                    )
+                    .wrap_err(RpcErrorCode::NotFound));
+                }
+            },
+        };
+
+        Ok(SettlementAttempt {
+            sender_wallet,
+            nonce,
+            hash: tx_hash,
+            submission_time: attempt.submission_time.unwrap_or_else(SystemTime::now),
+            max_fee_per_gas: attempt
+                .max_fee_per_gas
+                // Fully qualified: the RPC transaction type also offers
+                // `TransactionResponse::max_fee_per_gas`.
+                .or_else(|| {
+                    fetched_tx
+                        .as_ref()
+                        .map(alloy::consensus::Transaction::max_fee_per_gas)
+                })
+                .unwrap_or(0),
+            max_priority_fee_per_gas: attempt
+                .max_priority_fee_per_gas
+                .or_else(|| {
+                    fetched_tx
+                        .as_ref()
+                        .and_then(|tx| tx.max_priority_fee_per_gas())
+                })
+                .unwrap_or(0),
+        })
+    }
+
+    /// Appends a new settlement attempt to `job_id` and returns its assigned
+    /// attempt number.
+    ///
+    /// This always adds one new attempt under the next unused number and never
+    /// overwrites an existing one, so it is safe for porting an externally
+    /// submitted settlement transaction into the job.
+    #[tracing::instrument(skip(self))]
+    pub async fn admin_insert_settlement_attempt(
+        &self,
+        job_id: SettlementJobId,
+        attempt: NewSettlementAttempt,
+        edit_even_if_completed: EditEvenIfCompleted,
+    ) -> eyre::Result<(u64, LiveTaskNotification)> {
+        let attempt = self.resolve_new_settlement_attempt(attempt).await?;
+        let attempt_number = self
+            .store
+            .admin_insert_settlement_attempt(&job_id, &attempt, edit_even_if_completed)
+            .map_err(tag_admin_storage_error)
+            .wrap_err_with(|| format!("Failed to insert settlement attempt for job {job_id}"))?;
+        let live_task = self.notify_live_task_of_admin_edit(job_id).await;
+        Ok((attempt_number, live_task))
     }
 
     /// Records that an administrator asserts the attempt will never land on

--- a/crates/agglayer-settlement-service/src/settlement_service/tests.rs
+++ b/crates/agglayer-settlement-service/src/settlement_service/tests.rs
@@ -1,12 +1,15 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
 
 use agglayer_storage::{
     error::Error as StorageError, stores::EditEvenIfCompleted, tests::mocks::MockStateStore,
 };
 use agglayer_types::{
     CertificateId, ClientErrorType, ContractCallOutcome, ContractCallResult, Digest, Nonce,
-    RpcErrorCode, SettlementAttemptNumber, SettlementAttemptResult, SettlementJob, SettlementJobId,
-    SettlementJobResult, SettlementTxHash, B256, U256,
+    RpcErrorCode, SettlementAttempt, SettlementAttemptNumber, SettlementAttemptResult,
+    SettlementJob, SettlementJobId, SettlementJobResult, SettlementTxHash, B256, U256,
 };
 use alloy::{
     network::EthereumWallet,
@@ -680,6 +683,487 @@ async fn admin_reload_with_closed_admin_channel_is_classified_via_storage() {
     assert_eq!(
         error.downcast_ref::<RpcErrorCode>(),
         Some(&RpcErrorCode::NoLiveTask)
+    );
+}
+
+/// A fully specified admin attempt.
+fn mk_new_attempt(seed: u8, tx_hash: SettlementTxHash) -> NewSettlementAttempt {
+    NewSettlementAttempt {
+        tx_hash,
+        sender_wallet: Some(agglayer_types::Address::from([seed; 20])),
+        nonce: Some(Nonce(seed as u64)),
+        submission_time: Some(std::time::SystemTime::UNIX_EPOCH),
+        max_fee_per_gas: Some(30),
+        max_priority_fee_per_gas: Some(3),
+    }
+}
+
+/// What [`mk_new_attempt`] resolves to when its identity matches L1.
+fn mk_resolved_attempt(seed: u8, tx_hash: SettlementTxHash) -> SettlementAttempt {
+    SettlementAttempt {
+        sender_wallet: agglayer_types::Address::from([seed; 20]),
+        nonce: Nonce(seed as u64),
+        hash: tx_hash,
+        submission_time: std::time::SystemTime::UNIX_EPOCH,
+        max_fee_per_gas: 30,
+        max_priority_fee_per_gas: 3,
+    }
+}
+
+fn mk_l1_transaction(
+    sender: agglayer_types::Address,
+    nonce: u64,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+) -> alloy::rpc::types::Transaction {
+    let transaction =
+        alloy::consensus::TxEnvelope::Eip1559(alloy::consensus::Signed::new_unhashed(
+            alloy::consensus::TxEip1559 {
+                chain_id: 1,
+                nonce,
+                gas_limit: 21_000,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                ..Default::default()
+            },
+            alloy::primitives::Signature::new(U256::from(1), U256::from(2), false),
+        ));
+
+    alloy::rpc::types::Transaction {
+        inner: alloy::consensus::transaction::Recovered::new_unchecked(transaction, sender.into()),
+        block_hash: None,
+        block_number: None,
+        transaction_index: None,
+        effective_gas_price: Some(max_fee_per_gas),
+    }
+}
+
+fn mk_provider_with_tx_response(
+    transaction: Option<alloy::rpc::types::Transaction>,
+) -> impl Provider + WalletProvider + 'static {
+    let asserter = Asserter::new();
+    asserter.push_success(&transaction);
+    ProviderBuilder::new()
+        .wallet(EthereumWallet::from(
+            PrivateKeySigner::from_slice(&[0x11; 32]).expect("valid test signing key"),
+        ))
+        .connect_mocked_client(asserter)
+}
+
+const UNKNOWN_TX_WARNING: &str = "Settlement transaction is not known to the L1 RPC; trusting \
+                                  explicitly provided sender wallet and nonce";
+
+struct ExpectedWarnCountingSubscriber {
+    warn_events: Arc<AtomicUsize>,
+}
+
+impl tracing::Subscriber for ExpectedWarnCountingSubscriber {
+    fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        if *event.metadata().level() != tracing::Level::WARN
+            || event.metadata().target() != "agglayer_settlement_service::settlement_service"
+        {
+            return;
+        }
+
+        struct ExpectedMessageVisitor(bool);
+
+        impl tracing::field::Visit for ExpectedMessageVisitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" && format!("{value:?}") == UNKNOWN_TX_WARNING {
+                    self.0 = true;
+                }
+            }
+
+            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                if field.name() == "message" && value == UNKNOWN_TX_WARNING {
+                    self.0 = true;
+                }
+            }
+        }
+
+        let mut visitor = ExpectedMessageVisitor(false);
+        event.record(&mut visitor);
+        if visitor.0 {
+            self.warn_events.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn enter(&self, _span: &tracing::span::Id) {}
+
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+#[tokio::test]
+async fn admin_insert_attempt_returns_assigned_number_and_reports_absent_task() {
+    let transaction = mk_l1_transaction(agglayer_types::Address::from([30; 20]), 30, 30, 3);
+    let tx_hash =
+        SettlementTxHash::from(alloy::network::TransactionResponse::tx_hash(&transaction));
+    let provider = mk_provider_with_tx_response(Some(transaction));
+
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(30);
+    let expected_attempt = mk_resolved_attempt(30, tx_hash);
+
+    store
+        .expect_admin_insert_settlement_attempt()
+        .once()
+        .withf(
+            move |requested_job_id, requested_attempt, edit_even_if_completed| {
+                requested_job_id == &job_id
+                    && requested_attempt == &expected_attempt
+                    && *edit_even_if_completed == EditEvenIfCompleted::No
+            },
+        )
+        .return_once(|_, _, _| Ok(3));
+
+    let service = SettlementService::start(
+        SettlementServiceConfig::default(),
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(provider),
+        Arc::new(store),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("settlement service should start")
+    .0;
+
+    let result = service
+        .admin_insert_settlement_attempt(
+            job_id,
+            mk_new_attempt(30, tx_hash),
+            EditEvenIfCompleted::No,
+        )
+        .await
+        .expect("admin insert should succeed");
+
+    assert_eq!(result, (3, LiveTaskNotification::Absent));
+}
+
+#[tokio::test]
+async fn admin_insert_attempt_trusts_explicit_identity_for_unknown_tx_and_warns() {
+    let tx_hash = SettlementTxHash::new(Digest::from([0x40; 32]));
+    let expected_attempt = mk_resolved_attempt(40, tx_hash);
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(40);
+    store
+        .expect_admin_insert_settlement_attempt()
+        .once()
+        .withf(move |requested_job_id, attempt, edit_even_if_completed| {
+            requested_job_id == &job_id
+                && attempt == &expected_attempt
+                && *edit_even_if_completed == EditEvenIfCompleted::No
+        })
+        .return_once(|_, _, _| Ok(4));
+
+    let service = SettlementService::start(
+        SettlementServiceConfig::default(),
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(mk_provider_with_tx_response(None)),
+        Arc::new(store),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("settlement service should start")
+    .0;
+
+    let warn_events = Arc::new(AtomicUsize::new(0));
+    // Thread-local default: `#[tokio::test]` uses a current-thread runtime, so
+    // the warning from this call is isolated from concurrently running tests.
+    let _guard = tracing::subscriber::set_default(ExpectedWarnCountingSubscriber {
+        warn_events: warn_events.clone(),
+    });
+    let result = service
+        .admin_insert_settlement_attempt(
+            job_id,
+            mk_new_attempt(40, tx_hash),
+            EditEvenIfCompleted::No,
+        )
+        .await
+        .expect("an unknown transaction with explicit identity should be accepted");
+
+    assert_eq!(result, (4, LiveTaskNotification::Absent));
+    assert_eq!(warn_events.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn admin_insert_attempt_resolves_missing_fields_from_l1() {
+    let sender = agglayer_types::Address::from([0x41; 20]);
+    let nonce = 7;
+    let max_fee_per_gas = 2_000_000_000;
+    let max_priority_fee_per_gas = 1_000_000_000;
+    let transaction = mk_l1_transaction(sender, nonce, max_fee_per_gas, max_priority_fee_per_gas);
+    let tx_hash =
+        SettlementTxHash::from(alloy::network::TransactionResponse::tx_hash(&transaction));
+    let provider = mk_provider_with_tx_response(Some(transaction));
+
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(31);
+    store
+        .expect_admin_insert_settlement_attempt()
+        .once()
+        .withf(move |requested_job_id, attempt, edit_even_if_completed| {
+            requested_job_id == &job_id
+                && attempt.sender_wallet == sender
+                && attempt.nonce == Nonce(nonce)
+                && attempt.hash == tx_hash
+                && attempt.max_fee_per_gas == max_fee_per_gas
+                && attempt.max_priority_fee_per_gas == max_priority_fee_per_gas
+                && *edit_even_if_completed == EditEvenIfCompleted::No
+        })
+        .return_once(|_, _, _| Ok(0));
+
+    let service = SettlementService::start(
+        SettlementServiceConfig::default(),
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(provider),
+        Arc::new(store),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("settlement service should start")
+    .0;
+
+    let result = service
+        .admin_insert_settlement_attempt(
+            job_id,
+            NewSettlementAttempt {
+                tx_hash,
+                sender_wallet: None,
+                nonce: None,
+                submission_time: None,
+                max_fee_per_gas: None,
+                max_priority_fee_per_gas: None,
+            },
+            EditEvenIfCompleted::No,
+        )
+        .await
+        .expect("admin insert should resolve the attempt from L1");
+
+    assert_eq!(result, (0, LiveTaskNotification::Absent));
+}
+
+#[tokio::test]
+async fn admin_insert_attempt_rejects_explicit_sender_mismatch_with_l1() {
+    let l1_sender_wallet = agglayer_types::Address::from([0x51; 20]);
+    let provided_sender_wallet = agglayer_types::Address::from([0x52; 20]);
+    let nonce = 9;
+    let transaction = mk_l1_transaction(l1_sender_wallet, nonce, 30, 3);
+    let tx_hash =
+        SettlementTxHash::from(alloy::network::TransactionResponse::tx_hash(&transaction));
+
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    store.expect_admin_insert_settlement_attempt().never();
+    let service = SettlementService::start(
+        SettlementServiceConfig::default(),
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(mk_provider_with_tx_response(Some(transaction))),
+        Arc::new(store),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("settlement service should start")
+    .0;
+
+    let error = service
+        .admin_insert_settlement_attempt(
+            mk_job_id(41),
+            NewSettlementAttempt {
+                tx_hash,
+                sender_wallet: Some(provided_sender_wallet),
+                nonce: Some(Nonce(nonce)),
+                submission_time: None,
+                max_fee_per_gas: None,
+                max_priority_fee_per_gas: None,
+            },
+            EditEvenIfCompleted::No,
+        )
+        .await
+        .expect_err("an explicit sender that disagrees with L1 should be rejected");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::InvalidParams)
+    );
+    assert_eq!(
+        error.chain().map(ToString::to_string).collect::<Vec<_>>(),
+        vec![
+            "invalid params".to_owned(),
+            format!(
+                "Explicit sender wallet {provided_sender_wallet} does not match L1 sender wallet \
+                 {l1_sender_wallet} for settlement transaction {tx_hash}"
+            ),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn admin_insert_attempt_rejects_explicit_nonce_mismatch_with_l1() {
+    let sender_wallet = agglayer_types::Address::from([0x53; 20]);
+    let l1_nonce = Nonce(10);
+    let provided_nonce = Nonce(11);
+    let transaction = mk_l1_transaction(sender_wallet, l1_nonce.0, 30, 3);
+    let tx_hash =
+        SettlementTxHash::from(alloy::network::TransactionResponse::tx_hash(&transaction));
+
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    store.expect_admin_insert_settlement_attempt().never();
+    let service = SettlementService::start(
+        SettlementServiceConfig::default(),
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(mk_provider_with_tx_response(Some(transaction))),
+        Arc::new(store),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("settlement service should start")
+    .0;
+
+    let error = service
+        .admin_insert_settlement_attempt(
+            mk_job_id(42),
+            NewSettlementAttempt {
+                tx_hash,
+                sender_wallet: Some(sender_wallet),
+                nonce: Some(provided_nonce),
+                submission_time: None,
+                max_fee_per_gas: None,
+                max_priority_fee_per_gas: None,
+            },
+            EditEvenIfCompleted::No,
+        )
+        .await
+        .expect_err("an explicit nonce that disagrees with L1 should be rejected");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::InvalidParams)
+    );
+    assert_eq!(
+        error.chain().map(ToString::to_string).collect::<Vec<_>>(),
+        vec![
+            "invalid params".to_owned(),
+            format!(
+                "Explicit nonce {provided_nonce} does not match L1 nonce {l1_nonce} for \
+                 settlement transaction {tx_hash}"
+            ),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn admin_insert_attempt_fails_for_unknown_tx_when_fields_missing() {
+    for (sender_wallet, nonce) in [
+        (None, None),
+        (Some(agglayer_types::Address::from([0x42; 20])), None),
+        (None, Some(Nonce(42))),
+    ] {
+        let mut store = MockStateStore::new();
+        expect_empty_startup_recovery(&mut store);
+        store.expect_admin_insert_settlement_attempt().never();
+
+        let service = SettlementService::start(
+            SettlementServiceConfig::default(),
+            Arc::new(SettlementTransactionConfig::default()),
+            Arc::new(mk_provider_with_tx_response(None)),
+            Arc::new(store),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("settlement service should start")
+        .0;
+
+        let error = service
+            .admin_insert_settlement_attempt(
+                mk_job_id(32),
+                NewSettlementAttempt {
+                    tx_hash: SettlementTxHash::new(Digest::from([0x42; 32])),
+                    sender_wallet,
+                    nonce,
+                    submission_time: None,
+                    max_fee_per_gas: None,
+                    max_priority_fee_per_gas: None,
+                },
+                EditEvenIfCompleted::No,
+            )
+            .await
+            .expect_err("unknown transaction with an incomplete identity should be rejected");
+
+        assert_eq!(
+            error.downcast_ref::<RpcErrorCode>(),
+            Some(&RpcErrorCode::NotFound)
+        );
+        assert!(format!("{error:#}").contains("not known to the L1 RPC"));
+    }
+}
+
+#[tokio::test]
+async fn admin_insert_attempt_completed_job_error_is_tagged_without_notification() {
+    let transaction = mk_l1_transaction(agglayer_types::Address::from([33; 20]), 33, 30, 3);
+    let tx_hash =
+        SettlementTxHash::from(alloy::network::TransactionResponse::tx_hash(&transaction));
+    let mut store = MockStateStore::new();
+    expect_empty_startup_recovery(&mut store);
+    let job_id = mk_job_id(33);
+
+    store
+        .expect_admin_insert_settlement_attempt()
+        .once()
+        .withf(move |requested_job_id, _, edit_even_if_completed| {
+            requested_job_id == &job_id && *edit_even_if_completed == EditEvenIfCompleted::No
+        })
+        .return_once(move |_, _, _| Err(StorageError::SettlementJobAlreadyCompleted(job_id)));
+
+    let service = SettlementService::start(
+        SettlementServiceConfig::default(),
+        Arc::new(SettlementTransactionConfig::default()),
+        Arc::new(mk_provider_with_tx_response(Some(transaction))),
+        Arc::new(store),
+        CancellationToken::new(),
+    )
+    .await
+    .expect("settlement service should start")
+    .0;
+    let (task_control_handle, mut task_control) =
+        TaskControlHandle::new(&service.cancellation_token);
+    service
+        .task_controls
+        .lock()
+        .await
+        .insert(job_id, task_control_handle);
+
+    let error = service
+        .admin_insert_settlement_attempt(
+            job_id,
+            mk_new_attempt(33, tx_hash),
+            EditEvenIfCompleted::No,
+        )
+        .await
+        .expect_err("a completed job should reject an unforced insert");
+
+    assert_eq!(
+        error.downcast_ref::<RpcErrorCode>(),
+        Some(&RpcErrorCode::AlreadyCompleted)
+    );
+    assert!(
+        task_control.try_recv_admin_command().is_none(),
+        "a failed storage insert must not trigger a task reload"
     );
 }
 

--- a/crates/agglayer-types/src/rpc_error_code.rs
+++ b/crates/agglayer-types/src/rpc_error_code.rs
@@ -10,6 +10,13 @@
 #[serde(rename_all = "kebab-case")]
 #[repr(i32)]
 pub enum RpcErrorCode {
+    /// A client-provided argument is structurally valid but conflicts with
+    /// authoritative state. This uses JSON-RPC's standard `INVALID_PARAMS`
+    /// code so service-layer validation can carry the wire classification as
+    /// an `eyre` tag.
+    #[error("invalid params")]
+    InvalidParams = -32602,
+
     /// Rollup is not registered.
     #[error("rollup not registered")]
     RollupNotRegistered = -10001,
@@ -83,6 +90,7 @@ impl RpcErrorCode {
     /// Stable machine-readable tag for wire payloads.
     pub const fn tag(&self) -> &'static str {
         match self {
+            Self::InvalidParams => "invalid-params",
             Self::RollupNotRegistered => "rollup-not-registered",
             Self::SignatureMismatch => "signature-mismatch",
             Self::ValidationFailure => "validation-failure",

--- a/crates/agglayer-types/src/rpc_error_code/tests.rs
+++ b/crates/agglayer-types/src/rpc_error_code/tests.rs
@@ -4,6 +4,12 @@ use super::*;
 fn display_and_tag_are_pinned() {
     let cases = [
         (
+            RpcErrorCode::InvalidParams,
+            "invalid params",
+            "invalid-params",
+            -32602,
+        ),
+        (
             RpcErrorCode::RollupNotRegistered,
             "rollup not registered",
             "rollup-not-registered",
@@ -94,6 +100,7 @@ fn display_and_tag_are_pinned() {
 #[test]
 fn serialization_matches_tag() {
     let codes = [
+        RpcErrorCode::InvalidParams,
         RpcErrorCode::RollupNotRegistered,
         RpcErrorCode::SignatureMismatch,
         RpcErrorCode::ValidationFailure,


### PR DESCRIPTION
Add the admin mutation for porting externally submitted settlement
transactions, including out-of-band gas bumps and legacy-path
transactions, into an existing settlement job.

Following D1, attempts are append-only: storage assigns the next unused
number, and the RPC returns that number instead of echoing client input.

Following D2, resolve transaction identity against L1 when available.
Explicit sender and nonce values must match the fetched transaction.
When L1 does not know the transaction, accept a complete explicit
identity with a warning; reject a partial identity.

Fees resolve as explicit, then fetched, then zero. The zero baseline
makes a later fee-bumping retry start from freshly estimated fees.
Submission time resolves as explicit, then now, seeding retry backoff.

Tags map to stable wire codes: invalid-params (-32602),
not-found (-10008), already-completed (-10010), and
unavailable (-10014).

The insert-versus-live-task numbering race remains documented in
https://github.com/agglayer/agglayer/pull/1711. A future task-pause
mechanism is the clean fix.

Part of #1675.