### PR TITLE
fix(settlement): retry gateway timeout errors

### DIFF
--- a/crates/agglayer-settlement-service/src/utils.rs
+++ b/crates/agglayer-settlement-service/src/utils.rs
@@ -137,12 +137,12 @@ pub(crate) fn is_transient_alloy_error(error: &TransportError) -> bool {
 }
 
 fn is_request_timeout_error(error: &TransportError) -> bool {
-    // HTTP 408 has standardized request-timeout semantics, unlike JSON-RPC
-    // server error codes, so it is sufficient without inspecting the body.
+    // HTTP 408 and 504 have standardized timeout semantics, unlike JSON-RPC
+    // server error codes, so they are sufficient without inspecting the body.
     if error
         .as_transport_err()
         .and_then(|error| error.as_http_error())
-        .is_some_and(|error| error.status == 408)
+        .is_some_and(|error| matches!(error.status, 408 | 504))
     {
         return true;
     }

--- a/crates/agglayer-settlement-service/src/utils/tests.rs
+++ b/crates/agglayer-settlement-service/src/utils/tests.rs
@@ -462,11 +462,14 @@ fn transient_alloy_error_recognizes_request_timeouts_narrowly() {
         408,
         String::new()
     )));
+    assert!(is_transient_alloy_error(&TransportErrorKind::http_error(
+        504,
+        String::new()
+    )));
     assert!(!is_transient_alloy_error(&TransportErrorKind::http_error(
         400,
         TIMEOUT_RESPONSE.to_owned()
     )));
-
     for message in ["Request timed out", "REQUEST TIMEOUT", "request time-out"] {
         let error = RpcError::ErrorResp(alloy::rpc::json_rpc::ErrorPayload {
             code: -32009,
@@ -492,7 +495,7 @@ fn transient_alloy_error_recognizes_request_timeouts_narrowly() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn retry_alloy_callback_until_success_retries_http_request_timeouts() {
+async fn retry_alloy_callback_until_success_retries_http_timeout_responses() {
     const TIMEOUT_RESPONSE: &str =
         r#"{"id":11481,"jsonrpc":"2.0","error":{"code":-32009,"message":"Request timed out"}}"#;
 
@@ -515,7 +518,7 @@ async fn retry_alloy_callback_until_success_retries_http_request_timeouts() {
                     let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                     if attempt < 2 {
                         Err::<u64, _>(TransportErrorKind::http_error(
-                            408,
+                            if attempt == 0 { 408 } else { 504 },
                             TIMEOUT_RESPONSE.to_owned(),
                         ))
                     } else {


### PR DESCRIPTION
Settlement RPC requests can fail with HTTP 504 when an upstream gateway
times out. Treat these responses as transient alongside HTTP 408 and
retry them using the existing backoff.

Extend the timeout classification and retry-loop tests to cover both
statuses.

Follow up of https://github.com/agglayer/agglayer/pull/1741