### PR TITLE
feat(network-info): cache the settled claim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,6 @@ version = "0.1.0"
 dependencies = [
  "agglayer-config",
  "agglayer-contracts",
- "agglayer-primitives 0.18.0",
  "agglayer-rate-limiting",
  "agglayer-storage",
  "agglayer-tries 0.18.0",
@@ -579,8 +578,6 @@ dependencies = [
  "eyre",
  "futures",
  "mockall",
- "pessimistic-proof",
- "pessimistic-proof-test-suite",
  "serde",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/agglayer-certificate-orchestrator/src/network_task.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task.rs
@@ -12,7 +12,7 @@ use agglayer_storage::{
 use agglayer_types::{
     primitives::{Digest, Hashable as _},
     CertificateId, CertificateIndex, CertificateStatus, CertificateStatusError, EpochNumber,
-    ExecutionMode, Height, LocalNetworkStateData, NetworkId,
+    ExecutionMode, Height, LocalNetworkStateData, NetworkId, SettledClaim,
 };
 use agglayer_utils::task::spawn_blocking_in_current_span;
 use arc_swap::ArcSwap;
@@ -281,7 +281,7 @@ where
         let task = self
             .initialize_certificate_task(height, sender, cancellation_token.clone())
             .await?;
-        let Some((task, bridge_exit_hashes, certificate_id)) = task else {
+        let Some((task, bridge_exit_hashes, settled_claim, certificate_id)) = task else {
             debug!(
                 "No certificate found for network {} at height {}",
                 self.network_id, *next_expected_height
@@ -350,6 +350,7 @@ where
                             .assign_and_persist_settled_certificate(
                                 new,
                                 bridge_exit_hashes,
+                                settled_claim,
                                 height,
                                 certificate_id,
                             )
@@ -384,6 +385,7 @@ where
         Option<(
             CertificateTask<StateStore, PendingStore, CertifierClient, SettlementService>,
             Vec<Digest>,
+            Option<SettledClaim>,
             CertificateId,
         )>,
         Error,
@@ -412,6 +414,10 @@ where
                 .iter()
                 .map(|exit| exit.hash())
                 .collect::<Vec<Digest>>();
+            let settled_claim = certificate
+                .imported_bridge_exits
+                .last()
+                .map(SettledClaim::from);
             let task = CertificateTask::new(
                 certificate,
                 sender,
@@ -422,7 +428,12 @@ where
                 cancellation_token,
             )?;
 
-            Ok(Some((task, bridge_exit_hashes, certificate_id)))
+            Ok(Some((
+                task,
+                bridge_exit_hashes,
+                settled_claim,
+                certificate_id,
+            )))
         })
         .await
         .expect("certificate task initialization panicked")
@@ -439,6 +450,7 @@ where
         &self,
         new: Box<LocalNetworkStateData>,
         bridge_exit_hashes: Vec<Digest>,
+        settled_claim: Option<SettledClaim>,
         height: Height,
         certificate_id: CertificateId,
     ) -> Result<(Box<LocalNetworkStateData>, EpochNumber, CertificateIndex), Error> {
@@ -500,6 +512,7 @@ where
                     &certificate_id,
                     &epoch_number,
                     &certificate_index,
+                    settled_claim,
                 )
             })();
             persistence.map_err(|e| Error::PersistenceError {

--- a/crates/agglayer-certificate-orchestrator/src/network_task/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/network_task/tests.rs
@@ -248,8 +248,9 @@ async fn start_from_zero() {
             eq(certificate_id),
             eq(EpochNumber::ZERO),
             eq(CertificateIndex::ZERO),
+            eq(None),
         )
-        .returning(|_, _, _, _, _| Ok(()));
+        .returning(|_, _, _, _, _, _| Ok(()));
 
     state
         .expect_get_certificate_settlement_job_id()
@@ -651,8 +652,9 @@ async fn retries() {
             eq(certificate_id2),
             eq(EpochNumber::ZERO),
             eq(CertificateIndex::ZERO),
+            eq(None),
         )
-        .returning(|_, _, _, _, _| Ok(()));
+        .returning(|_, _, _, _, _, _| Ok(()));
 
     let mut settlement_service = MockSettlementServiceTrait::new();
     settlement_service
@@ -1294,7 +1296,7 @@ async fn dropped_settlement_still_persists_settled_state() {
     state
         .expect_set_latest_settled_certificate_for_network()
         .once()
-        .return_once(move |_, _, _, _, _| {
+        .return_once(move |_, _, _, _, _, _| {
             sender.send("settled_cursor").expect("test channel closed");
             Ok(())
         });
@@ -1317,6 +1319,7 @@ async fn dropped_settlement_still_persists_settled_state() {
         task.assign_and_persist_settled_certificate(
             Box::new(LocalNetworkStateData::default()),
             Vec::new(),
+            None,
             Height::ZERO,
             certificate_id,
         )

--- a/crates/agglayer-certificate-orchestrator/src/tests.rs
+++ b/crates/agglayer-certificate-orchestrator/src/tests.rs
@@ -397,6 +397,7 @@ impl StateWriter for DummyPendingStore {
         _certificate_id: &CertificateId,
         _epoch_number: &EpochNumber,
         _certificate_index: &CertificateIndex,
+        _settled_claim: Option<agglayer_types::SettledClaim>,
     ) -> Result<(), agglayer_storage::error::Error> {
         Ok(())
     }

--- a/crates/agglayer-grpc-api/src/certificate_submission_service/mod.rs
+++ b/crates/agglayer-grpc-api/src/certificate_submission_service/mod.rs
@@ -7,8 +7,8 @@ use agglayer_grpc_types::node::v1::{
 };
 use agglayer_rpc::AgglayerService;
 use agglayer_storage::stores::{
-    DebugReader, DebugWriter, EpochStoreReader, PendingCertificateReader, PendingCertificateWriter,
-    SettlementReader, StateReader, StateWriter,
+    DebugReader, DebugWriter, PendingCertificateReader, PendingCertificateWriter, SettlementReader,
+    StateReader, StateWriter,
 };
 use error::CertificateSubmissionErrorWrapper;
 use tonic_types::{ErrorDetails, StatusExt};
@@ -17,22 +17,20 @@ use tracing::instrument;
 const SUBMIT_CERTIFICATE_METHOD_PATH: &str =
     "agglayer-node.grpc-api.v1.certificate-submission-service.submit_certificate";
 
-pub struct CertificateSubmissionServer<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore> {
-    pub(crate) service:
-        Arc<AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>>,
+pub struct CertificateSubmissionServer<L1Rpc, PendingStore, StateStore, DebugStore> {
+    pub(crate) service: Arc<AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore>>,
 }
 
 mod error;
 
 #[tonic::async_trait]
-impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore> CertificateSubmissionService
-    for CertificateSubmissionServer<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<L1Rpc, PendingStore, StateStore, DebugStore> CertificateSubmissionService
+    for CertificateSubmissionServer<L1Rpc, PendingStore, StateStore, DebugStore>
 where
     PendingStore: PendingCertificateReader + PendingCertificateWriter + 'static,
     StateStore: SettlementReader + StateReader + StateWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
     L1Rpc: RollupContract + AggchainContract + L1TransactionFetcher + Send + Sync + 'static,
-    EpochsStore: EpochStoreReader + 'static,
 {
     #[instrument(skip(self, request), level = "debug", fields(
         certificate_id = tracing::field::Empty,

--- a/crates/agglayer-grpc-api/src/configuration_service.rs
+++ b/crates/agglayer-grpc-api/src/configuration_service.rs
@@ -11,20 +11,18 @@ use tracing::instrument;
 pub(crate) const GET_EPOCH_CONFIGURATION_METHOD_PATH: &str =
     "agglayer-node.grpc-api.v1.configuration-service.get-epoch-configuration";
 
-pub struct ConfigurationServer<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore> {
-    pub(crate) service:
-        Arc<AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>>,
+pub struct ConfigurationServer<L1Rpc, PendingStore, StateStore, DebugStore> {
+    pub(crate) service: Arc<AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore>>,
 }
 
 #[tonic::async_trait]
-impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore> ConfigurationService
-    for ConfigurationServer<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<L1Rpc, PendingStore, StateStore, DebugStore> ConfigurationService
+    for ConfigurationServer<L1Rpc, PendingStore, StateStore, DebugStore>
 where
     DebugStore: Send + Sync + 'static,
     L1Rpc: Send + Sync + 'static,
     PendingStore: Send + Sync + 'static,
     StateStore: Send + Sync + 'static,
-    EpochsStore: Send + Sync + 'static,
 {
     #[instrument(skip(self, _request), level = "debug", fields(
         client = crate::client_info_from_metadata(_request.metadata())

--- a/crates/agglayer-grpc-api/src/lib.rs
+++ b/crates/agglayer-grpc-api/src/lib.rs
@@ -8,7 +8,7 @@ use agglayer_grpc_server::node::v1::{
     node_state_service_server::NodeStateServiceServer,
 };
 use agglayer_storage::stores::{
-    DebugReader, DebugWriter, EpochStoreReader, NetworkInfoReader, PendingCertificateReader,
+    DebugReader, DebugWriter, NetworkInfoReader, PendingCertificateReader,
     PendingCertificateWriter, SettlementReader, StateReader, StateWriter,
 };
 use certificate_submission_service::CertificateSubmissionServer;
@@ -91,10 +91,10 @@ impl ServerBuilder {
 }
 
 impl Server {
-    pub fn with_config<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>(
+    pub fn with_config<L1Rpc, PendingStore, StateStore, DebugStore>(
         config: Arc<Config>,
         rpc_service: Arc<
-            agglayer_rpc::AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>,
+            agglayer_rpc::AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore>,
         >,
     ) -> ServerBuilder
     where
@@ -102,7 +102,6 @@ impl Server {
         PendingStore: PendingCertificateReader + PendingCertificateWriter + 'static,
         StateStore: NetworkInfoReader + SettlementReader + StateReader + StateWriter + 'static,
         DebugStore: DebugReader + DebugWriter + 'static,
-        EpochsStore: EpochStoreReader + 'static,
     {
         let certificate_submission_server = CertificateSubmissionServer {
             service: rpc_service.clone(),

--- a/crates/agglayer-grpc-api/src/node_state_service.rs
+++ b/crates/agglayer-grpc-api/src/node_state_service.rs
@@ -12,7 +12,7 @@ use agglayer_grpc_types::{
 };
 use agglayer_rpc::AgglayerService;
 use agglayer_storage::stores::{
-    DebugReader, EpochStoreReader, NetworkInfoReader, PendingCertificateReader, StateReader,
+    DebugReader, NetworkInfoReader, PendingCertificateReader, StateReader,
 };
 use tonic_types::{ErrorDetails, StatusExt as _};
 use tracing::error;
@@ -24,20 +24,18 @@ const GET_LATEST_CERTIFICATE_HEADER_METHOD_PATH: &str =
 const GET_NETWORK_INFO_METHOD_PATH: &str =
     "agglayer-node.grpc-api.v1.node-state-service.get_network_info";
 
-pub struct NodeStateServer<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore> {
-    pub(crate) service:
-        Arc<AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>>,
+pub struct NodeStateServer<L1Rpc, PendingStore, StateStore, DebugStore> {
+    pub(crate) service: Arc<AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore>>,
 }
 
 #[tonic::async_trait]
-impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore> NodeStateService
-    for NodeStateServer<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<L1Rpc, PendingStore, StateStore, DebugStore> NodeStateService
+    for NodeStateServer<L1Rpc, PendingStore, StateStore, DebugStore>
 where
     PendingStore: PendingCertificateReader + 'static,
     StateStore: NetworkInfoReader + StateReader + 'static,
     DebugStore: DebugReader + 'static,
     L1Rpc: Send + Sync + 'static,
-    EpochsStore: EpochStoreReader + 'static,
 {
     #[tracing::instrument(level = "debug", skip(self, request), fields(
         request_id = tracing::field::Empty,
@@ -171,17 +169,6 @@ where
             .map_err(|error| {
                 error!(?error, "Failed to get network state");
                 match error {
-                    agglayer_rpc::GetNetworkInfoError::UnknownNetworkType { .. } => {
-                        tonic::Status::with_error_details(
-                            tonic::Code::NotFound,
-                            "Network type could not be determined",
-                            ErrorDetails::with_error_info(
-                                GetNetworkInfoErrorKind::UnknownNetworkType.as_str_name(),
-                                GET_NETWORK_INFO_METHOD_PATH,
-                                [],
-                            ),
-                        )
-                    }
                     agglayer_rpc::GetNetworkInfoError::InternalError { source, .. } => {
                         tonic::Status::with_error_details(
                             tonic::Code::Internal,

--- a/crates/agglayer-grpc-api/src/tests/certificate_submission.rs
+++ b/crates/agglayer-grpc-api/src/tests/certificate_submission.rs
@@ -12,7 +12,7 @@ use agglayer_interop::grpc::v1 as interop_v1;
 use agglayer_rpc::AgglayerService;
 use agglayer_storage::{
     backup::BackupClient,
-    stores::{debug::DebugStore, epochs::EpochsStore, pending::PendingStore, state::StateStore},
+    stores::{debug::DebugStore, pending::PendingStore, state::StateStore},
     tests::TempDBDir,
 };
 use agglayer_types::{
@@ -198,18 +198,9 @@ async fn start_server_with_certificate_submission_service(
     );
     let service = Arc::new(AgglayerService::new(
         sender,
-        pending_store.clone(),
-        state_store.clone(),
+        pending_store,
+        state_store,
         Arc::new(DebugStore::new_with_path(&config.storage.debug_db_path).unwrap()),
-        Arc::new(
-            EpochsStore::new(
-                config.clone(),
-                pending_store,
-                state_store,
-                BackupClient::noop(),
-            )
-            .unwrap(),
-        ),
         config,
         Arc::new(L1Rpc),
     ));

--- a/crates/agglayer-grpc-api/src/tests/configuration.rs
+++ b/crates/agglayer-grpc-api/src/tests/configuration.rs
@@ -10,7 +10,7 @@ use agglayer_grpc_types::node::{types::v1, v1::GetEpochConfigurationRequest};
 use agglayer_rpc::AgglayerService;
 use agglayer_storage::{
     backup::BackupClient,
-    stores::{debug::DebugStore, epochs::EpochsStore, pending::PendingStore, state::StateStore},
+    stores::{debug::DebugStore, pending::PendingStore, state::StateStore},
     tests::TempDBDir,
 };
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
@@ -101,18 +101,9 @@ async fn start_server_with_configuration_service(
     );
     let service = Arc::new(AgglayerService::new(
         sender,
-        pending_store.clone(),
-        state_store.clone(),
+        pending_store,
+        state_store,
         Arc::new(DebugStore::new_with_path(&config.storage.debug_db_path).unwrap()),
-        Arc::new(
-            EpochsStore::new(
-                config.clone(),
-                pending_store,
-                state_store,
-                BackupClient::noop(),
-            )
-            .unwrap(),
-        ),
         config,
         Arc::new(L1Rpc {}),
     ));

--- a/crates/agglayer-grpc-api/src/tests/node_state.rs
+++ b/crates/agglayer-grpc-api/src/tests/node_state.rs
@@ -6,10 +6,7 @@ use agglayer_grpc_types::node::v1::GetCertificateHeaderRequest;
 use agglayer_rpc::AgglayerService;
 use agglayer_storage::{
     backup::BackupClient,
-    stores::{
-        debug::DebugStore, epochs::EpochsStore, pending::PendingStore, state::StateStore,
-        StateWriter as _,
-    },
+    stores::{debug::DebugStore, pending::PendingStore, state::StateStore, StateWriter as _},
     tests::TempDBDir,
 };
 use agglayer_types::{CertificateId, CertificateStatus, Digest, Height};
@@ -43,18 +40,9 @@ async fn get_certificate_header() {
     let (sender, _receiver) = tokio::sync::mpsc::channel(10);
     let service = Arc::new(AgglayerService::new(
         sender,
-        pending_store.clone(),
-        state_store.clone(),
+        pending_store,
+        state_store,
         debug_store,
-        Arc::new(
-            EpochsStore::new(
-                config.clone(),
-                pending_store,
-                state_store,
-                BackupClient::noop(),
-            )
-            .unwrap(),
-        ),
         config,
         Arc::new(L1Rpc {}),
     ));

--- a/crates/agglayer-jsonrpc-api/src/lib.rs
+++ b/crates/agglayer-jsonrpc-api/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 
 use agglayer_contracts::{AggchainContract, L1TransactionFetcher, RollupContract};
 use agglayer_storage::stores::{
-    DebugReader, DebugWriter, EpochStoreReader, NetworkInfoReader, PendingCertificateReader,
+    DebugReader, DebugWriter, NetworkInfoReader, PendingCertificateReader,
     PendingCertificateWriter, SettlementReader, StateReader, StateWriter,
 };
 use agglayer_types::{
@@ -86,21 +86,19 @@ trait Agglayer {
 }
 
 /// The RPC agglayer service implementation.
-pub struct AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore> {
+pub struct AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore> {
     service: Arc<AgglayerService<V0Rpc>>,
     pub(crate) rpc_service:
-        Arc<agglayer_rpc::AgglayerService<Rpc, PendingStore, StateStore, DebugStore, EpochsStore>>,
+        Arc<agglayer_rpc::AgglayerService<Rpc, PendingStore, StateStore, DebugStore>>,
 }
 
-impl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
-    AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore>
+    AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore>
 {
     /// Create an instance of the RPC agglayer service.
     pub fn new(
         service: Arc<AgglayerService<V0Rpc>>,
-        rpc_service: Arc<
-            agglayer_rpc::AgglayerService<Rpc, PendingStore, StateStore, DebugStore, EpochsStore>,
-        >,
+        rpc_service: Arc<agglayer_rpc::AgglayerService<Rpc, PendingStore, StateStore, DebugStore>>,
     ) -> Self {
         Self {
             service,
@@ -109,23 +107,22 @@ impl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
     }
 }
 
-impl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore> Drop
-    for AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore> Drop
+    for AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore>
 {
     fn drop(&mut self) {
         info!("Shutting down the agglayer JsonRPC server");
     }
 }
 
-impl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
-    AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore>
+    AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore>
 where
     V0Rpc: Provider + Clone + 'static,
     Rpc: RollupContract + AggchainContract + L1TransactionFetcher + 'static + Send + Sync,
     PendingStore: PendingCertificateWriter + PendingCertificateReader + 'static,
     StateStore: NetworkInfoReader + SettlementReader + StateReader + StateWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
-    EpochsStore: EpochStoreReader + 'static,
 {
     pub async fn start(self) -> eyre::Result<axum::Router> {
         let config = self.rpc_service.config();
@@ -193,15 +190,14 @@ where
 }
 
 #[async_trait]
-impl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore> AgglayerServer
-    for AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore> AgglayerServer
+    for AgglayerImpl<V0Rpc, Rpc, PendingStore, StateStore, DebugStore>
 where
     V0Rpc: Provider + Clone + 'static,
     Rpc: RollupContract + AggchainContract + L1TransactionFetcher + 'static + Send + Sync,
     PendingStore: PendingCertificateWriter + PendingCertificateReader + 'static,
     StateStore: NetworkInfoReader + SettlementReader + StateReader + StateWriter + 'static,
     DebugStore: DebugReader + DebugWriter + 'static,
-    EpochsStore: EpochStoreReader + 'static,
 {
     async fn send_tx(&self, tx: SignedTx) -> RpcResult<B256> {
         // The legacy `interop_sendTx` proof-settlement flow is disabled

--- a/crates/agglayer-jsonrpc-api/src/tests/get_latest_known_certificate_header.rs
+++ b/crates/agglayer-jsonrpc-api/src/tests/get_latest_known_certificate_header.rs
@@ -47,6 +47,7 @@ async fn returns_the_pending_certificate_header() {
             &settled_certificate.hash(),
             &EpochNumber::ZERO,
             &CertificateIndex::ZERO,
+            None,
         )
         .expect("unable to set latest settled certificate");
 
@@ -129,6 +130,7 @@ async fn returns_the_proven_certificate_header() {
             &settled_certificate.hash(),
             &EpochNumber::ZERO,
             &CertificateIndex::ZERO,
+            None,
         )
         .expect("unable to set latest settled certificate");
     context
@@ -208,6 +210,7 @@ async fn returns_the_settled_certificate_header() {
             &settled_certificate.hash(),
             &EpochNumber::ZERO,
             &CertificateIndex::ZERO,
+            None,
         )
         .expect("unable to set latest settled certificate");
 
@@ -332,6 +335,7 @@ async fn returns_the_highest_height() {
             &settled_certificate.hash(),
             &EpochNumber::ZERO,
             &CertificateIndex::ZERO,
+            None,
         )
         .expect("unable to set latest settled certificate");
 
@@ -423,6 +427,7 @@ async fn returns_the_settled_one_at_same_height() {
             &settled_certificate.hash(),
             &EpochNumber::ZERO,
             &CertificateIndex::ZERO,
+            None,
         )
         .expect("unable to set latest settled certificate");
 

--- a/crates/agglayer-jsonrpc-api/src/testutils.rs
+++ b/crates/agglayer-jsonrpc-api/src/testutils.rs
@@ -8,7 +8,7 @@ use agglayer_contracts::L1RpcClient;
 use agglayer_settlement_service::SettlementService;
 use agglayer_storage::{
     backup::BackupClient,
-    stores::{debug::DebugStore, epochs::EpochsStore, pending::PendingStore, state::StateStore},
+    stores::{debug::DebugStore, pending::PendingStore, state::StateStore},
     tests::TempDBDir,
     NetworkMetrics,
 };
@@ -46,7 +46,6 @@ pub type RawRpcClient = crate::AgglayerImpl<
     PendingStore,
     StateStore,
     DebugStore,
-    EpochsStore<PendingStore, StateStore>,
 >;
 
 pub struct RawRpcContext {
@@ -171,24 +170,12 @@ impl TestContext {
             crate::kernel::Kernel::new(real_provider.clone(), config.clone()).unwrap(),
         ));
 
-        // Create a real epoch store for testing
-        let epochs_store = Arc::new(
-            EpochsStore::new(
-                config.clone(),
-                pending_store.clone(),
-                state_store.clone(),
-                BackupClient::noop(),
-            )
-            .unwrap(),
-        );
-
         // Create agglayer_rpc::AgglayerService with the provider
         let rpc_service = Arc::new(agglayer_rpc::AgglayerService::new(
             certificate_sender.clone(),
             pending_store.clone(),
             state_store.clone(),
             debug_store.clone(),
-            epochs_store,
             config.clone(),
             Arc::new(l1_rpc_client),
         ));
@@ -327,24 +314,12 @@ impl TestContext {
             crate::kernel::Kernel::new(Arc::new(mock_provider.clone()), config.clone()).unwrap(),
         ));
 
-        // Create a real epoch store for testing
-        let epochs_store = Arc::new(
-            EpochsStore::new(
-                config.clone(),
-                pending_store.clone(),
-                state_store.clone(),
-                BackupClient::noop(),
-            )
-            .unwrap(),
-        );
-
         // Create agglayer_rpc::AgglayerService
         let rpc_service = Arc::new(agglayer_rpc::AgglayerService::new(
             certificate_sender,
             pending_store.clone(),
             state_store.clone(),
             debug_store.clone(),
-            epochs_store,
             config.clone(),
             Arc::new(l1_rpc_client),
         ));

--- a/crates/agglayer-node/src/node.rs
+++ b/crates/agglayer-node/src/node.rs
@@ -375,7 +375,6 @@ impl Node {
             pending_store.clone(),
             state_store.clone(),
             debug_store.clone(),
-            epochs_store.clone(),
             config.clone(),
             Arc::clone(&rollup_manager),
         ));

--- a/crates/agglayer-rpc/Cargo.toml
+++ b/crates/agglayer-rpc/Cargo.toml
@@ -7,14 +7,11 @@ license.workspace = true
 [dependencies]
 agglayer-contracts.workspace = true
 agglayer-config.workspace = true
-agglayer-primitives.workspace = true
 agglayer-rate-limiting.workspace = true
 agglayer-storage.workspace = true
 agglayer-tries.workspace = true
 agglayer-types.workspace = true
 agglayer-utils.workspace = true
-pessimistic-proof.workspace = true
-
 
 alloy.workspace = true
 eyre.workspace = true
@@ -27,7 +24,6 @@ tracing.workspace = true
 [dev-dependencies]
 agglayer-storage = { workspace = true, features = ["testutils"] }
 async-trait.workspace = true
-pessimistic-proof-test-suite = { path = "../pessimistic-proof-test-suite" }
 mockall.workspace = true
 
 [lints]

--- a/crates/agglayer-rpc/src/error.rs
+++ b/crates/agglayer-rpc/src/error.rs
@@ -111,55 +111,7 @@ impl SignatureVerificationError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum ProofRetrievalError {
-    #[error(transparent)]
-    Storage(#[from] StorageError),
-
-    #[error("Proof for certificate {certificate_id} not found")]
-    NotFound { certificate_id: CertificateId },
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum GetLatestCertificateError {
-    #[error(transparent)]
-    Storage(#[from] StorageError),
-
-    #[error("Unknown latest certificate header for network {network_id}")]
-    UnknownLatestCertificateHeader {
-        network_id: NetworkId,
-        source: Box<CertificateRetrievalError>,
-    },
-
-    #[error(
-        "Mismatch on the certificate id. expected: {expected}, re-computed from the certificate \
-         in DB: {got}"
-    )]
-    CertificateIdHashMismatch {
-        expected: CertificateId,
-        got: CertificateId,
-    },
-
-    #[error("Latest certificate header for certificate {certificate_id} not found")]
-    NotFound { certificate_id: CertificateId },
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum GetLatestSettledClaimError {
-    #[error(transparent)]
-    Storage(#[from] StorageError),
-
-    #[error("Could not get latest settled claim, inconsistent state for {network_id}")]
-    InconsistentState {
-        network_id: NetworkId,
-        height: Height,
-    },
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum GetNetworkInfoError {
-    #[error("Unable to determine network type for network {network_id}")]
-    UnknownNetworkType { network_id: NetworkId },
-
     #[error("Could not get network status for network {network_id}, internal error: {source}")]
     InternalError {
         network_id: NetworkId,

--- a/crates/agglayer-rpc/src/lib.rs
+++ b/crates/agglayer-rpc/src/lib.rs
@@ -2,20 +2,19 @@ use std::sync::Arc;
 
 use agglayer_config::{epoch::BlockClockConfig, Config, Epoch};
 use agglayer_contracts::{AggchainContract, L1TransactionFetcher, RollupContract};
-use agglayer_primitives::Hashable;
 use agglayer_rate_limiting as rate_limiting;
 use agglayer_storage::{
     columns::latest_settled_certificate_per_network::SettledCertificate,
     stores::{
-        async_api::AsyncStateReaderExt, DebugReader, DebugWriter, EpochStoreReader,
-        NetworkInfoReader, PendingCertificateReader, PendingCertificateWriter, SettlementReader,
-        StateReader, StateWriter,
+        async_api::AsyncStateReaderExt, DebugReader, DebugWriter, NetworkInfoReader,
+        PendingCertificateReader, PendingCertificateWriter, SettlementReader, StateReader,
+        StateWriter,
     },
 };
 use agglayer_types::{
     aggchain_data::MultisigCtx, aggchain_proof::AggchainData, Certificate, CertificateHeader,
     CertificateId, CertificateStatus, ContractCallOutcome, EpochConfiguration, Height, NetworkId,
-    NetworkInfo, NetworkStatus, NetworkType, SettledClaim, U256,
+    NetworkInfo, NetworkStatus,
 };
 use agglayer_utils::task::spawn_blocking_in_current_span;
 use error::SignatureVerificationError;
@@ -23,25 +22,23 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, instrument, warn};
 
 pub use self::error::{CertificateRetrievalError, CertificateSubmissionError, GetNetworkInfoError};
-use crate::error::{GetLatestCertificateError, GetLatestSettledClaimError, ProofRetrievalError};
 
 pub mod error;
 #[cfg(test)]
 mod tests;
 
 /// The RPC agglayer service implementation.
-pub struct AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore> {
+pub struct AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore> {
     certificate_sender: mpsc::Sender<(NetworkId, Height, CertificateId)>,
     pub(crate) pending_store: Arc<PendingStore>,
     pub(crate) state: Arc<StateStore>,
     debug_store: Arc<DebugStore>,
-    epochs_store: Arc<EpochsStore>,
     config: Arc<Config>,
     l1_rpc_provider: Arc<L1Rpc>,
 }
 
-impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
-    AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<L1Rpc, PendingStore, StateStore, DebugStore>
+    AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore>
 {
     /// Create an instance of the RPC agglayer service.
     pub fn new(
@@ -49,7 +46,6 @@ impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
         pending_store: Arc<PendingStore>,
         state: Arc<StateStore>,
         debug_store: Arc<DebugStore>,
-        epochs_store: Arc<EpochsStore>,
         config: Arc<Config>,
         l1_rpc_provider: Arc<L1Rpc>,
     ) -> Self {
@@ -58,7 +54,6 @@ impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
             pending_store,
             state,
             debug_store,
-            epochs_store,
             config,
             l1_rpc_provider,
         }
@@ -87,22 +82,21 @@ impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
     }
 }
 
-impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore> Drop
-    for AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<L1Rpc, PendingStore, StateStore, DebugStore> Drop
+    for AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore>
 {
     fn drop(&mut self) {
         info!("Shutting down the agglayer RPC service");
     }
 }
 
-impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
-    AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<L1Rpc, PendingStore, StateStore, DebugStore>
+    AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore>
 where
     PendingStore: PendingCertificateReader + 'static,
     StateStore: NetworkInfoReader + StateReader + 'static,
     DebugStore: DebugReader + 'static,
     L1Rpc: Send + Sync + 'static,
-    EpochsStore: EpochStoreReader + 'static,
 {
     fn latest_settled_id_and_height_blocking(
         state: &StateStore,
@@ -174,94 +168,6 @@ where
             None => Ok(None),
             Some(certificate_id) => {
                 Self::fetch_certificate_header_blocking(state, certificate_id).map(Some)
-            }
-        }
-    }
-
-    /// Get latest available certificate data for a network.
-    /// Note: This includes proven certificates
-    /// and settled certificates. If no certificate is found, return None.
-    fn get_latest_available_certificate_for_network_blocking(
-        pending_store: &PendingStore,
-        state: &StateStore,
-        epochs_store: &EpochsStore,
-        network_id: NetworkId,
-    ) -> Result<Option<Certificate>, GetLatestCertificateError> {
-        debug!("Received request to get the latest available certificate for rollup {network_id}");
-
-        let proven_certificate_id_and_height =
-            Self::latest_proven_id_and_height_blocking(pending_store, &network_id)?;
-        let settled_certificate_id_and_height =
-            Self::latest_settled_id_and_height_blocking(state, &network_id)?;
-
-        let certificate_id = std::cmp::max_by_key(
-            proven_certificate_id_and_height,
-            settled_certificate_id_and_height,
-            |v| v.map(|(_, ht)| ht),
-        )
-        .map(|v| v.0);
-
-        let latest_certificate_header = match certificate_id {
-            None => Ok(None),
-            Some(certificate_id) => Self::fetch_certificate_header_blocking(state, certificate_id)
-                .map(Some)
-                .map_err(|error| {
-                    error!(?error, "Failed to get latest known certificate header");
-                    GetLatestCertificateError::UnknownLatestCertificateHeader {
-                        network_id,
-                        source: Box::new(error),
-                    }
-                }),
-        }?;
-
-        match latest_certificate_header {
-            None => Ok(None),
-            Some(CertificateHeader {
-                certificate_id,
-                height,
-                epoch_number,
-                certificate_index,
-                ..
-            }) => {
-                // First try to get the full certificate from pending store
-                if let Ok(Some(certificate)) = pending_store.get_certificate(network_id, height) {
-                    // Verify that this is indeed the certificate we're looking
-                    // for
-                    if certificate.hash() == certificate_id {
-                        return Ok(Some(certificate));
-                    } else {
-                        error!(
-                            "Pending certificate hash mismatch: expected {}, got {}",
-                            certificate_id,
-                            certificate.hash()
-                        );
-                        return Err(GetLatestCertificateError::CertificateIdHashMismatch {
-                            expected: certificate_id,
-                            got: certificate.hash(),
-                        });
-                    }
-                }
-
-                // If not found in pending store, try to get from epoch store.
-                if let (Some(epoch_number), Some(certificate_index)) =
-                    (epoch_number, certificate_index)
-                {
-                    match epochs_store.get_certificate(epoch_number, certificate_index) {
-                        Ok(Some(certificate)) => {
-                            debug!("Found certificate {certificate_id} in epoch store");
-                            return Ok(Some(certificate));
-                        }
-                        _ => {
-                            debug!("Certificate {certificate_id} not found in epoch store");
-                        }
-                    }
-                }
-
-                warn!(
-                    "Certificate {} at height {} not found in any store",
-                    certificate_id, height
-                );
-                Err(GetLatestCertificateError::NotFound { certificate_id })
             }
         }
     }
@@ -365,147 +271,6 @@ where
             .ok_or(CertificateRetrievalError::NotFound { certificate_id })
     }
 
-    /// Get the proof for a certificate by certificate ID.
-    fn get_proof_blocking(
-        pending_store: &PendingStore,
-        state: &StateStore,
-        epochs_store: &EpochsStore,
-        certificate_id: CertificateId,
-    ) -> Result<Option<agglayer_types::Proof>, ProofRetrievalError> {
-        // First try to get the proof from the pending store
-        match pending_store.get_proof(certificate_id).map_err(|error| {
-            error!(
-                ?error,
-                "Failed to get proof for certificate {certificate_id} from pending store",
-            );
-            ProofRetrievalError::Storage(error)
-        })? {
-            Some(proof) => Ok(Some(proof)),
-            None => {
-                // If not found in pending store, check the epoch store
-                // First get the certificate header to obtain epoch_number and
-                // certificate_index
-                match Self::fetch_certificate_header_blocking(state, certificate_id) {
-                    Ok(header) => {
-                        if let (Some(epoch_number), Some(certificate_index)) =
-                            (header.epoch_number, header.certificate_index)
-                        {
-                            // Call the epoch store's get_proof method with
-                            // epoch_number and
-                            // certificate_index
-                            epochs_store
-                                .get_proof(epoch_number, certificate_index)
-                                .map_err(|error| {
-                                    error!(
-                                        ?error,
-                                        "Failed to get proof for certificate {certificate_id} \
-                                         from epoch store",
-                                    );
-                                    ProofRetrievalError::NotFound { certificate_id }
-                                })
-                        } else {
-                            // Certificate doesn't have epoch information, so no
-                            // proof in epoch store
-                            Ok(None)
-                        }
-                    }
-                    Err(_) => {
-                        // Certificate header not found, so no proof in epoch
-                        // store
-                        Ok(None)
-                    }
-                }
-            }
-        }
-    }
-
-    fn get_latest_settled_claim_blocking(
-        state: &StateStore,
-        epochs_store: &EpochsStore,
-        network_id: NetworkId,
-        settled_height: Height,
-    ) -> Result<Option<SettledClaim>, GetLatestSettledClaimError> {
-        // Iterate from the given height down to 0
-        for current_height in (0..=settled_height.as_u64()).rev().map(Height::from) {
-            // Fetch certificate header for the current height
-            let header_opt = state.get_certificate_header_by_cursor(network_id, current_height)?;
-
-            let header = match header_opt {
-                Some(h) => h,
-
-                None => {
-                    // No certificate at this height, return an error indicating
-                    // inconsistent state
-                    error!(
-                        "No certificate header found for network {network_id} at height \
-                         {current_height}, inconsistent state"
-                    );
-                    return Err(GetLatestSettledClaimError::InconsistentState {
-                        network_id,
-                        height: settled_height,
-                    });
-                }
-            };
-
-            // Only proceed if both epoch_number and certificate_index are
-            // present
-            let (epoch_number, certificate_index) =
-                match (header.epoch_number, header.certificate_index) {
-                    (Some(epoch), Some(idx)) => (epoch, idx),
-                    _ => {
-                        // Missing epoch information, return an error indicating
-                        // inconsistent state
-                        error!(
-                            "Missing epoch information in certificate header for network \
-                             {network_id} at height {current_height}, inconsistent state"
-                        );
-                        return Err(GetLatestSettledClaimError::InconsistentState {
-                            network_id,
-                            height: settled_height,
-                        });
-                    }
-                };
-
-            // Fetch the certificate from the epoch store
-            let certificate_opt = epochs_store
-                .get_certificate(epoch_number, certificate_index)
-                .map_err(GetLatestSettledClaimError::from)?;
-
-            let certificate = match certificate_opt {
-                Some(cert) => cert,
-                None => {
-                    // Settled certificate not found, return an error indicating
-                    // inconsistent state
-                    error!(
-                        "Settled certificate not found in epoch store for network {network_id} at \
-                         height {current_height}, inconsistent state"
-                    );
-                    return Err(GetLatestSettledClaimError::InconsistentState {
-                        network_id,
-                        height: settled_height,
-                    });
-                }
-            };
-
-            // Check for imported bridge exits
-            if let Some(last_imported_exit) = certificate.imported_bridge_exits.last() {
-                let global_index: U256 = last_imported_exit.global_index.into();
-                let bridge_exit_hash = last_imported_exit.bridge_exit.hash();
-
-                return Ok(Some(SettledClaim {
-                    global_index: global_index.to_be_bytes().into(),
-                    bridge_exit_hash,
-                }));
-            }
-            // Keep iterating downwards if no imported bridge exits found and no
-            // error happened
-        }
-
-        // No imported bridge exits found in any certificate from
-        // `settled_height` down to 0
-        Ok(None)
-    }
-
     /// Assemble the current information of the specified network from
     /// the data in various sources.
     #[instrument(skip(self))]
@@ -515,152 +280,36 @@ where
     ) -> Result<NetworkInfo, GetNetworkInfoError> {
         let pending_store = self.pending_store.clone();
         let state = self.state.clone();
-        let epochs_store = self.epochs_store.clone();
 
         spawn_blocking_in_current_span(move || {
-            Self::get_network_info_blocking(
-                pending_store.as_ref(),
-                state.as_ref(),
-                epochs_store.as_ref(),
-                network_id,
-            )
+            Self::get_network_info_blocking(pending_store.as_ref(), state.as_ref(), network_id)
         })
         .await
         .expect("network-info query task panicked")
     }
 
+    /// Every field comes from storage: no epoch database is opened, no
+    /// certificate or proof is decoded, and nothing is written.
     fn get_network_info_blocking(
         pending_store: &PendingStore,
         state: &StateStore,
-        epochs_store: &EpochsStore,
         network_id: NetworkId,
     ) -> Result<NetworkInfo, GetNetworkInfoError> {
         debug!("Received request to get the network state for rollup {network_id}");
 
-        let mut network_info = state
-            .get_network_info(network_id)
-            .inspect_err(|error| {
-                warn!(
-                    ?error,
-                    "Failed to retrieve network info for network {network_id} from the storage"
-                );
-            })
-            .unwrap_or_else(|_| NetworkInfo::from_network_id(network_id));
-
-        if network_info.settled_certificate_id.is_none() {
-            // Get the latest settled certificate for the network
-            let latest_settled_certificate =
-                match Self::get_latest_settled_certificate_header_blocking(state, network_id) {
-                    Ok(cert) => cert,
-                    Err(CertificateRetrievalError::NotFound { .. }) => {
-                        warn!("No settled certificate found for network {network_id}");
-                        None
-                    }
-                    Err(error) => {
-                        error!(
-                            ?error,
-                            "Failed to get latest settled certificate for network {network_id}"
-                        );
-                        return Err(GetNetworkInfoError::InternalError {
-                            network_id,
-                            source: error.into(),
-                        });
-                    }
-                };
-
-            if let Some(cert) = latest_settled_certificate {
-                network_info.settled_certificate_id = Some(cert.certificate_id);
-                network_info.settled_height = Some(cert.height);
-                network_info.settled_ler = Some(cert.new_local_exit_root);
-                network_info.latest_epoch_with_settlement =
-                    cert.epoch_number.map(|num| num.as_u64());
-
-                if network_info.settled_pp_root.is_none() {
-                    // Extract settled_pp_root from the settled certificate's
-                    // proof public values
-                    network_info.settled_pp_root = match Self::get_proof_blocking(
-                        pending_store,
-                        state,
-                        epochs_store,
-                        cert.certificate_id,
-                    ) {
-                        Ok(Some(agglayer_types::Proof::SP1(sp1_proof))) => {
-                            match pessimistic_proof::PessimisticProofOutput::bincode_codec()
-                                .deserialize::<pessimistic_proof::PessimisticProofOutput>(
-                                sp1_proof.public_values.as_slice(),
-                            ) {
-                                Ok(output) => Some(output.new_pessimistic_root),
-                                Err(error) => {
-                                    error!(
-                                        ?error,
-                                        "get network status: failed to deserialize pessimistic \
-                                         proof output"
-                                    );
-                                    return Err(GetNetworkInfoError::InternalError {
-                                        network_id,
-                                        source: error.into(),
-                                    });
-                                }
-                            }
-                        }
-                        Ok(None) => None,
-                        Err(ProofRetrievalError::NotFound { .. }) => None,
-                        Err(error) => {
-                            error!(
-                                ?error,
-                                "get network status: failed to get proof for settled certificate \
-                                 {certificate_id}",
-                                certificate_id = cert.certificate_id
-                            );
-                            return Err(GetNetworkInfoError::InternalError {
-                                network_id,
-                                source: error.into(),
-                            });
-                        }
-                    };
-
-                    if network_info.settled_let_leaf_count.is_none() {
-                        network_info.settled_let_leaf_count =
-                            match state.read_local_network_state(network_id) {
-                                Ok(local_network_state) => {
-                                    local_network_state.map(|v| v.exit_tree.leaf_count as u64)
-                                }
-                                Err(error) => {
-                                    error!(
-                                        ?error,
-                                        "get network status: failed to read local network state \
-                                         for network {network_id}"
-                                    );
-                                    return Err(GetNetworkInfoError::InternalError {
-                                        network_id,
-                                        source: error.into(),
-                                    });
-                                }
-                            };
-                    }
-
-                    if network_info.settled_claim.is_none() {
-                        if let Some(height) = network_info.settled_height {
-                            // Get the last settled claim if we have a settled
-                            // height
-                            network_info.settled_claim = Self::get_latest_settled_claim_blocking(
-                                state,
-                                epochs_store,
-                                network_id,
-                                height,
-                            )
-                            .map_err(|error| {
-                                error!(?error, "Failed to get last settled claim");
-                                GetNetworkInfoError::InternalError {
-                                    network_id,
-                                    source: error.into(),
-                                }
-                            })?;
-                        }
-                    }
-                }
+        // Storage owns the complete settlement snapshot, including any legacy
+        // fallback. Further point reads here could attach a newer settlement
+        // to the claim and aggregates from that snapshot.
+        let mut network_info = state.get_network_info(network_id).map_err(|error| {
+            error!(
+                ?error,
+                "Failed to retrieve network info for network {network_id} from the storage"
+            );
+            GetNetworkInfoError::InternalError {
+                network_id,
+                source: error.into(),
             }
-        }
+        })?;
 
         let latest_pending_certificate = match network_info.latest_pending_certificate_id {
             Some(certificate_id) => {
@@ -711,56 +360,6 @@ where
             network_info.latest_pending_status = Some(cert.status);
         }
 
-        if network_info.network_type == NetworkType::Unspecified {
-            // Determine network type from the latest available certificate
-            let aggchain_data = match Self::get_latest_available_certificate_for_network_blocking(
-                pending_store,
-                state,
-                epochs_store,
-                network_id,
-            ) {
-                Ok(Some(certificate)) => Ok(Some(certificate.aggchain_data)),
-                Ok(None) if network_info.latest_pending_height.is_some() => {
-                    // If there's no latest available certificate but we have a
-                    // pending height, We can unwrap
-                    let height = network_info.latest_pending_height.unwrap();
-                    pending_store
-                        .get_certificate(network_id, height)
-                        .map_err(|error| {
-                            error!(
-                                ?error,
-                                "Failed to get pending certificate at height {height} for network \
-                                 {network_id}"
-                            );
-                            GetNetworkInfoError::InternalError {
-                                network_id,
-                                source: error.into(),
-                            }
-                        })
-                        .map(|maybe_cert| maybe_cert.map(|cert| cert.aggchain_data))
-                }
-                Ok(None) => {
-                    // No certificates at all, cannot determine network type
-                    warn!(
-                        "No certificates found for network {network_id}, cannot determine network \
-                         type"
-                    );
-                    return Err(GetNetworkInfoError::UnknownNetworkType { network_id });
-                }
-                Err(error) => {
-                    error!(?error, "Unable to determine network type");
-                    Err(GetNetworkInfoError::InternalError {
-                        network_id,
-                        source: error.into(),
-                    })
-                }
-            }?;
-
-            if let Some(ref aggchain_data) = aggchain_data {
-                network_info.network_type = aggchain_data.into();
-            }
-        }
-
         let network_is_disabled = state.is_network_disabled(&network_id).map_err(|error| {
             error!(
                 ?error,
@@ -796,8 +395,8 @@ where
     }
 }
 
-impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
-    AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<L1Rpc, PendingStore, StateStore, DebugStore>
+    AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore>
 where
     StateStore: StateReader + SettlementReader + 'static,
 {
@@ -884,8 +483,8 @@ where
     }
 }
 
-impl<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
-    AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore, EpochsStore>
+impl<L1Rpc, PendingStore, StateStore, DebugStore>
+    AgglayerService<L1Rpc, PendingStore, StateStore, DebugStore>
 where
     PendingStore: PendingCertificateWriter + PendingCertificateReader + 'static,
     StateStore: StateReader + StateWriter + SettlementReader + 'static,

--- a/crates/agglayer-rpc/src/tests/blocking_boundary.rs
+++ b/crates/agglayer-rpc/src/tests/blocking_boundary.rs
@@ -9,9 +9,7 @@ use std::{
 
 use agglayer_config::Config;
 use agglayer_contracts::{AggchainContract, L1RpcError, L1TransactionFetcher, RollupContract};
-use agglayer_storage::tests::mocks::{
-    MockDebugStore, MockEpochsStore, MockPendingStore, MockStateStore,
-};
+use agglayer_storage::tests::mocks::{MockDebugStore, MockPendingStore, MockStateStore};
 use agglayer_types::{Address, Certificate, CertificateId, Digest, Height, NetworkId};
 use alloy::{
     network::Ethereum,
@@ -59,7 +57,6 @@ async fn certificate_header_query_keeps_the_runtime_responsive() {
         Arc::new(MockPendingStore::new()),
         Arc::new(state_store),
         Arc::new(MockDebugStore::new()),
-        Arc::new(MockEpochsStore::new()),
         Arc::new(Config::default()),
         Arc::new(ProviderBuilder::new().connect_mocked_client(asserter)),
     ));
@@ -239,7 +236,6 @@ async fn dropped_send_certificate_still_notifies_orchestrator() {
         Arc::new(pending_store),
         Arc::new(state_store),
         Arc::new(debug_store),
-        Arc::new(MockEpochsStore::new()),
         Arc::new(config),
         Arc::new(StubL1Rpc),
     ));

--- a/crates/agglayer-rpc/src/tests/certificate_replacement.rs
+++ b/crates/agglayer-rpc/src/tests/certificate_replacement.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use agglayer_config::Config;
-use agglayer_storage::tests::mocks::{
-    MockDebugStore, MockEpochsStore, MockPendingStore, MockStateStore,
-};
+use agglayer_storage::tests::mocks::{MockDebugStore, MockPendingStore, MockStateStore};
 use agglayer_types::{
     Address, Certificate, CertificateId, ContractCallOutcome, ContractCallResult, Digest,
     NetworkId, Nonce, SettlementAttemptNumber, SettlementJobId, SettlementJobResult,
@@ -42,7 +40,6 @@ fn service_with_state(
     MockPendingStore,
     MockStateStore,
     MockDebugStore,
-    MockEpochsStore,
 > {
     let certificate_sender = tokio::sync::mpsc::channel(1).0;
     let asserter = Asserter::new();
@@ -53,7 +50,6 @@ fn service_with_state(
         Arc::new(MockPendingStore::new()),
         Arc::new(state_store),
         Arc::new(MockDebugStore::new()),
-        Arc::new(MockEpochsStore::new()),
         Arc::new(Config::default()),
         l1_rpc_provider,
     )

--- a/crates/agglayer-rpc/src/tests/network_info.rs
+++ b/crates/agglayer-rpc/src/tests/network_info.rs
@@ -2,22 +2,18 @@ use std::sync::Arc;
 
 use agglayer_config::Config;
 use agglayer_storage::{
-    columns::latest_settled_certificate_per_network::SettledCertificate,
     error::Error as StorageError,
-    tests::mocks::{MockDebugStore, MockEpochsStore, MockPendingStore, MockStateStore},
+    tests::mocks::{MockDebugStore, MockPendingStore, MockStateStore},
 };
 use agglayer_types::{
-    aggchain_data::CertificateAggchainDataCtx, Certificate, CertificateHeader, CertificateIndex,
-    CertificateStatusError, Digest, EpochNumber, Height, L1WitnessCtx, Metadata, NetworkId,
-    NetworkInfo, PessimisticRootInput,
+    Certificate, CertificateHeader, CertificateIndex, CertificateStatusError, Digest, Metadata,
+    NetworkId, NetworkInfo, NetworkType, SettledClaim,
 };
 use alloy::providers::{
     mock::{Asserter, MockTransport},
     ProviderBuilder,
 };
 use mockall::predicate::eq;
-use pessimistic_proof::core::commitment::PessimisticRootCommitmentVersion;
-use pessimistic_proof_test_suite::forest::Forest;
 
 const DEFAULT_NETWORK_INFO: NetworkInfo = NetworkInfo::from_network_id(NetworkId::new(1));
 const NETWORK_1: NetworkId = NetworkId::new(1);
@@ -38,12 +34,6 @@ async fn transient_network_info() {
         .with(eq(NETWORK_1))
         .return_once(|_network_id| Ok(false));
 
-    state_store
-        .expect_get_latest_settled_certificate_per_network()
-        .with(eq(NETWORK_1))
-        .once()
-        .return_once(|_| Ok(None));
-
     let pending_certificate = Certificate::new_for_test(NETWORK_1, 0.into());
     let pending_certificate_id = pending_certificate.hash();
     let pending_certificate_header = CertificateHeader {
@@ -60,35 +50,17 @@ async fn transient_network_info() {
     };
 
     state_store
-        .expect_get_latest_settled_certificate_per_network()
-        .with(eq(NETWORK_1))
-        .once()
-        .returning(|_| Ok(None));
-
-    state_store
         .expect_get_certificate_header()
         .with(eq(pending_certificate_id))
         .once()
         .return_once(move |_| Ok(Some(pending_certificate_header.clone())));
 
     pending_store
-        .expect_get_certificate()
-        .with(eq(NETWORK_1), eq(Height::new(0)))
-        .once()
-        .return_once(move |_, _| Ok(Some(pending_certificate.clone())));
-
-    pending_store
         .expect_get_latest_pending_certificate_for_network()
         .with(eq(NETWORK_1))
         .returning(move |_| Ok(Some((pending_certificate_id, 0.into()))));
 
-    pending_store
-        .expect_get_latest_proven_certificate_per_network()
-        .with(eq(NETWORK_1))
-        .returning(move |_| Ok(None));
-
     let debug_store = MockDebugStore::new();
-    let epochs_store = MockEpochsStore::new();
     let config = Arc::new(Config::default());
 
     // Create a mock provider for the default case
@@ -101,12 +73,14 @@ async fn transient_network_info() {
         Arc::new(pending_store),
         Arc::new(state_store),
         Arc::new(debug_store),
-        Arc::new(epochs_store),
         config,
         l1_rpc_provider,
     );
 
     let info = service.get_network_info(1.into()).await.unwrap();
+    // The record holds no type yet, and the request reports that rather than
+    // decoding a certificate to recover it or failing outright.
+    assert_eq!(info.network_type, NetworkType::Unspecified);
     assert_eq!(info.settled_certificate_id, None);
     assert_eq!(info.settled_claim, None);
     assert_eq!(info.settled_height, None);
@@ -133,50 +107,24 @@ async fn pending_certificate_defined() {
     let mut pending_store = MockPendingStore::new();
     let mut state_store = MockStateStore::new();
     state_store
-        .expect_get_network_info()
-        .with(eq(NETWORK_1))
-        .return_once(|_network_id| Ok(DEFAULT_NETWORK_INFO));
-
-    state_store
         .expect_is_network_disabled()
         .with(eq(NETWORK_1))
         .return_once(|_network_id| Ok(false));
 
     let settled_certificate = Certificate::new_for_test(NETWORK_1, 0.into());
     let settled_certificate_id = settled_certificate.hash();
-    let settled_certificate_header = CertificateHeader {
-        network_id: NETWORK_1,
-        height: 0.into(),
-        epoch_number: Some(0.into()),
-        certificate_index: Some(CertificateIndex::new(0)),
-        certificate_id: settled_certificate_id,
-        prev_local_exit_root: settled_certificate.prev_local_exit_root,
-        new_local_exit_root: settled_certificate.new_local_exit_root,
-        metadata: Metadata::DEFAULT,
-        status: agglayer_types::CertificateStatus::Settled,
-        settlement_tx_hash: Some(Digest::ZERO.into()),
+    let network_info = NetworkInfo {
+        settled_certificate_id: Some(settled_certificate_id),
+        settled_height: Some(settled_certificate.height),
+        settled_ler: Some(settled_certificate.new_local_exit_root),
+        latest_epoch_with_settlement: Some(0),
+        ..DEFAULT_NETWORK_INFO
     };
-
-    let mut network_state = Forest::default();
-
-    let l1_info_root = settled_certificate
-        .l1_info_root()
-        .unwrap()
-        .unwrap_or_default();
-    let signer = network_state.get_signer();
-    network_state
-        .state_b
-        .apply_certificate(
-            &settled_certificate,
-            L1WitnessCtx {
-                l1_info_root,
-                prev_pessimistic_root: PessimisticRootInput::Computed(
-                    PessimisticRootCommitmentVersion::V2,
-                ),
-                aggchain_data_ctx: CertificateAggchainDataCtx::LegacyEcdsa { signer },
-            },
-        )
-        .unwrap();
+    state_store
+        .expect_get_network_info()
+        .with(eq(NETWORK_1))
+        .once()
+        .return_once(move |_| Ok(network_info));
 
     let pending_certificate = Certificate::new_for_test(NETWORK_1, 1.into());
     let pending_certificate_id = pending_certificate.hash();
@@ -193,68 +141,18 @@ async fn pending_certificate_defined() {
         settlement_tx_hash: None,
     };
 
-    state_store
-        .expect_read_local_network_state()
-        .returning(move |_| Ok(Some(network_state.state_b.clone())));
-
     pending_store
         .expect_get_latest_pending_certificate_for_network()
         .with(eq(NETWORK_1))
         .returning(move |_| Ok(Some((pending_certificate_id, 1.into()))));
 
-    pending_store
-        .expect_get_latest_proven_certificate_per_network()
-        .with(eq(NETWORK_1))
-        .returning(move |_| Ok(None));
-
-    pending_store.expect_get_proof().returning(|_| Ok(None));
-
-    pending_store
-        .expect_get_certificate()
-        .with(eq(NETWORK_1), eq(Height::new(0)))
-        .returning(move |_, _| Ok(None));
-
     let get_pending_header = pending_certificate_header.clone();
-    let get_settled_header = settled_certificate_header.clone();
     state_store
         .expect_get_certificate_header()
         .with(eq(pending_certificate_id))
         .returning(move |_| Ok(Some(get_pending_header.clone())));
 
-    state_store
-        .expect_get_certificate_header()
-        .with(eq(settled_certificate_id))
-        .returning(move |_| Ok(Some(get_settled_header.clone())));
-
-    state_store
-        .expect_get_certificate_header_by_cursor()
-        .with(eq(NETWORK_1), eq(Height::new(0)))
-        .returning(move |_, _| Ok(Some(settled_certificate_header.clone())));
-
-    state_store
-        .expect_get_latest_settled_certificate_per_network()
-        .with(eq(NETWORK_1))
-        .returning(move |_| {
-            Ok(Some((
-                NETWORK_1,
-                SettledCertificate(
-                    settled_certificate_id,
-                    0.into(),
-                    0.into(),
-                    CertificateIndex::new(0),
-                ),
-            )))
-        });
-
     let debug_store = MockDebugStore::new();
-
-    let mut epochs_store = MockEpochsStore::new();
-    let get_settled_certificate = settled_certificate.clone();
-    epochs_store.expect_get_proof().returning(|_, _| Ok(None));
-    epochs_store
-        .expect_get_certificate()
-        .with(eq(EpochNumber::new(0)), eq(CertificateIndex::new(0)))
-        .returning(move |_, _| Ok(Some(get_settled_certificate.clone())));
 
     let config = Arc::new(Config::default());
 
@@ -268,7 +166,6 @@ async fn pending_certificate_defined() {
         Arc::new(pending_store),
         Arc::new(state_store),
         Arc::new(debug_store),
-        Arc::new(epochs_store),
         config,
         l1_rpc_provider,
     );
@@ -283,7 +180,7 @@ async fn pending_certificate_defined() {
         Some(settled_certificate.new_local_exit_root)
     );
     assert_eq!(info.settled_pp_root, None);
-    assert_eq!(info.settled_let_leaf_count, Some(0));
+    assert_eq!(info.settled_let_leaf_count, None);
 
     assert_eq!(info.latest_pending_error, None);
     assert_eq!(
@@ -304,7 +201,6 @@ async fn pending_certificate_defined_with_network_info() {
     let pending_store = MockPendingStore::new();
     let mut state_store = MockStateStore::new();
     let debug_store = MockDebugStore::new();
-    let epochs_store = MockEpochsStore::new();
     let config = Arc::new(Config::default());
     let pending_certificate = Certificate::new_for_test(NETWORK_1, 11.into());
     let pending_certificate_id = pending_certificate.hash();
@@ -364,7 +260,6 @@ async fn pending_certificate_defined_with_network_info() {
         Arc::new(pending_store),
         Arc::new(state_store),
         Arc::new(debug_store),
-        Arc::new(epochs_store),
         config,
         l1_rpc_provider,
     );
@@ -401,7 +296,6 @@ async fn settled_cached_pending_header_is_omitted() {
     let pending_store = MockPendingStore::new();
     let mut state_store = MockStateStore::new();
     let debug_store = MockDebugStore::new();
-    let epochs_store = MockEpochsStore::new();
     let config = Arc::new(Config::default());
 
     let certificate = Certificate::new_for_test(NETWORK_1, 11.into());
@@ -431,10 +325,6 @@ async fn settled_cached_pending_header_is_omitted() {
         .with(eq(NETWORK_1))
         .return_once(move |_| Ok(network_info));
     state_store
-        .expect_get_latest_settled_certificate_per_network()
-        .with(eq(NETWORK_1))
-        .return_once(|_| Ok(None));
-    state_store
         .expect_get_certificate_header()
         .with(eq(certificate_id))
         .return_once(move |_| Ok(Some(header)));
@@ -451,7 +341,6 @@ async fn settled_cached_pending_header_is_omitted() {
         Arc::new(pending_store),
         Arc::new(state_store),
         Arc::new(debug_store),
-        Arc::new(epochs_store),
         config,
         l1_rpc_provider,
     );
@@ -463,187 +352,94 @@ async fn settled_cached_pending_header_is_omitted() {
     assert_eq!(info.latest_pending_error, None);
 }
 
+/// Every settled field is whatever the network info record holds — claim,
+/// network type and leaf count alike. No certificate or proof expectation is
+/// set on purpose, so any attempt to recover one of them by reading a
+/// certificate or a proof fails the test instead of passing quietly. Storage
+/// owns keeping that record self-consistent; see
+/// `settled_header_is_read_from_the_same_snapshot`.
 #[tokio::test]
-async fn get_network_info_propagates_error_from_read_local_network_state() {
-    let certificate_sender = tokio::sync::mpsc::channel(1).0;
+async fn settled_claim_is_served_from_the_network_info_record() {
+    for claim in [
+        None,
+        Some(SettledClaim {
+            global_index: Digest([7u8; 32]),
+            bridge_exit_hash: Digest([9u8; 32]),
+        }),
+    ] {
+        for leaf_count in [None, Some(7)] {
+            let certificate_sender = tokio::sync::mpsc::channel(1).0;
 
-    let mut pending_store = MockPendingStore::new();
-    let mut state_store = MockStateStore::new();
-    let mut epochs_store = MockEpochsStore::new();
-    let debug_store = MockDebugStore::new();
-    let config = Arc::new(Config::default());
+            let mut pending_store = MockPendingStore::new();
+            let mut state_store = MockStateStore::new();
+            let debug_store = MockDebugStore::new();
+            let config = Arc::new(Config::default());
 
-    // Base network info (no settled data yet)
-    state_store
-        .expect_get_network_info()
-        .with(eq(NETWORK_1))
-        .return_once(|_| Ok(DEFAULT_NETWORK_INFO));
+            let certificate = Certificate::new_for_test(NETWORK_1, 10_000.into());
+            let certificate_id = certificate.hash();
+            let network_info = NetworkInfo {
+                network_type: agglayer_types::NetworkType::Generic,
+                settled_certificate_id: Some(certificate_id),
+                settled_height: Some(certificate.height),
+                settled_claim: claim.clone(),
+                settled_let_leaf_count: leaf_count,
+                ..NetworkInfo::from_network_id(NETWORK_1)
+            };
 
-    // Latest settled certificate exists
-    let settled_certificate = Certificate::new_for_test(NETWORK_1, 0.into());
-    let settled_certificate_id = settled_certificate.hash();
-    let settled_certificate_header = CertificateHeader {
-        network_id: NETWORK_1,
-        height: 0.into(),
-        epoch_number: Some(0.into()),
-        certificate_index: Some(CertificateIndex::new(0)),
-        certificate_id: settled_certificate_id,
-        prev_local_exit_root: settled_certificate.prev_local_exit_root,
-        new_local_exit_root: settled_certificate.new_local_exit_root,
-        metadata: Metadata::DEFAULT,
-        status: agglayer_types::CertificateStatus::Settled,
-        settlement_tx_hash: Some(Digest::ZERO.into()),
-    };
+            state_store
+                .expect_get_network_info()
+                .with(eq(NETWORK_1))
+                .return_once(move |_| Ok(network_info));
+            state_store
+                .expect_is_network_disabled()
+                .with(eq(NETWORK_1))
+                .return_once(|_| Ok(false));
+            pending_store
+                .expect_get_latest_pending_certificate_for_network()
+                .with(eq(NETWORK_1))
+                .return_once(|_| Ok(None));
 
-    state_store
-        .expect_get_latest_settled_certificate_per_network()
-        .with(eq(NETWORK_1))
-        .returning(move |_| {
-            Ok(Some((
-                NETWORK_1,
-                SettledCertificate(
-                    settled_certificate_id,
-                    0.into(),
-                    0.into(),
-                    CertificateIndex::new(0),
-                ),
-            )))
-        });
+            let asserter = Asserter::new();
+            let _transport = MockTransport::new(asserter.clone());
+            let l1_rpc_provider = Arc::new(ProviderBuilder::new().connect_mocked_client(asserter));
+            let service = crate::AgglayerService::new(
+                certificate_sender,
+                Arc::new(pending_store),
+                Arc::new(state_store),
+                Arc::new(debug_store),
+                config,
+                l1_rpc_provider,
+            );
 
-    // Fetching header
-    let get_settled_header = settled_certificate_header.clone();
-    state_store
-        .expect_get_certificate_header()
-        .with(eq(settled_certificate_id))
-        .returning(move |_| Ok(Some(get_settled_header.clone())));
-
-    // get_proof -> pending: None
-    pending_store.expect_get_proof().returning(|_| Ok(None));
-
-    // get_proof -> epochs: None
-    epochs_store.expect_get_proof().returning(|_, _| Ok(None));
-
-    // read_local_network_state should error and be propagated
-    state_store
-        .expect_read_local_network_state()
-        .with(eq(NETWORK_1))
-        .return_once(|_| Err(StorageError::Unexpected("boom".into())));
-
-    // Create a mock provider
-    let asserter = Asserter::new();
-    let _transport = MockTransport::new(asserter.clone());
-    let l1_rpc_provider = Arc::new(ProviderBuilder::new().connect_mocked_client(asserter));
-
-    let service = crate::AgglayerService::new(
-        certificate_sender,
-        Arc::new(pending_store),
-        Arc::new(state_store),
-        Arc::new(debug_store),
-        Arc::new(epochs_store),
-        config,
-        l1_rpc_provider,
-    );
-
-    let res = service.get_network_info(NETWORK_1).await;
-    assert!(matches!(
-        res,
-        Err(crate::error::GetNetworkInfoError::InternalError { .. })
-    ));
+            let info = service.get_network_info(NETWORK_1).await.unwrap();
+            assert_eq!(info.settled_claim, claim);
+            assert_eq!(info.network_type, NetworkType::Generic);
+            assert_eq!(info.settled_let_leaf_count, leaf_count);
+            assert_eq!(info.settled_pp_root, None);
+        }
+    }
 }
 
 #[tokio::test]
-async fn get_network_info_propagates_error_from_get_latest_settled_claim() {
-    let certificate_sender = tokio::sync::mpsc::channel(1).0;
-
-    let mut pending_store = MockPendingStore::new();
+async fn network_info_storage_error_is_propagated() {
     let mut state_store = MockStateStore::new();
-    let mut epochs_store = MockEpochsStore::new();
-    let debug_store = MockDebugStore::new();
-    let config = Arc::new(Config::default());
-
     state_store
         .expect_get_network_info()
         .with(eq(NETWORK_1))
-        .return_once(|_| Ok(DEFAULT_NETWORK_INFO));
-
-    let settled_certificate = Certificate::new_for_test(NETWORK_1, 0.into());
-    let settled_certificate_id = settled_certificate.hash();
-    let settled_certificate_header = CertificateHeader {
-        network_id: NETWORK_1,
-        height: 0.into(),
-        epoch_number: Some(0.into()),
-        certificate_index: Some(CertificateIndex::new(0)),
-        certificate_id: settled_certificate_id,
-        prev_local_exit_root: settled_certificate.prev_local_exit_root,
-        new_local_exit_root: settled_certificate.new_local_exit_root,
-        metadata: Metadata::DEFAULT,
-        status: agglayer_types::CertificateStatus::Settled,
-        settlement_tx_hash: Some(Digest::ZERO.into()),
-    };
-
-    state_store
-        .expect_get_latest_settled_certificate_per_network()
-        .with(eq(NETWORK_1))
-        .returning(move |_| {
-            Ok(Some((
-                NETWORK_1,
-                SettledCertificate(
-                    settled_certificate_id,
-                    0.into(),
-                    0.into(),
-                    CertificateIndex::new(0),
-                ),
-            )))
-        });
-
-    // Header by id (used by get_proof fallback)
-    let get_settled_header = settled_certificate_header.clone();
-    state_store
-        .expect_get_certificate_header()
-        .with(eq(settled_certificate_id))
-        .returning(move |_| Ok(Some(get_settled_header.clone())));
-
-    // Proof not found anywhere so we proceed to settled claim step
-    pending_store.expect_get_proof().returning(|_| Ok(None));
-    epochs_store.expect_get_proof().returning(|_, _| Ok(None));
-
-    // read_local_network_state returns Ok(None) to skip leaf count path
-    state_store
-        .expect_read_local_network_state()
-        .with(eq(NETWORK_1))
-        .return_once(|_| Ok(None));
-
-    // Header by cursor for settled height
-    let cursor_header = settled_certificate_header.clone();
-    state_store
-        .expect_get_certificate_header_by_cursor()
-        .with(eq(NETWORK_1), eq(Height::new(0)))
-        .return_once(move |_, _| Ok(Some(cursor_header.clone())));
-
-    // epochs_store.get_certificate errors -> should propagate as InternalError
-    epochs_store
-        .expect_get_certificate()
-        .with(eq(EpochNumber::new(0)), eq(CertificateIndex::new(0)))
-        .return_once(|_, _| Err(StorageError::Unexpected("ep err".into())));
-
-    // Create a mock provider
-    let asserter = Asserter::new();
-    let _transport = MockTransport::new(asserter.clone());
-    let l1_rpc_provider = Arc::new(ProviderBuilder::new().connect_mocked_client(asserter));
+        .once()
+        .return_once(|_| Err(StorageError::Unexpected("unreadable network info".into())));
 
     let service = crate::AgglayerService::new(
-        certificate_sender,
-        Arc::new(pending_store),
+        tokio::sync::mpsc::channel(1).0,
+        Arc::new(MockPendingStore::new()),
         Arc::new(state_store),
-        Arc::new(debug_store),
-        Arc::new(epochs_store),
-        config,
-        l1_rpc_provider,
+        Arc::new(MockDebugStore::new()),
+        Arc::new(Config::default()),
+        Arc::new(ProviderBuilder::new().connect_mocked_client(Asserter::new())),
     );
 
-    let res = service.get_network_info(NETWORK_1).await;
-    assert!(matches!(
-        res,
-        Err(crate::error::GetNetworkInfoError::InternalError { .. })
-    ));
+    let crate::error::GetNetworkInfoError::InternalError { network_id, source } =
+        service.get_network_info(NETWORK_1).await.unwrap_err();
+    assert_eq!(network_id, NETWORK_1);
+    assert!(source.to_string().contains("unreadable network info"));
 }

--- a/crates/agglayer-storage/src/network_metrics/tests.rs
+++ b/crates/agglayer-storage/src/network_metrics/tests.rs
@@ -160,6 +160,7 @@ fn store_mutations_update_gauges_after_each_successful_write() {
             &certificate_id,
             &EpochNumber::ZERO,
             &CertificateIndex::ZERO,
+            None,
         )
         .unwrap();
     assert_eq!(height_of(&registry, 1, "settled"), Some(0));
@@ -325,6 +326,7 @@ fn hydrate_seeds_every_series_from_a_storage_snapshot() {
                 &CertificateId::new([5; 32].into()),
                 &EpochNumber::ZERO,
                 &CertificateIndex::ZERO,
+                None,
             )
             .unwrap();
     }
@@ -419,6 +421,7 @@ fn failed_writes_leave_gauges_unchanged() {
                 &certificate_id,
                 &EpochNumber::ZERO,
                 &CertificateIndex::ZERO,
+                None,
             )
             .unwrap();
     }
@@ -469,6 +472,7 @@ fn failed_writes_leave_gauges_unchanged() {
             &certificate_id,
             &EpochNumber::ZERO,
             &CertificateIndex::ZERO,
+            None,
         )
         .is_err());
 

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -15,8 +15,10 @@ use crate::schema::{
 
 pub(crate) mod iterators;
 mod migration;
+mod snapshot;
 
 pub use migration::{Builder, DBMigrationError, DBMigrationErrorDetails, DBOpenError, DbAccess};
+pub(crate) use snapshot::Snapshot;
 
 #[derive(Debug, thiserror::Error)]
 pub enum DBError {
@@ -106,34 +108,9 @@ impl DB {
             .map_or(Ok(None), |v| v.map(Some))
     }
 
-    pub fn atomic_multi_get<C: ColumnSchema>(
-        &self,
-        keys: impl IntoIterator<Item = C::Key>,
-    ) -> Result<Vec<Option<C::Value>>, DBError> {
-        let snapshot = self.rocksdb.snapshot();
-        let cf = self
-            .rocksdb
-            .cf_handle(C::COLUMN_FAMILY_NAME)
-            .ok_or(DBError::ColumnFamilyNotFound)?;
-
-        let keys: Result<Vec<_>, _> = keys
-            .into_iter()
-            .map(|k| k.encode().map(|key| (cf, key)))
-            .collect();
-
-        let results = snapshot
-            .multi_get_cf(keys?)
-            .into_iter()
-            .map(|r| r.map_err(DBError::from))
-            .collect::<Result<Vec<Option<_>>, _>>()?;
-
-        results
-            .into_iter()
-            .map(|bytes| match bytes {
-                Some(bytes) => C::Value::decode(&bytes[..]).map_err(Into::into).map(Some),
-                None => Ok(None),
-            })
-            .collect()
+    /// Pin one database view for related reads across column families.
+    pub(crate) fn snapshot(&self) -> Snapshot<'_> {
+        Snapshot::new(self)
     }
 
     pub fn multi_get<C: ColumnSchema>(

--- a/crates/agglayer-storage/src/storage/snapshot.rs
+++ b/crates/agglayer-storage/src/storage/snapshot.rs
@@ -1,0 +1,49 @@
+use super::{DBError, DB};
+use crate::schema::{Codec, ColumnSchema};
+
+/// Typed reads from one RocksDB snapshot. Keep this borrowed view inside the
+/// blocking store operation and return only owned results to async callers.
+pub(crate) struct Snapshot<'a> {
+    db: &'a DB,
+    snapshot: rocksdb::Snapshot<'a>,
+}
+
+impl<'a> Snapshot<'a> {
+    pub(super) fn new(db: &'a DB) -> Self {
+        Self {
+            db,
+            snapshot: db.rocksdb.snapshot(),
+        }
+    }
+
+    pub(crate) fn get<C: ColumnSchema>(&self, key: &C::Key) -> Result<Option<C::Value>, DBError> {
+        let key = key.encode()?;
+        let cf = self.db.cf::<C>()?;
+
+        self.snapshot
+            .get_cf(cf, key)?
+            .map(|bytes| C::Value::decode(&bytes).map_err(Into::into))
+            .transpose()
+    }
+
+    pub(crate) fn multi_get<C: ColumnSchema>(
+        &self,
+        keys: impl IntoIterator<Item = C::Key>,
+    ) -> Result<Vec<Option<C::Value>>, DBError> {
+        let cf = self.db.cf::<C>()?;
+        let keys: Result<Vec<_>, _> = keys
+            .into_iter()
+            .map(|key| key.encode().map(|key| (cf, key)))
+            .collect();
+
+        self.snapshot
+            .multi_get_cf(keys?)
+            .into_iter()
+            .map(|result| {
+                result?
+                    .map(|bytes| C::Value::decode(&bytes).map_err(Into::into))
+                    .transpose()
+            })
+            .collect()
+    }
+}

--- a/crates/agglayer-storage/src/stores/interfaces/reader/network_info_reader.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/reader/network_info_reader.rs
@@ -3,6 +3,14 @@ use agglayer_types::{CertificateId, Height, NetworkId, NetworkInfo};
 use crate::error::Error;
 
 pub trait NetworkInfoReader: Send + Sync {
+    /// Read all settled fields, including legacy cursor/header fallbacks, from
+    /// one database snapshot. Optional aggregates absent from that settlement's
+    /// record stay absent; the live network state may have advanced already.
+    ///
+    /// A settled claim the record does not hold reads as no claim. That is only
+    /// the truth for a network that never settled an imported bridge exit, so
+    /// the record has to be complete: settlement keeps it complete, and a
+    /// database migration is what makes it complete to begin with.
     fn get_network_info(&self, network_id: NetworkId) -> Result<NetworkInfo, Error>;
 
     fn get_latest_pending_height(&self, network_id: NetworkId) -> Result<Option<Height>, Error>;

--- a/crates/agglayer-storage/src/stores/interfaces/writer.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/writer.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use agglayer_types::{
     primitives::Digest, Certificate, CertificateId, CertificateIndex, CertificateStatus,
-    EpochNumber, ExecutionMode, Height, LocalNetworkStateData, NetworkId, Proof, SettlementTxHash,
+    EpochNumber, ExecutionMode, Height, LocalNetworkStateData, NetworkId, Proof, SettledClaim,
+    SettlementTxHash,
 };
 
 use crate::{error::Error, stores::PerEpochReader};
@@ -101,6 +102,13 @@ pub trait StateWriter: Send + Sync {
         certificate_index: &CertificateIndex,
     ) -> Result<(), Error>;
 
+    /// Record the network's settled cursor together with everything
+    /// `getNetworkInfo` serves about the settlement: the settled pointer, the
+    /// local exit tree leaf count, and the claim the certificate carried.
+    ///
+    /// All of it lands in one batch, so a request reads one settlement rather
+    /// than fields from two, and nothing has to be re-derived on the request
+    /// path.
     fn set_latest_settled_certificate_for_network(
         &self,
         network_id: &NetworkId,
@@ -108,6 +116,7 @@ pub trait StateWriter: Send + Sync {
         certificate_id: &CertificateId,
         epoch_number: &EpochNumber,
         certificate_index: &CertificateIndex,
+        settled_claim: Option<SettledClaim>,
     ) -> Result<(), Error>;
 
     fn write_local_network_state(

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -8,8 +8,8 @@ use std::{
 use agglayer_tries::{node::Node, smt::Smt};
 use agglayer_types::{
     primitives::Digest, Certificate, CertificateHeader, CertificateId, CertificateIndex,
-    CertificateStatus, EpochNumber, Height, LocalNetworkStateData, NetworkId, SettlementJobId,
-    SettlementTxHash,
+    CertificateStatus, EpochNumber, Height, LocalNetworkStateData, NetworkId, SettledClaim,
+    SettlementJobId, SettlementTxHash,
 };
 use pessimistic_proof::{
     local_balance_tree::LOCAL_BALANCE_TREE_DEPTH, nullifier_tree::NULLIFIER_TREE_DEPTH,
@@ -39,7 +39,12 @@ use crate::{
     schema::ColumnSchema,
     storage::DB,
     stores::interfaces::writer::{UpdateEvenIfAlreadyPresent, UpdateStatusToCandidate},
-    types::{MetadataKey, MetadataValue, SmtKey, SmtKeyType, SmtValue},
+    types::{
+        network_info::v0::{
+            self as network_info_v0, network_info_value::Value as NetworkInfoValue,
+        },
+        MetadataKey, MetadataValue, SmtKey, SmtKeyType, SmtValue,
+    },
     NetworkMetrics,
 };
 
@@ -367,14 +372,60 @@ impl StateWriter for StateStore {
         certificate_id: &CertificateId,
         epoch_number: &EpochNumber,
         certificate_index: &CertificateIndex,
+        settled_claim: Option<SettledClaim>,
     ) -> Result<(), Error> {
         let prometheus_height = NetworkMetrics::prometheus_height(*height)?;
         let mut metrics = self.network_metrics.mutation();
-        self.db.put::<LatestSettledCertificatePerNetworkColumn>(
-            network_id,
-            &SettledCertificate(*certificate_id, *height, *epoch_number, *certificate_index),
+
+        let mut batch = WriteBatch::default();
+
+        let cursor =
+            SettledCertificate(*certificate_id, *height, *epoch_number, *certificate_index);
+        self.db
+            .multi_insert_batch::<LatestSettledCertificatePerNetworkColumn>(
+                [(network_id, &cursor)],
+                &mut batch,
+            )?;
+
+        let settled_certificate = network_info_v0::SettledCertificate {
+            certificate_id: Some(network_info_v0::SettledCertificateId {
+                id: certificate_id.as_digest().as_slice().to_vec().into(),
+            }),
+            let_leaf_count: self.local_exit_tree_leaf_count(*network_id)?.map(|count| {
+                network_info_v0::SettledLocalExitTreeLeafCount {
+                    settled_let_leaf_count: u64::from(count),
+                }
+            }),
+            // `pp_root` and `ler` are left unset: nothing writes the former, and
+            // the reader takes the latter off the settled certificate header.
+            ..Default::default()
+        };
+        self.stage_network_info(
+            *network_id,
+            NetworkInfoValue::SettledCertificate(settled_certificate),
+            &mut batch,
         )?;
+
+        // A certificate without an imported bridge exit leaves the stored claim
+        // in place: it is still the latest one settled.
+        if let Some(claim) = settled_claim {
+            self.stage_network_info(
+                *network_id,
+                NetworkInfoValue::SettledClaim(network_info_v0::SettledClaim {
+                    global_index: Some(network_info_v0::GlobalIndex {
+                        value: claim.global_index.as_slice().to_vec().into(),
+                    }),
+                    bridge_exit_hash: Some(network_info_v0::BridgeExitHash {
+                        bridge_exit_hash: claim.bridge_exit_hash.as_slice().to_vec().into(),
+                    }),
+                }),
+                &mut batch,
+            )?;
+        }
+
+        self.db.write_batch(batch)?;
         metrics.height_written(*network_id, NetworkStage::Settled, prometheus_height);
+
         Ok(())
     }
 
@@ -471,6 +522,17 @@ impl StateWriter for StateStore {
 }
 
 impl StateStore {
+    /// The leaf count recorded for the network's local exit tree.
+    fn local_exit_tree_leaf_count(&self, network_id: NetworkId) -> Result<Option<u32>, Error> {
+        match self.db.get::<LocalExitTreePerNetworkColumn>(&LET::Key {
+            network_id: network_id.into(),
+            key_type: LET::KeyType::LeafCount,
+        })? {
+            None => Ok(None),
+            Some(LET::Value::LeafCount(leaf_count)) => Ok(Some(leaf_count)),
+            Some(_) => Err(Error::WrongValueType),
+        }
+    }
     /// Requests a best-effort backup of the state and pending databases.
     fn request_backup(&self) {
         if let Err(error) = self.backup_client.backup_state() {

--- a/crates/agglayer-storage/src/stores/state/network_info/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/network_info/mod.rs
@@ -4,11 +4,19 @@
 //! providing functionality to read and retrieve network-related information
 //! from the database.
 use agglayer_types::{CertificateId, Height, NetworkId, NetworkInfo, NetworkType};
+use rocksdb::WriteBatch;
 
 use crate::{
-    columns::network_info::NetworkInfoColumn,
+    columns::{
+        certificate_header::CertificateHeaderColumn,
+        latest_settled_certificate_per_network::{
+            LatestSettledCertificatePerNetworkColumn, SettledCertificate as SettledCursor,
+        },
+        network_info::NetworkInfoColumn,
+    },
     error::Error,
-    stores::{expected_type_or_fail, state::StateStore, try_digest, StateReader as _},
+    storage::Snapshot,
+    stores::{expected_type_or_fail, state::StateStore, try_digest},
     types::network_info::{
         self,
         v0::{
@@ -19,12 +27,44 @@ use crate::{
     },
 };
 
-impl crate::stores::NetworkInfoReader for StateStore {
-    fn get_network_info(&self, network_id: NetworkId) -> Result<NetworkInfo, Error> {
+impl StateStore {
+    /// One row of a network's info record, keyed by the kind of value it holds.
+    ///
+    /// Deriving the key from the value is what keeps the two in step: a value
+    /// can never be stored under another kind's key.
+    pub(super) fn network_info_row(
+        network_id: NetworkId,
+        value: network_info_value::Value,
+    ) -> (network_info::Key, network_info::Value) {
+        let key = network_info::Key {
+            network_id: network_id.to_u32(),
+            kind: (&value).into(),
+        };
+
+        (key, network_info::Value { value: Some(value) })
+    }
+
+    pub(super) fn stage_network_info(
+        &self,
+        network_id: NetworkId,
+        value: network_info_value::Value,
+        batch: &mut WriteBatch,
+    ) -> Result<(), Error> {
+        let (key, value) = Self::network_info_row(network_id, value);
+
+        Ok(self
+            .db
+            .multi_insert_batch::<NetworkInfoColumn>([(&key, &value)], batch)?)
+    }
+
+    fn network_info_from_snapshot(
+        snapshot: &Snapshot<'_>,
+        network_id: NetworkId,
+    ) -> Result<NetworkInfo, Error> {
         let mut state = NetworkInfo::from_network_id(network_id);
         let keys = network_info::Key::all_keys_for_network(network_id);
-        self.db
-            .atomic_multi_get::<NetworkInfoColumn>(keys.clone())?
+        snapshot
+            .multi_get::<NetworkInfoColumn>(keys.clone())?
             .into_iter()
             .zip(keys)
             .try_for_each(|(maybe_value, network_info::Key { kind, .. })| {
@@ -62,7 +102,7 @@ impl crate::stores::NetworkInfoReader for StateStore {
                         {
                             let certificate_id = try_digest!(&*id, "CertificateId")?
                                 .into();
-                            if let Some(header) = self.get_certificate_header(&certificate_id)? {
+                            if let Some(header) = snapshot.get::<CertificateHeaderColumn>(&certificate_id)? {
                                 state.settled_certificate_id = Some(certificate_id);
                                 state.settled_height = Some(header.height);
                                 state.settled_ler = Some(header.new_local_exit_root);
@@ -133,7 +173,33 @@ impl crate::stores::NetworkInfoReader for StateStore {
                 Ok::<(), Error>(())
             })?;
 
+        // Legacy databases can have a settled cursor without a network-info
+        // row. Its header must come from the same snapshot as the cached claim.
+        if state.settled_certificate_id.is_none() {
+            if let Some(SettledCursor(certificate_id, _, _, _)) =
+                snapshot.get::<LatestSettledCertificatePerNetworkColumn>(&network_id)?
+            {
+                if let Some(header) = snapshot.get::<CertificateHeaderColumn>(&certificate_id)? {
+                    state.settled_certificate_id = Some(certificate_id);
+                    state.settled_height = Some(header.height);
+                    state.settled_ler = Some(header.new_local_exit_root);
+                    state.latest_epoch_with_settlement =
+                        header.epoch_number.map(|epoch| epoch.as_u64());
+                }
+            }
+        }
+
+        // The live LET may already include the next certificate before its
+        // settled cursor is published. Only the count recorded alongside the
+        // settled pointer belongs to this settlement; missing counts stay
+        // absent.
         Ok(state)
+    }
+}
+
+impl crate::stores::NetworkInfoReader for StateStore {
+    fn get_network_info(&self, network_id: NetworkId) -> Result<NetworkInfo, Error> {
+        Self::network_info_from_snapshot(&self.db.snapshot(), network_id)
     }
 
     fn get_latest_pending_height(&self, network_id: NetworkId) -> Result<Option<Height>, Error> {

--- a/crates/agglayer-storage/src/stores/state/network_info/tests.rs
+++ b/crates/agglayer-storage/src/stores/state/network_info/tests.rs
@@ -1,5 +1,7 @@
 use agglayer_types::{
+    aggchain_proof::{AggchainData, MultisigPayload},
     Certificate, CertificateIndex, CertificateStatus, Digest, EpochNumber, Height,
+    LocalNetworkStateData,
 };
 use rstest::rstest;
 
@@ -18,6 +20,19 @@ use crate::{
         Key,
     },
 };
+
+/// A store that keeps its temporary directory, for tests that write enough to
+/// make RocksDB flush: the shared `store` fixture drops the directory on
+/// return, and the flush is what notices.
+fn owned_store() -> (crate::tests::TempDBDir, StateStore) {
+    let tmp = crate::tests::TempDBDir::new();
+    let db = std::sync::Arc::new(StateStore::init_db(tmp.path.as_path()).unwrap());
+
+    (
+        tmp,
+        StateStore::new(db, crate::backup::BackupClient::noop()),
+    )
+}
 
 #[test_log::test(rstest)]
 fn fetching_an_unexisting_network(network_id: NetworkId, store: StateStore) {
@@ -162,5 +177,220 @@ fn settled_pointer_allows_absent_optional_aggregates(network_id: NetworkId, stor
     assert_eq!(
         network_info.latest_epoch_with_settlement,
         Some(epoch.as_u64())
+    );
+}
+
+#[test_log::test(rstest)]
+#[case::preserve_claim(false)]
+#[case::replace_claim(true)]
+fn settled_info_advances_together(network_id: NetworkId, #[case] replace_claim: bool) {
+    let (_tmp, store) = owned_store();
+    let mut local_state = LocalNetworkStateData::default();
+    let mut expected_claim = None;
+    let mut published_settled_id = None;
+    let mut published_leaf_count = None;
+
+    for height in [Height::ZERO, Height::new(1)] {
+        let snapshot = store.db.snapshot();
+        let before = StateStore::network_info_from_snapshot(&snapshot, network_id).unwrap();
+        let mut certificate = Certificate::new_for_test(network_id, height);
+        if height != Height::ZERO {
+            certificate.aggchain_data = AggchainData::MultisigOnly {
+                multisig: MultisigPayload(Vec::new()),
+            };
+        }
+        let certificate_id = certificate.hash();
+        let leaf = Digest([height.as_u64() as u8; 32]);
+        local_state.exit_tree.add_leaf(leaf).unwrap();
+        store
+            .write_local_network_state(&network_id, &local_state, &[leaf])
+            .unwrap();
+        store
+            .insert_certificate_header(&certificate, CertificateStatus::Proven)
+            .unwrap();
+        store
+            .assign_certificate_to_epoch(
+                &certificate_id,
+                &EpochNumber::ZERO,
+                &CertificateIndex::ZERO,
+            )
+            .unwrap();
+
+        // None of that moves the published settlement: the leaf count and the
+        // settled pointer advance only when the settlement publishes them.
+        let unpublished = store.get_network_info(network_id).unwrap();
+        assert_eq!(unpublished.settled_certificate_id, published_settled_id);
+        assert_eq!(unpublished.settled_let_leaf_count, published_leaf_count);
+
+        let claim =
+            (height == Height::ZERO || replace_claim).then_some(agglayer_types::SettledClaim {
+                global_index: leaf,
+                bridge_exit_hash: leaf,
+            });
+        expected_claim = claim.clone().or(expected_claim);
+        store
+            .set_latest_settled_certificate_for_network(
+                &network_id,
+                &height,
+                &certificate_id,
+                &EpochNumber::ZERO,
+                &CertificateIndex::ZERO,
+                claim,
+            )
+            .unwrap();
+
+        let info = store.get_network_info(network_id).unwrap();
+        assert_eq!(info.settled_certificate_id, Some(certificate_id));
+        assert_eq!(info.settled_height, Some(height));
+        assert_eq!(info.settled_ler, Some(certificate.new_local_exit_root));
+        assert_eq!(info.settled_let_leaf_count, Some(height.as_u64() + 1));
+        assert_eq!(info.settled_claim, expected_claim);
+        assert_eq!(
+            StateStore::network_info_from_snapshot(&snapshot, network_id).unwrap(),
+            before,
+        );
+        published_settled_id = info.settled_certificate_id;
+        published_leaf_count = info.settled_let_leaf_count;
+    }
+}
+
+#[test_log::test(rstest)]
+#[case::legacy_cursor(false)]
+#[case::cached_pointer_without_leaf_count(true)]
+fn legacy_settlement_does_not_borrow_the_next_settlements_leaf_count(
+    network_id: NetworkId,
+    #[case] cached_pointer: bool,
+) {
+    let (_tmp, store) = owned_store();
+    let mut local_state = LocalNetworkStateData::default();
+    let first_leaf = Digest([1; 32]);
+    local_state.exit_tree.add_leaf(first_leaf).unwrap();
+    store
+        .write_local_network_state(&network_id, &local_state, &[first_leaf])
+        .unwrap();
+    let certificate = Certificate::new_for_test(network_id, Height::ZERO);
+    let certificate_id = certificate.hash();
+    let epoch = EpochNumber::new(3);
+    store
+        .insert_certificate_header(&certificate, CertificateStatus::Proven)
+        .unwrap();
+    store
+        .assign_certificate_to_epoch(&certificate_id, &epoch, &CertificateIndex::ZERO)
+        .unwrap();
+    store
+        .db
+        .put::<LatestSettledCertificatePerNetworkColumn>(
+            &network_id,
+            &SettledCursor(certificate_id, Height::ZERO, epoch, CertificateIndex::ZERO),
+        )
+        .unwrap();
+    if cached_pointer {
+        let (key, value) = StateStore::network_info_row(
+            network_id,
+            network_info_value::Value::SettledCertificate(SettledCertificate {
+                certificate_id: Some(SettledCertificateId {
+                    id: certificate_id.as_digest().as_slice().to_vec().into(),
+                }),
+                ..Default::default()
+            }),
+        );
+        store.db.put::<NetworkInfoColumn>(&key, &value).unwrap();
+    }
+
+    // The next settlement writes the LET before publishing its cursor. A
+    // database snapshot in this interval must not associate that count with
+    // the old settled certificate, even when both reads use the snapshot.
+    let second_leaf = Digest([2; 32]);
+    local_state.exit_tree.add_leaf(second_leaf).unwrap();
+    store
+        .write_local_network_state(&network_id, &local_state, &[second_leaf])
+        .unwrap();
+    let snapshot = store.db.snapshot();
+    let before = store.get_network_info(network_id).unwrap();
+    assert_eq!(before.settled_certificate_id, Some(certificate_id));
+    assert_eq!(before.settled_height, Some(Height::ZERO));
+    assert_eq!(before.settled_ler, Some(certificate.new_local_exit_root));
+    assert_eq!(before.latest_epoch_with_settlement, Some(epoch.as_u64()));
+    assert_eq!(before.settled_let_leaf_count, None);
+
+    let next = Certificate::new_for_test(network_id, Height::new(1));
+    let next_id = next.hash();
+    store
+        .insert_certificate_header(&next, CertificateStatus::Proven)
+        .unwrap();
+    store
+        .assign_certificate_to_epoch(&next_id, &epoch, &CertificateIndex::new(1))
+        .unwrap();
+    let claim = agglayer_types::SettledClaim {
+        global_index: Digest([7; 32]),
+        bridge_exit_hash: Digest([9; 32]),
+    };
+    store
+        .set_latest_settled_certificate_for_network(
+            &network_id,
+            &next.height,
+            &next_id,
+            &epoch,
+            &CertificateIndex::new(1),
+            Some(claim.clone()),
+        )
+        .unwrap();
+
+    assert_eq!(
+        StateStore::network_info_from_snapshot(&snapshot, network_id).unwrap(),
+        before,
+    );
+    let after = store.get_network_info(network_id).unwrap();
+    assert_eq!(after.settled_certificate_id, Some(next_id));
+    assert_eq!(after.settled_let_leaf_count, Some(2));
+    assert_eq!(after.settled_claim, Some(claim));
+}
+
+#[test_log::test(rstest)]
+fn settled_header_is_read_from_the_same_snapshot(network_id: NetworkId, store: StateStore) {
+    let certificate = Certificate::new_for_test(network_id, Height::ZERO);
+    let certificate_id = certificate.hash();
+    store
+        .insert_certificate_header(&certificate, CertificateStatus::Proven)
+        .unwrap();
+    store
+        .assign_certificate_to_epoch(&certificate_id, &EpochNumber::ZERO, &CertificateIndex::ZERO)
+        .unwrap();
+    store
+        .set_latest_settled_certificate_for_network(
+            &network_id,
+            &Height::ZERO,
+            &certificate_id,
+            &EpochNumber::ZERO,
+            &CertificateIndex::ZERO,
+            None,
+        )
+        .unwrap();
+    let snapshot = store.db.snapshot();
+
+    // Rewriting a header after the snapshot must not change the joined fields.
+    let mut header = store
+        .db
+        .get::<CertificateHeaderColumn>(&certificate_id)
+        .unwrap()
+        .unwrap();
+    header.epoch_number = Some(EpochNumber::new(1));
+    store
+        .db
+        .put::<CertificateHeaderColumn>(&certificate_id, &header)
+        .unwrap();
+
+    assert_eq!(
+        StateStore::network_info_from_snapshot(&snapshot, network_id)
+            .unwrap()
+            .latest_epoch_with_settlement,
+        Some(0),
+    );
+    assert_eq!(
+        store
+            .get_network_info(network_id)
+            .unwrap()
+            .latest_epoch_with_settlement,
+        Some(1)
     );
 }

--- a/crates/agglayer-storage/src/tests/mocks/state_store.rs
+++ b/crates/agglayer-storage/src/tests/mocks/state_store.rs
@@ -84,7 +84,8 @@ mock! {
             height: &Height,
             certificate_id: &CertificateId,
             epoch_number: &EpochNumber,
-            certificate_index: &agglayer_types::CertificateIndex
+            certificate_index: &agglayer_types::CertificateIndex,
+            settled_claim: Option<agglayer_types::SettledClaim>
         ) -> Result<(), Error>;
 
         fn write_local_network_state(

--- a/crates/agglayer-types/src/network_info.rs
+++ b/crates/agglayer-types/src/network_info.rs
@@ -1,5 +1,5 @@
-use agglayer_interop_types::aggchain_proof;
-use agglayer_primitives::Digest;
+use agglayer_interop_types::{aggchain_proof, ImportedBridgeExit};
+use agglayer_primitives::{Digest, Hashable as _, U256};
 use agglayer_tries::roots::LocalExitRoot;
 use serde::{Deserialize, Serialize};
 
@@ -63,6 +63,17 @@ pub struct SettledClaim {
     pub global_index: Digest,
     /// / Hash of the claimed imported bridge exit.
     pub bridge_exit_hash: Digest,
+}
+
+impl From<&ImportedBridgeExit> for SettledClaim {
+    fn from(exit: &ImportedBridgeExit) -> Self {
+        let global_index: U256 = exit.global_index.into();
+
+        Self {
+            global_index: global_index.to_be_bytes().into(),
+            bridge_exit_hash: exit.bridge_exit.hash(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
`interop_getNetworkInfo` rebuilt most of its answer on every call: it walked the
    height range down to the last certificate carrying an imported bridge exit to
    find the settled claim, opening one per-epoch RocksDB per height; it read the
    settlement proof and decoded its public values for the pessimistic root; it
    materialised the balance and nullifier trees to count local exit tree leaves; and
    it opened another epoch database to decode a whole certificate for the network
    type, on every call, because nothing ever wrote that record.

 An audit of the consumers decided what was worth keeping. aggkit has one
    production reader, `aggsender/query/certificate_query.go`, and it reads the
    settled claim alone. `network_type`,
    `settled_pp_root`, `latest_epoch_with_settlement` and `network_status` are read
    by nobody, so nothing is spent on them any more.

 Changes:
 - Settlement publishes what it settled in one batch: the settled cursor, the
      settled pointer, the local exit tree leaf count and the claim the certificate
      carried. A certificate without an imported bridge exit leaves the stored claim
      in place, since it is still the latest one settled.
 - `getNetworkInfo` only reads. It opens no epoch database, decodes no certificate
      or proof, and performs no write on a request.
 - A storage read failure is an RPC error instead of a silently absent claim,
      which is the one field a production consumer reads.
 - Deleted the height descent, the proof accessor it shared with nothing else, the
      network type derivation, and with them `GetLatestCertificateError`,
      `ProofRetrievalError` and `GetNetworkInfoError::UnknownNetworkType`. A network
      that cannot be classified reports `UNSPECIFIED` rather than failing the call.
 - A network info row derives its key from its value, so a value can never be
      stored under another kind's key.
 - `AgglayerService` no longer takes an epoch store, nor do the four API servers
      that threaded the type parameter only to hold it.
 - Fixed the state store test fixture, which dropped its `TempDBDir` on return and
      left every test running against a deleted directory: reads keep working off open
      handles, then the first flush fails to create an SST.

 `network_type` and `settled_pp_root` now always come back unset, and a claim that
    settled before this record existed stays absent until a database migration
    backfills it.

 Part of #1754