### PR TITLE
feat(pp): introduce groth16 wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "eyre",
  "fail",
  "futures-util",
+ "hex",
  "lazy_static",
  "mockall",
  "parking_lot",
@@ -671,6 +672,7 @@ dependencies = [
  "serde-reflection",
  "serde_json",
  "serde_with",
+ "sp1-prover 6.2.2",
  "sp1-sdk 5.2.2",
  "sp1-sdk 6.2.2",
  "strum 0.28.0",
@@ -8257,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "prover-alloy"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v2.0.0-rc.6#5c51190e0c0edd1ee9ba8bc4383bd74f361760e7"
+source = "git+https://github.com/agglayer/provers.git?branch=feat%2Fproof-type-groth16#c016d1acb126a1475e4ce5a65acbe5598a2b87ed"
 dependencies = [
  "agglayer-evm-client",
  "alloy",
@@ -8273,7 +8275,7 @@ dependencies = [
 [[package]]
 name = "prover-config"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v2.0.0-rc.6#5c51190e0c0edd1ee9ba8bc4383bd74f361760e7"
+source = "git+https://github.com/agglayer/provers.git?branch=feat%2Fproof-type-groth16#c016d1acb126a1475e4ce5a65acbe5598a2b87ed"
 dependencies = [
  "prover-utils",
  "serde",
@@ -8284,7 +8286,7 @@ dependencies = [
 [[package]]
 name = "prover-engine"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v2.0.0-rc.6#5c51190e0c0edd1ee9ba8bc4383bd74f361760e7"
+source = "git+https://github.com/agglayer/provers.git?branch=feat%2Fproof-type-groth16#c016d1acb126a1475e4ce5a65acbe5598a2b87ed"
 dependencies = [
  "agglayer-telemetry 0.1.0 (git+https://github.com/agglayer/agglayer.git?tag=v0.4.4)",
  "anyhow",
@@ -8305,7 +8307,7 @@ dependencies = [
 [[package]]
 name = "prover-executor"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v2.0.0-rc.6#5c51190e0c0edd1ee9ba8bc4383bd74f361760e7"
+source = "git+https://github.com/agglayer/provers.git?branch=feat%2Fproof-type-groth16#c016d1acb126a1475e4ce5a65acbe5598a2b87ed"
 dependencies = [
  "anyhow",
  "buildstructor 0.5.4",
@@ -8331,7 +8333,7 @@ dependencies = [
 [[package]]
 name = "prover-logger"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v2.0.0-rc.6#5c51190e0c0edd1ee9ba8bc4383bd74f361760e7"
+source = "git+https://github.com/agglayer/provers.git?branch=feat%2Fproof-type-groth16#c016d1acb126a1475e4ce5a65acbe5598a2b87ed"
 dependencies = [
  "serde",
  "tracing",
@@ -8342,7 +8344,7 @@ dependencies = [
 [[package]]
 name = "prover-utils"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/provers.git?tag=v2.0.0-rc.6#5c51190e0c0edd1ee9ba8bc4383bd74f361760e7"
+source = "git+https://github.com/agglayer/provers.git?branch=feat%2Fproof-type-groth16#c016d1acb126a1475e4ce5a65acbe5598a2b87ed"
 dependencies = [
  "humantime-serde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,11 +57,11 @@ agglayer-tries = "0.18.0"
 unified-bridge = "0.18.0"
 
 # Provers
-prover-alloy = { git = "https://github.com/agglayer/provers.git", tag = "v2.0.0-rc.6" }
-prover-config = { git = "https://github.com/agglayer/provers.git", tag = "v2.0.0-rc.6" }
-prover-logger = { git = "https://github.com/agglayer/provers.git", tag = "v2.0.0-rc.6" }
-prover-executor = { git = "https://github.com/agglayer/provers.git", tag = "v2.0.0-rc.6" }
-prover-engine = { git = "https://github.com/agglayer/provers.git", tag = "v2.0.0-rc.6" }
+prover-alloy = { git = "https://github.com/agglayer/provers.git", branch = "feat/proof-type-groth16" }
+prover-config = { git = "https://github.com/agglayer/provers.git", branch = "feat/proof-type-groth16" }
+prover-logger = { git = "https://github.com/agglayer/provers.git", branch = "feat/proof-type-groth16" }
+prover-executor = { git = "https://github.com/agglayer/provers.git", branch = "feat/proof-type-groth16" }
+prover-engine = { git = "https://github.com/agglayer/provers.git", branch = "feat/proof-type-groth16" }
 
 # SP1 dependencies
 # Note: Whenever these are updated, also consider updating the SP1 toolchain docker image version.
@@ -148,3 +148,4 @@ tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 ulid = { version = "1.2", features = ["serde"] }
 url = { version = "2.5", features = ["serde"] }
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ FROM --platform=${BUILDPLATFORM} golang:1.22 AS go-builder
 FROM debian:bookworm-slim AS circuits
 
 ARG CIRCUIT_ARTIFACTS_URL_BASE=https://sp1-circuits.s3-us-east-2.amazonaws.com
-# Both wrappings ship: groth16 is the default, plonk is the rollback target.
+# Both wrappings ship: plonk is the default and what runs today, groth16 is
+# opt-in via `proof-wrapping`. Shipping both is what lets that be a config
+# change rather than a redeploy, in either direction.
 ARG CIRCUIT_TYPES="groth16 plonk"
 ARG CIRCUIT_VERSION=v6.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,20 @@ FROM --platform=${BUILDPLATFORM} golang:1.22 AS go-builder
 FROM debian:bookworm-slim AS circuits
 
 ARG CIRCUIT_ARTIFACTS_URL_BASE=https://sp1-circuits.s3-us-east-2.amazonaws.com
-ARG CIRCUIT_TYPE=plonk
+# Both wrappings ship: groth16 is the default, plonk is the rollback target.
+ARG CIRCUIT_TYPES="groth16 plonk"
 ARG CIRCUIT_VERSION=v6.1.0
 
 RUN apt-get update && \
     apt-get --no-install-recommends install -y ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN mkdir -p /root/.sp1/circuits/${CIRCUIT_TYPE}/${CIRCUIT_VERSION} \
-    && curl -s -o /tmp/circuits.tar.gz ${CIRCUIT_ARTIFACTS_URL_BASE}/${CIRCUIT_VERSION}-${CIRCUIT_TYPE}.tar.gz \
-    && tar -Pxzf /tmp/circuits.tar.gz -C /root/.sp1/circuits/${CIRCUIT_TYPE}/${CIRCUIT_VERSION} \
-    && rm /tmp/circuits.tar.gz
+RUN set -eu; for circuit_type in ${CIRCUIT_TYPES}; do \
+        mkdir -p /root/.sp1/circuits/${circuit_type}/${CIRCUIT_VERSION} \
+        && curl -sSf -o /tmp/circuits.tar.gz ${CIRCUIT_ARTIFACTS_URL_BASE}/${CIRCUIT_VERSION}-${circuit_type}.tar.gz \
+        && tar -Pxzf /tmp/circuits.tar.gz -C /root/.sp1/circuits/${circuit_type}/${CIRCUIT_VERSION} \
+        && rm /tmp/circuits.tar.gz; \
+    done
 
 FROM chef AS builder
 

--- a/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/mod.rs
@@ -1,7 +1,7 @@
 use std::{panic::AssertUnwindSafe, sync::Arc};
 
 use agglayer_certificate_orchestrator::{CertificationError, Certifier, CertifierOutput};
-use agglayer_config::Config;
+use agglayer_config::{proof_wrapping::ProofWrapping, Config};
 use agglayer_contracts::{aggchain::AggchainContract, RollupContract};
 use agglayer_sp1::{AcceptancePolicy, ProofError, ProofExt as _};
 use agglayer_storage::stores::{PendingCertificateReader, PendingCertificateWriter};
@@ -11,7 +11,10 @@ use agglayer_types::{
 };
 use eyre::{eyre, Context as _};
 use pessimistic_proof::{
-    core::{commitment::StateCommitment, generate_pessimistic_proof, AggchainHashValues},
+    core::{
+        commitment::StateCommitment, generate_pessimistic_proof, AggchainHashValues,
+        PP_SELECTOR_GROTH16, PP_SELECTOR_PLONK,
+    },
     local_state::LocalNetworkState,
     multi_batch_header::MultiBatchHeader,
     unified_bridge::{
@@ -39,6 +42,21 @@ type ProverService = Buffer<
     BoxCloneService<prover_executor::Request, prover_executor::Response, prover_executor::Error>,
     prover_executor::Request,
 >;
+
+fn proof_type(wrapping: ProofWrapping) -> prover_executor::ProofType {
+    match wrapping {
+        ProofWrapping::Groth16 => prover_executor::ProofType::Groth16,
+        ProofWrapping::Plonk => prover_executor::ProofType::Plonk,
+    }
+}
+
+fn pp_selector(wrapping: ProofWrapping) -> [u8; 4] {
+    match wrapping {
+        ProofWrapping::Groth16 => PP_SELECTOR_GROTH16,
+        ProofWrapping::Plonk => PP_SELECTOR_PLONK,
+    }
+}
+
 #[derive(Clone)]
 pub struct CertifierClient<PendingStore, L1Rpc> {
     /// The pending store to fetch and store certificates and proofs.
@@ -194,6 +212,10 @@ where
         self.l1_rpc.default_l1_info_tree_entry().0
     }
 
+    fn pp_selector(&self) -> [u8; 4] {
+        pp_selector(self.config.proof_wrapping)
+    }
+
     #[instrument(skip(self, state, height), fields(certificate_id, %network_id), level = "info")]
     async fn certify(
         &self,
@@ -305,7 +327,7 @@ where
 
         let request = prover_executor::Request {
             stdin,
-            proof_type: prover_executor::ProofType::Plonk,
+            proof_type: proof_type(self.config.proof_wrapping),
         };
         info!("Sending the Proof generation request to the agglayer-prover service...");
         // Check if fail points are active and log warnings

--- a/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
+++ b/crates/agglayer-aggregator-notifier/src/certifier/tests.rs
@@ -322,3 +322,15 @@ mockall::mock! {
         ) -> Result<alloy::providers::PendingTransactionBuilder<Ethereum>, ContractError>;
     }
 }
+
+#[test]
+fn pp_selector_differs_only_by_wrapping() {
+    use agglayer_config::proof_wrapping::ProofWrapping;
+
+    let groth16 = super::pp_selector(ProofWrapping::Groth16);
+    let plonk = super::pp_selector(ProofWrapping::Plonk);
+
+    assert_eq!(groth16[0], 0x01);
+    assert_eq!(plonk[0], 0x00);
+    assert_eq!(groth16[1..], plonk[1..]);
+}

--- a/crates/agglayer-certificate-orchestrator/Cargo.toml
+++ b/crates/agglayer-certificate-orchestrator/Cargo.toml
@@ -41,6 +41,7 @@ agglayer-storage.workspace = true
 agglayer-telemetry.workspace = true
 agglayer-test-suite = { workspace = true, optional = true }
 agglayer-types.workspace = true
+hex.workspace = true
 agglayer-settlement-service.workspace = true
 pessimistic-proof.workspace = true
 

--- a/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/certificate_task.rs
@@ -16,7 +16,7 @@ use agglayer_types::{
     Certificate, CertificateHeader, CertificateStatus, CertificateStatusError, ContractCallOutcome,
     Digest, Proof, SettlementJob, SettlementJobResult, U256,
 };
-use pessimistic_proof::{core::PESSIMISTIC_PROOF_PROGRAM_SELECTOR, PessimisticProofOutput};
+use pessimistic_proof::PessimisticProofOutput;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn};
@@ -365,15 +365,16 @@ where
         let certificate_id = self.header.certificate_id;
 
         let proof = match self.pending_store.get_proof(certificate_id)? {
-            Some(Proof::SP1(proof)) => proof,
-            _ => {
+            Some(proof) => proof,
+            None => {
                 return Err(CertificateStatusError::SettlementError(format!(
                     "No SP1 proof found for certificate {certificate_id}"
                 )))
             }
         };
+        let Proof::SP1(sp1_proof) = &proof;
         let output = PessimisticProofOutput::bincode_codec()
-            .deserialize::<PessimisticProofOutput>(proof.public_values.as_slice())
+            .deserialize::<PessimisticProofOutput>(sp1_proof.public_values.as_slice())
             .map_err(|error| {
                 CertificateStatusError::SettlementError(format!(
                     "Failed to deserialize proof output: {error}"
@@ -391,11 +392,24 @@ where
                 ))
             })?;
 
-        let proof_bytes = proof.bytes();
+        let proof_bytes = proof
+            .onchain_bytes()
+            .map_err(|error| CertificateStatusError::SettlementError(error.to_string()))?;
         let proof_with_selector: Vec<u8> = match verifier_type {
             VerifierType::Pessimistic => proof_bytes,
             VerifierType::ALGateway => {
-                let mut prefixed = PESSIMISTIC_PROOF_PROGRAM_SELECTOR.to_vec();
+                let selector = self.certifier_client.pp_selector();
+
+                // The wrapping comes from the stored proof, the selector from
+                // the running config. Seeing both is what tells a settlement
+                // revert apart from every other kind.
+                info!(
+                    wrapping = %sp1_proof.proof,
+                    selector = %format!("0x{}", hex::encode(selector)),
+                    "Settling through the AgglayerGateway route"
+                );
+
+                let mut prefixed = selector.to_vec();
                 prefixed.extend(&proof_bytes);
                 prefixed
             }

--- a/crates/agglayer-certificate-orchestrator/src/certifier.rs
+++ b/crates/agglayer-certificate-orchestrator/src/certifier.rs
@@ -53,4 +53,8 @@ pub trait Certifier: Unpin + Send + Sync + 'static {
 
     /// Default l1-info-tree leaf count, used when the certificate carries none.
     fn default_l1_info_tree_leaf_count(&self) -> u32;
+
+    /// Selector prefixed to the proof so the `AgglayerGateway` picks the
+    /// verifier route matching the configured wrapping.
+    fn pp_selector(&self) -> [u8; 4];
 }

--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -923,4 +923,8 @@ impl Certifier for Check {
     fn default_l1_info_tree_leaf_count(&self) -> u32 {
         0
     }
+
+    fn pp_selector(&self) -> [u8; 4] {
+        pessimistic_proof::core::PP_SELECTOR_GROTH16
+    }
 }

--- a/crates/agglayer-certificate-orchestrator/src/tests/mocks.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests/mocks.rs
@@ -31,5 +31,7 @@ mock! {
         ) -> Result<agglayer_contracts::rollup::VerifierType, CertificationError>;
 
         fn default_l1_info_tree_leaf_count(&self) -> u32;
+
+        fn pp_selector(&self) -> [u8; 4];
     }
 }

--- a/crates/agglayer-config/src/lib.rs
+++ b/crates/agglayer-config/src/lib.rs
@@ -26,6 +26,7 @@ pub mod log;
 mod multiplier;
 pub mod outbound;
 mod port;
+pub mod proof_wrapping;
 pub mod rate_limiting;
 pub(crate) mod rpc;
 pub mod settlement_service;
@@ -114,6 +115,10 @@ pub struct Config {
     #[serde(default)]
     pub prover: prover_config::ProverType,
 
+    /// Wrapping used for the pessimistic proof, which also picks its L1 route.
+    #[serde(default)]
+    pub proof_wrapping: proof_wrapping::ProofWrapping,
+
     #[serde(default = "default_prover_buffer_size")]
     pub prover_buffer_size: usize,
 
@@ -178,6 +183,7 @@ impl Config {
             prover: prover_config::ProverType::NetworkProver(
                 prover_config::NetworkProverConfig::default(),
             ),
+            proof_wrapping: Default::default(),
             prover_buffer_size: default_prover_buffer_size(),
             debug_mode: false,
             mock_verifier: false,

--- a/crates/agglayer-config/src/proof_wrapping.rs
+++ b/crates/agglayer-config/src/proof_wrapping.rs
@@ -4,10 +4,13 @@ use serde::{Deserialize, Serialize};
 ///
 /// This also picks the `AgglayerGateway` route the proof is sent to, so the
 /// two can never disagree.
+///
+/// Defaults to Plonk, which is what is registered on L1 today: an existing
+/// deployment keeps settling exactly as before until it opts into Groth16.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ProofWrapping {
     #[default]
-    Groth16,
     Plonk,
+    Groth16,
 }

--- a/crates/agglayer-config/src/proof_wrapping.rs
+++ b/crates/agglayer-config/src/proof_wrapping.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+/// Wrapping applied to the pessimistic proof before it is settled on L1.
+///
+/// This also picks the `AgglayerGateway` route the proof is sent to, so the
+/// two can never disagree.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProofWrapping {
+    #[default]
+    Groth16,
+    Plonk,
+}

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_distinct_pp_and_tx_settlement_keys_are_preserved.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_distinct_pp_and_tx_settlement_keys_are_preserved.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/agglayer-config/tests/auth_config.rs
-expression: config
+expression: "$crate :: toml_snapshot_string(& config)"
 ---
+proof-wrapping = "groth16"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_distinct_pp_and_tx_settlement_keys_are_preserved.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_distinct_pp_and_tx_settlement_keys_are_preserved.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer-config/tests/auth_config.rs
 expression: "$crate :: toml_snapshot_string(& config)"
 ---
-proof-wrapping = "groth16"
+proof-wrapping = "plonk"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_legacy.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_legacy.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/agglayer-config/tests/auth_config.rs
-expression: config
+expression: "$crate :: toml_snapshot_string(& config)"
 ---
+proof-wrapping = "groth16"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_legacy.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_legacy.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer-config/tests/auth_config.rs
 expression: "$crate :: toml_snapshot_string(& config)"
 ---
-proof-wrapping = "groth16"
+proof-wrapping = "plonk"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_transition.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_transition.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/agglayer-config/tests/auth_config.rs
-expression: config
+expression: "$crate :: toml_snapshot_string(& config)"
 ---
+proof-wrapping = "groth16"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_transition.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_transition.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer-config/tests/auth_config.rs
 expression: "$crate :: toml_snapshot_string(& config)"
 ---
-proof-wrapping = "groth16"
+proof-wrapping = "plonk"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_update.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_update.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/agglayer-config/tests/auth_config.rs
-expression: config
+expression: "$crate :: toml_snapshot_string(& config)"
 ---
+proof-wrapping = "groth16"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/auth_config__auth_update.snap
+++ b/crates/agglayer-config/tests/snapshots/auth_config__auth_update.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer-config/tests/auth_config.rs
 expression: "$crate :: toml_snapshot_string(& config)"
 ---
-proof-wrapping = "groth16"
+proof-wrapping = "plonk"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
+++ b/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer-config/tests/backup.rs
 expression: "$crate :: toml_snapshot_string(& config)"
 ---
-proof-wrapping = "groth16"
+proof-wrapping = "plonk"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
+++ b/crates/agglayer-config/tests/snapshots/backup__backup_enabled.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/agglayer-config/tests/backup.rs
-expression: config
+expression: "$crate :: toml_snapshot_string(& config)"
 ---
+proof-wrapping = "groth16"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/agglayer-config/tests/validate_deserialize.rs
-expression: config
+expression: "$crate :: toml_snapshot_string(& config)"
 ---
+proof-wrapping = "groth16"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer-config/tests/validate_deserialize.rs
 expression: "$crate :: toml_snapshot_string(& config)"
 ---
-proof-wrapping = "groth16"
+proof-wrapping = "plonk"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/agglayer-config/tests/validate_deserialize.rs
-expression: config
+expression: "$crate :: toml_snapshot_string(& config)"
 ---
+proof-wrapping = "groth16"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__grpc_max_decoding_message_size.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer-config/tests/validate_deserialize.rs
 expression: "$crate :: toml_snapshot_string(& config)"
 ---
-proof-wrapping = "groth16"
+proof-wrapping = "plonk"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/agglayer-config/tests/validate_deserialize.rs
-expression: config
+expression: "$crate :: toml_snapshot_string(& config)"
 ---
+proof-wrapping = "groth16"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
+++ b/crates/agglayer-config/tests/snapshots/validate_deserialize__max_rpc_request_size.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer-config/tests/validate_deserialize.rs
 expression: "$crate :: toml_snapshot_string(& config)"
 ---
-proof-wrapping = "groth16"
+proof-wrapping = "plonk"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer-storage/Cargo.toml
+++ b/crates/agglayer-storage/Cargo.toml
@@ -46,6 +46,7 @@ rstest.workspace = true
 serde-reflection.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+sp1-prover.workspace = true
 sp1-sdk.workspace = true
 sp1-sdk-v5.workspace = true
 test-log.workspace = true

--- a/crates/agglayer-storage/src/columns/proof_per_certificate/tests.rs
+++ b/crates/agglayer-storage/src/columns/proof_per_certificate/tests.rs
@@ -37,6 +37,28 @@ fn can_parse_value() {
     assert!(matches!(expected_value, Proof::SP1(_)));
 }
 
+/// Groth16 rows coexist with pre-existing Plonk ones: the wrapping is a bincode
+/// enum tag, so the column needs no migration.
+#[test]
+fn groth16_round_trips_alongside_stored_plonk() {
+    let value = Proof::SP1(sp1_sdk::SP1ProofWithPublicValues {
+        proof: sp1_sdk::SP1Proof::Groth16(sp1_prover::Groth16Bn254Proof::default()),
+        public_values: sp1_sdk::SP1PublicValues::new(),
+        sp1_version: sp1_sdk::SP1_CIRCUIT_VERSION.to_owned(),
+        tee_proof: None,
+    });
+
+    let encoded = value.encode().expect("Unable to encode value");
+    let Proof::SP1(decoded) = Proof::decode(&encoded[..]).expect("Unable to decode value");
+    assert!(matches!(decoded.proof, sp1_sdk::SP1Proof::Groth16(_)));
+
+    let stored_plonk: SP1ProofWithPublicValues =
+        SP1ProofWithPublicValuesV3::load(non_regression_proof_path())
+            .unwrap()
+            .into();
+    assert!(matches!(stored_plonk.proof, sp1_sdk_v5::SP1Proof::Plonk(_)));
+}
+
 fn non_regression_proof_path() -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("./src/columns/proof_per_certificate/fixtures/non_regression_proof_encoding.proof")

--- a/crates/agglayer/src/main.rs
+++ b/crates/agglayer/src/main.rs
@@ -52,9 +52,10 @@ fn main() -> eyre::Result<()> {
         }
 
         cli::Commands::VkeySelector => {
-            let vkey_selector_hex =
-                hex::encode(pessimistic_proof::core::PESSIMISTIC_PROOF_PROGRAM_SELECTOR);
-            println!("0x{vkey_selector_hex}");
+            use pessimistic_proof::core::{PP_SELECTOR_GROTH16, PP_SELECTOR_PLONK};
+
+            println!("plonk   0x{}", hex::encode(PP_SELECTOR_PLONK));
+            println!("groth16 0x{}", hex::encode(PP_SELECTOR_GROTH16));
         }
 
         cli::Commands::Backup(cli::Backup::List { config_path: cfg }) => {

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -2,6 +2,7 @@
 source: crates/agglayer/tests/config.rs
 expression: sanitize_config_folder_path(result)
 ---
+proof-wrapping = "groth16"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/agglayer/tests/snapshots/config__config_display.snap
+++ b/crates/agglayer/tests/snapshots/config__config_display.snap
@@ -2,7 +2,7 @@
 source: crates/agglayer/tests/config.rs
 expression: sanitize_config_folder_path(result)
 ---
-proof-wrapping = "groth16"
+proof-wrapping = "plonk"
 prover-buffer-size = 100
 
 [full-node-rpcs]

--- a/crates/pessimistic-proof-core/src/lib.rs
+++ b/crates/pessimistic-proof-core/src/lib.rs
@@ -13,5 +13,13 @@ pub mod nullifier_tree;
 pub use local_state::NetworkState;
 
 include!(concat!(env!("OUT_DIR"), "/version.rs"));
-pub const PESSIMISTIC_PROOF_PROGRAM_SELECTOR: [u8; 4] =
-    PESSIMISTIC_PROOF_PROGRAM_VERSION.to_be_bytes();
+
+/// Selector high byte is the proof wrapping, low three bytes are the program
+/// major, so the two wrappings can never claim the same route.
+const fn selector(wrapping: u8) -> [u8; 4] {
+    let [_, a, b, c] = PESSIMISTIC_PROOF_PROGRAM_VERSION.to_be_bytes();
+    [wrapping, a, b, c]
+}
+
+pub const PP_SELECTOR_PLONK: [u8; 4] = selector(0x00);
+pub const PP_SELECTOR_GROTH16: [u8; 4] = selector(0x01);

--- a/crates/pessimistic-proof-test-suite/src/bin/README.md
+++ b/crates/pessimistic-proof-test-suite/src/bin/README.md
@@ -8,7 +8,7 @@ cargo run -r -p pessimistic-proof-test-suite --bin ppgen -- --help
 
 ## Local mode
 
-The following command will generate one plonk proof with the default mode which is local.
+The following command will generate one Groth16 proof with the default mode which is local.
 
 ```
 RUST_LOG=info cargo run -r -p pessimistic-proof-test-suite --bin ppgen -- --proof-dir ./data/proofs/ --n-exits 10
@@ -55,7 +55,7 @@ Expected logs:
 2024-10-01T10:31:05.958692Z  INFO View in explorer: https://explorer.succinct.xyz/proofrequest_01j93t47b4e8dv7kgcm0a02dra
 2024-10-01T10:31:10.517512Z  INFO Proof request claimed, proving...
 2024-10-01T10:34:23.797319Z  INFO Proof request fulfilled
-2024-10-01T10:34:24.767493Z  INFO Successfully generated the plonk proof with a latency of 223.186621825s
+2024-10-01T10:34:24.767493Z  INFO Successfully generated the proof with a latency of 223.186621825s
 2024-10-01T10:34:24.767799Z  INFO Writing the proof to "./data/proofs/1-exits-v0x00c745-b99b2bf1-c58c-4808-8b3a-7548d13a151d.json"
 ```
 

--- a/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
+++ b/crates/pessimistic-proof-test-suite/src/bin/ppgen.rs
@@ -119,11 +119,11 @@ pub fn main() {
 
     let start = Instant::now();
     let (proof, vk, new_roots) = Runner::new()
-        .generate_plonk_proof(&old_state.into(), &multi_batch_header)
+        .generate_snark_proof(&old_state.into(), &multi_batch_header)
         .expect("proving failed");
     let duration = start.elapsed();
     info!(
-        "Successfully generated the plonk proof with a latency of {:?}",
+        "Successfully generated the proof with a latency of {:?}",
         duration
     );
 
@@ -140,7 +140,7 @@ pub fn main() {
     };
 
     if let Some(proof_dir) = args.proof_dir {
-        // Save the plonk proof to a json file.
+        // Save the proof to a json file.
         let proof_path = proof_dir.join(format!(
             "{}-exits-v{}-{}.json",
             args.n_exits,

--- a/crates/pessimistic-proof-test-suite/src/runner.rs
+++ b/crates/pessimistic-proof-test-suite/src/runner.rs
@@ -75,8 +75,8 @@ impl Runner {
             .clone())
     }
 
-    /// Generate one plonk proof.
-    pub fn generate_plonk_proof(
+    /// Generate one SNARK-wrapped proof.
+    pub fn generate_snark_proof(
         &self,
         state: &NetworkState,
         batch_header: &MultiBatchHeader,
@@ -95,7 +95,7 @@ impl Runner {
         let proof = self
             .client
             .prove(&pk, stdin)
-            .plonk()
+            .groth16()
             .run()
             .map_err(|e| eyre!(e))?;
         let output = Self::extract_output(proof.public_values.clone());

--- a/crates/pessimistic-proof-test-suite/tests/snapshots/vkey_selector__vkey_snapshot.snap
+++ b/crates/pessimistic-proof-test-suite/tests/snapshots/vkey_selector__vkey_snapshot.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/pessimistic-proof-test-suite/tests/vkey_selector.rs
 expression: message
-snapshot_kind: text
 ---
 # If this test fails, it means the PP vkey has changed.
 # When that happens, consider updating the selector by bumping the PP version.
 | PP_VKEY          | 0x00d14f977a6ec393014f300ad78d0761dc29435d3fa1e2626fa466bd3343578e |
-| PP_VKEY_SELECTOR | 0x0000000e                                                         |
+| SELECTOR_PLONK   | 0x0000000e                                                         |
+| SELECTOR_GROTH16 | 0x0100000e                                                         |

--- a/crates/pessimistic-proof-test-suite/tests/vkey_selector.rs
+++ b/crates/pessimistic-proof-test-suite/tests/vkey_selector.rs
@@ -1,6 +1,7 @@
 #[tokio::test]
 async fn vkey_snapshot() {
-    let selector = hex::encode(pessimistic_proof::core::PESSIMISTIC_PROOF_PROGRAM_SELECTOR);
+    let plonk = hex::encode(pessimistic_proof::core::PP_SELECTOR_PLONK);
+    let groth16 = hex::encode(pessimistic_proof::core::PP_SELECTOR_GROTH16);
     let vkey = pessimistic_proof_test_suite::compute_program_vkey(pessimistic_proof::ELF)
         .await
         .unwrap();
@@ -9,7 +10,8 @@ async fn vkey_snapshot() {
         "# If this test fails, it means the PP vkey has changed.",
         "# When that happens, consider updating the selector by bumping the PP version.",
         &format!("| PP_VKEY          | {vkey} |"),
-        &format!("| PP_VKEY_SELECTOR | 0x{selector:64} |"),
+        &format!("| SELECTOR_PLONK   | 0x{plonk:64} |"),
+        &format!("| SELECTOR_GROTH16 | 0x{groth16:64} |"),
     ]
     .into_iter()
     .flat_map(|line| [line, "\n"])

--- a/crates/pessimistic-proof/src/lib.rs
+++ b/crates/pessimistic-proof/src/lib.rs
@@ -25,7 +25,7 @@ pub mod core {
         },
         generate_pessimistic_proof,
         local_state::commitment,
-        PESSIMISTIC_PROOF_PROGRAM_SELECTOR, PESSIMISTIC_PROOF_PROGRAM_VERSION,
+        PESSIMISTIC_PROOF_PROGRAM_VERSION, PP_SELECTOR_GROTH16, PP_SELECTOR_PLONK,
     };
 }
 

--- a/crates/pessimistic-proof/src/proof.rs
+++ b/crates/pessimistic-proof/src/proof.rs
@@ -42,7 +42,24 @@ pub enum Proof {
     SP1(SP1ProofWithPublicValues),
 }
 
+/// Only SNARK-wrapped proofs carry an on-chain verifiable encoding.
+#[derive(Debug, thiserror::Error)]
+#[error("proof mode {0} is not verifiable on-chain")]
+pub struct NotOnchainVerifiable(String);
+
 impl Proof {
+    /// Proof bytes as expected by the on-chain verifier.
+    ///
+    /// `SP1ProofWithPublicValues::bytes` panics on non-SNARK modes, so the
+    /// mode is checked first.
+    pub fn onchain_bytes(&self) -> Result<Vec<u8>, NotOnchainVerifiable> {
+        let Self::SP1(proof) = self;
+        match &proof.proof {
+            SP1Proof::Plonk(_) | SP1Proof::Groth16(_) => Ok(proof.bytes()),
+            other => Err(NotOnchainVerifiable(other.to_string())),
+        }
+    }
+
     pub fn dummy() -> Self {
         Self::SP1(SP1ProofWithPublicValues {
             proof: SP1Proof::Core(vec![]),

--- a/docs/knowledge-base/pessimistic-proof-elf.md
+++ b/docs/knowledge-base/pessimistic-proof-elf.md
@@ -60,15 +60,26 @@ unless it has already been bumped since the last release.
 
 ## How the selector is derived
 
-The selector is `PESSIMISTIC_PROOF_PROGRAM_SELECTOR`
-in `pessimistic-proof-core`. It is the **major version**
-of `crates/pessimistic-proof-program/Cargo.toml` encoded
-as a big-endian `[u8; 4]`.
+The selector is four bytes: the **high byte is the proof wrapping**,
+the low three bytes are the **major version** of
+`crates/pessimistic-proof-program/Cargo.toml`.
+
+| High byte | Wrapping |
+|-----------|----------|
+| `0x00`    | PLONK (every selector up to `0x0000000e`) |
+| `0x01`    | Groth16 |
 
 The build script `crates/pessimistic-proof-core/build.rs`
 reads the program's `Cargo.toml`, extracts the major version,
 and generates a `PESSIMISTIC_PROOF_PROGRAM_VERSION: u32`
-constant. The selector is that value in big-endian bytes.
+constant. `PP_SELECTOR_PLONK` and `PP_SELECTOR_GROTH16`
+combine it with each wrapping byte; the node picks between
+them from its configured wrapping.
+
+The two ranges are kept disjoint so a route registered for one
+wrapping can never collide with a future version of the other.
+Routes on L1 are immutable, so a collision is unrecoverable.
+See [pp-groth16-migration.md](pp-groth16-migration.md).
 
 ## How to bump the selector
 

--- a/docs/knowledge-base/pp-groth16-migration.md
+++ b/docs/knowledge-base/pp-groth16-migration.md
@@ -54,7 +54,8 @@ new one differs from the old one without the program version moving.
 7. **Stop new certificates and let the queue drain.**
    Note that `admin_disableNetwork` only *reports* a network as disabled — it does not block
    anything — so this has to be agreed with whoever runs the aggsenders.
-8. **Deploy the node.**
+8. **Deploy the node with `proof-wrapping = "groth16"`.**
+   Deploying alone changes nothing — PLONK is the default — so this key is the switch.
 9. **Turn the networks back on** and confirm a certificate settles.
 10. **Leave the PLONK route alone.** Do not freeze it. It is the way back.
 
@@ -71,7 +72,7 @@ new one differs from the old one without the program version moving.
    proof-wrapping = "plonk"
    ```
 
-   That is the whole change, and the only knob there is.
+   Or drop the key entirely — PLONK is the default.
    The selector follows the wrapping, so there is no second value to keep in step.
 3. Restart the node.
 4. Turn the networks back on.
@@ -141,8 +142,8 @@ so that clash would be permanent.
 
 Only two selectors exist for a given program, `PP_SELECTOR_PLONK` and `PP_SELECTOR_GROTH16`,
 and the wrapping picks between them. There is nothing else to configure, so the selector and
-the wrapping cannot disagree. A deployment that sets no `proof-wrapping` at all lands on
-Groth16.
+the wrapping cannot disagree. `proof-wrapping` defaults to PLONK, so a deployment that never
+sets it keeps settling exactly as it does today.
 See [pessimistic-proof-elf.md](pessimistic-proof-elf.md) for how the version drives the ELF
 and the vkey snapshot.
 

--- a/docs/knowledge-base/pp-groth16-migration.md
+++ b/docs/knowledge-base/pp-groth16-migration.md
@@ -1,0 +1,184 @@
+# Moving the pessimistic proof from PLONK to Groth16
+
+**Status:** proposed, not yet executed.
+**Scope:** the pessimistic proof only, and only chains verified through `AgglayerGateway`.
+The aggchain proof is unaffected.
+
+Groth16 wrapping is faster to produce and cheaper to verify on L1 than PLONK.
+This document describes everything needed to make the switch,
+and how to go back if we ever have to.
+
+## Three words you need
+
+- **Wrapping** — the final format of the proof we send to L1. Today PLONK, moving to Groth16.
+- **Route** — an entry on L1 that says: *for this 4-byte tag, use this verifier contract and
+  this program key*. Once added, a route can never be edited, only frozen.
+- **Selector** — that 4-byte tag. The node puts it at the front of every proof.
+
+A PLONK proof and a Groth16 proof need **different verifier contracts**,
+so they need different routes, so they need different selectors.
+The program key is the same for both.
+
+## What actually changes
+
+The program itself does not change, so its key does not change either.
+Only the wrapping around it does. That means the whole migration is:
+
+| | Selector | Verifier | Program key |
+|---|---|---|---|
+| Today, stays as the way back | `0x0000000e` | `SP1VerifierPlonk` | `0x00d14f97…` |
+| **Add this** | `0x0100000e` | `SP1VerifierGroth16` | `0x00d14f97…` (same) |
+
+**One new route.** The existing route is untouched and becomes the rollback target for free.
+Selectors carry the wrapping in the high byte and the program major in the low three, so the
+new one differs from the old one without the program version moving.
+
+## Migration process
+
+1. **Check no chain uses the old direct-verifier setup.**
+   Those chains (`VerifierType::Pessimistic`) have no route and no selector,
+   so nothing in this document protects them, and a config rollback cannot help them either.
+   If even one live chain uses it, stop.
+2. **Confirm the program key really is unchanged**: `cargo make pp-check-vkey-change`.
+   The whole plan rests on the new route reusing today's key.
+   If it did change, see *When the program changes* below.
+3. **Release the prover library** with Groth16 support, and tag it.
+   Nothing changes yet — nobody asks for Groth16 until step 4.
+4. **Build the node**, with both proof toolkits in the Docker image
+   so either wrapping can be produced.
+5. **Check a Groth16 verifier contract exists** on every target network.
+   It is not in our contracts repo, so it comes from Succinct or we deploy it.
+   Confirm any candidate address with `VERIFIER_HASH()` rather than trusting a list.
+6. **Add the Groth16 route on L1**, before touching the node.
+   Adding a route changes nothing for the running node, so this is safe to do early.
+7. **Stop new certificates and let the queue drain.**
+   Note that `admin_disableNetwork` only *reports* a network as disabled — it does not block
+   anything — so this has to be agreed with whoever runs the aggsenders.
+8. **Deploy the node.**
+9. **Turn the networks back on** and confirm a certificate settles.
+10. **Leave the PLONK route alone.** Do not freeze it. It is the way back.
+
+## Rollback runbook
+
+**Use when:** Groth16 turns out to be broken, or we stop trusting it, for any reason.
+
+**What you need:** nothing on L1. The PLONK route is the one that was already there.
+
+1. Stop new certificates and let in-flight ones finish, as in migration step 7.
+2. In the node config, set:
+
+   ```toml
+   proof-wrapping = "plonk"
+   ```
+
+   That is the whole change, and the only knob there is.
+   The selector follows the wrapping, so there is no second value to keep in step.
+3. Restart the node.
+4. Turn the networks back on.
+5. Confirm one certificate settles, and check the transaction used the PLONK route.
+
+### Good to know
+
+- Certificates that already settled are untouched.
+  The selector is not stored against them, and settled certificates are never reprocessed.
+- A certificate whose transaction was already built keeps the selector it was built with,
+  and settles on that route. This is why neither route should be frozen.
+
+## When the program changes
+
+Bump the program major only when the ELF changes — that is what the version means.
+A new program has a new key, so **both** of its routes must be registered:
+`0x000000NN` for PLONK and `0x010000NN` for Groth16, both carrying the new key.
+Register the PLONK one at the same time as the Groth16 one, not during an incident:
+`addPessimisticVKeyRoute` needs the route-admin role and can sit up to 3 days behind the
+timelock, which would strand the rollback exactly when it is needed.
+
+---
+
+## Reference
+
+### How a proof reaches L1
+
+```
+proof[0:4]   our selector    -> AgglayerGateway.pessimisticVKeyRoutes[sel] = {verifier, ppVKey, frozen}
+proof[4:8]   SP1's own tag   -> identifies the wrapping; written by the SDK, never by us
+proof[8:]    the proof
+```
+
+`AgglayerGateway` looks up the route by our selector and calls
+`ISP1Verifier(route.verifier).verifyProof(route.pessimisticVKey, publicValues, proof[4:])`.
+The verifier then checks `proof[4:8]` against its own wrapping and reverts if it disagrees.
+That last check is why a Groth16 proof cannot be sent to a PLONK route.
+
+No contract change is needed: `SP1VerifierPlonk` and `SP1VerifierGroth16` implement the same
+`ISP1Verifier.verifyProof`, so the gateway does not care which one sits behind a route.
+Registering the route is the only on-chain step.
+
+This repo currently emits selector `0x0000000e` (program version 14).
+Which selector a given network's route uses depends on the node version deployed there,
+so read `pessimisticVKeyRoutes` on that network rather than assuming.
+On mainnet the PP route points at `SP1VerifierPlonk` v6.1.0
+(`0x0459d576A6223fEeA177Fb3DF53C9c77BF84C459`).
+That is a plain verifier, not a gateway that dispatches on `proof[4:8]`,
+so one route cannot serve both wrappings.
+
+Gateways: mainnet `0x046Bb8bb98Db4ceCbB2929542686B74b516274b3`,
+Cardona `0xaA8103640A6C92af48A97D720168011E9f3Ec697`.
+
+### Selector scheme
+
+The high byte is the wrapping, the low three bytes are the program version.
+
+```
+0x000000NN   PLONK     (what every historical selector already is: 0x06 .. 0x0e)
+0x010000NN   Groth16   (new)
+```
+
+The two ranges can never collide, which is the point.
+Taking "the next free number" instead would eventually clash: a route parked on `0x0000000f`
+takes the number the next program version needs, and routes cannot be edited afterwards,
+so that clash would be permanent.
+
+Only two selectors exist for a given program, `PP_SELECTOR_PLONK` and `PP_SELECTOR_GROTH16`,
+and the wrapping picks between them. There is nothing else to configure, so the selector and
+the wrapping cannot disagree. A deployment that sets no `proof-wrapping` at all lands on
+Groth16.
+See [pessimistic-proof-elf.md](pessimistic-proof-elf.md) for how the version drives the ELF
+and the vkey snapshot.
+
+Headroom: about 16.7 million versions, and 256 wrappings with 2 in use.
+At the historical 7–13 version bumps a year, this is not a limit.
+
+### The program key is the same for both wrappings
+
+`vk.bytes32()` is the hex form of `vk.hash_bn254()`,
+and both hash the program's verifying key — nothing about the wrapping enters.
+So both routes carry the **same** `ppVKey`; only the verifier address differs.
+For this repo's current ELF that value is
+`0x00d14f977a6ec393014f300ad78d0761dc29435d3fa1e2626fa466bd3343578e`
+(`crates/pessimistic-proof-test-suite/tests/snapshots/vkey_selector__vkey_snapshot.snap`).
+
+Do not confuse it with the *circuit* key hash, `sha256(circuit_vk)[..4]`,
+which **is** per wrapping and travels inside the proof as `proof[4:8]`.
+The names collide; they are different values with different jobs.
+
+### Storage needs no migration
+
+Proofs are stored as bincode, and the proof enum already has a Groth16 case at a fixed
+position (`Core 0, Compressed 1, Plonk 2, Groth16 3`).
+New proofs write the Groth16 tag; old PLONK rows still decode.
+Mixed rows are normal and expected, not a transitional state to clean up.
+
+### Still to confirm
+
+- Is the program key genuinely unchanged? Run `cargo make pp-check-vkey-change`, which
+  rebuilds the ELF through Docker. The new route reuses today's key, so this is the one
+  assumption the plan rests on.
+- Does a Groth16 verifier v6.1.0 exist on each network, or must we deploy one?
+- Who holds `AL_ADD_PP_ROUTE_ROLE`, and is it behind the timelock?
+  It does not block this migration, but it sets the cost of registering routes for a future
+  program version.
+
+Already settled: Succinct fulfils Groth16 requests for SP1 `=6.2.2`,
+and the live verifier is a plain `SP1VerifierPlonk`,
+so there is no shortcut through a dispatching gateway.


### PR DESCRIPTION
Fixes #1625 

The pessimistic proof is wrapped in PLONK and verified on L1 by a concrete SP1VerifierPlonk reached through a gateway route. Groth16 is faster to wrap and cheaper to verify, but a route binds exactly one verifier and is immutable, so switching means sending the proof to a different route.

Make the wrapping configurable, **defaulting to PLONK**. That is deliberate: it lets this land in `main` with no behavioural change at all. A deployment that never sets the key keeps producing the same proofs and settling through the same route it uses today, so merging disturbs nothing and needs no coordination with L1. Turning Groth16 on later is a one-line config change rather than a release — and so is turning it back off, which is what makes a compromised Groth16 recoverable without a redeploy.

The route selector carries the wrapping in its high byte (0x00 plonk, 0x01 groth16) and the program major in the low three, keeping the two ranges disjoint so a route registered for one can never collide with a future version of the other. The selector is not configurable -- it follows the wrapping -- so the two cannot disagree.

The program is untouched, so its version and key do not move: Groth16 at major 14 is 0x0100000e, distinct from today's 0x0000000e without a bump. That leaves one new route to register, and the existing PLONK route -- same key, still valid -- stays both the default and the rollback target, at no cost.

Storage needs no migration: the wrapping is a bincode enum tag, so Groth16 rows sit alongside existing PLONK ones.

CONFIG-CHANGE: new optional top-level `proof-wrapping` key, `plonk` (default) or `groth16`, which also selects the L1 route the proof settles through. Omitting it preserves current behaviour.
