### PR TITLE
fix(storage): rework how backups are triggered and taken

### DIFF
--- a/crates/agglayer-storage/src/backup/mod.rs
+++ b/crates/agglayer-storage/src/backup/mod.rs
@@ -3,11 +3,11 @@ use std::{
     fs::read_dir,
     path::{Path, PathBuf},
     sync::Arc,
+    time::Instant,
 };
 
 use agglayer_errors::ResultExt as _;
 use agglayer_types::EpochNumber;
-use eyre::eyre;
 use rocksdb::backup::{
     BackupEngine as RocksBackupEngine, BackupEngineInfo as RocksBackupEngineInfo,
     BackupEngineOptions, RestoreOptions,
@@ -15,9 +15,50 @@ use rocksdb::backup::{
 use serde::Serialize;
 use tokio::sync;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info};
 
 use crate::storage::DB;
+
+/// Whether a backup of the state and pending databases first flushes the
+/// memtables to disk.
+///
+/// This is deliberately off. A forced flush writes one small SST file per
+/// column family that has taken a write since the previous backup, and those
+/// files are never merged away: the settlement column families are keyed by
+/// ULID, so each new file sorts above every file already on disk and RocksDB
+/// moves it straight to the bottom level untouched. Backing up on every
+/// settlement write therefore grew the live file count without bound, and the
+/// backup engine stats every live file against the backup directory before it
+/// copies anything, so backups got slower in proportion to how many had
+/// already been taken.
+///
+/// With the flush off the write-ahead log is copied into the backup instead
+/// and replayed on restore. Writes are already synced to that log
+/// (`WriteOptions::set_sync`), so the recovery point is unchanged, and
+/// [`crate::storage::MAX_TOTAL_WAL_SIZE`] bounds how much log a backup carries.
+const FLUSH_BEFORE_BACKUP: bool = false;
+
+/// Number of files the backup engine copies in parallel.
+///
+/// RocksDB defaults to one, serialising every file copy. That is felt most on
+/// restore, which copies every file of the database back out of the backup
+/// directory, typically a network filesystem.
+const BACKUP_PARALLELISM: i32 = 16;
+
+/// Build the backup engine options used for every backup directory.
+fn backup_engine_options(path: impl AsRef<Path>) -> Result<BackupEngineOptions, rocksdb::Error> {
+    let mut options = BackupEngineOptions::new(path)?;
+    options.set_max_background_operations(BACKUP_PARALLELISM);
+
+    Ok(options)
+}
+
+/// Run one step of a backup, reporting a failure and counting it.
+fn step(failures: &mut usize, result: Result<(), rocksdb::Error>, message: &str) {
+    if result.log_err(message).is_err() {
+        *failures += 1;
+    }
+}
 
 #[cfg(test)]
 mod test_hooks {
@@ -47,10 +88,22 @@ mod test_hooks {
     }
 }
 
-/// Request to create a new backup.
-pub struct BackupRequest {
-    /// Optional epoch db to backup.
-    pub epoch_db: Option<(Arc<DB>, EpochNumber)>,
+/// Work for the backup engine.
+pub(crate) enum BackupRequest {
+    /// Back up the state and pending databases.
+    State,
+
+    /// Back up one packed epoch database.
+    ///
+    /// The open handle travels with the request on purpose. Reopening the
+    /// epoch database read-only to back it up later looks like it would work —
+    /// the backup even reports success — but a read-only handle does not
+    /// expose its write-ahead log to the backup engine, so the resulting
+    /// backup silently omits everything not already flushed.
+    Epoch {
+        db: Arc<DB>,
+        epoch_number: EpochNumber,
+    },
 }
 
 struct BackupEngineConfig {
@@ -76,9 +129,13 @@ impl From<&Path> for BackupEngineConfig {
 }
 
 /// Client used to request a backup.
+///
+/// The queue is unbounded and every send is infallible. The bounded queue this
+/// replaces dropped whatever did not fit, which cost the epoch backups that
+/// are only ever offered once.
 #[derive(Clone)]
 pub struct BackupClient {
-    sender: Option<sync::mpsc::Sender<BackupRequest>>,
+    sender: Option<sync::mpsc::UnboundedSender<BackupRequest>>,
 }
 
 impl BackupClient {
@@ -88,11 +145,11 @@ impl BackupClient {
         BackupClient { sender: None }
     }
 
-    /// Create a backup client whose requests are collected instead of being
+    /// Create a backup client whose requests are recorded instead of being
     /// executed, so tests can assert on the triggers.
     #[cfg(test)]
-    pub(crate) fn observable() -> (BackupClient, sync::mpsc::Receiver<BackupRequest>) {
-        let (sender, receiver) = sync::mpsc::channel(10);
+    pub(crate) fn observable() -> (BackupClient, sync::mpsc::UnboundedReceiver<BackupRequest>) {
+        let (sender, receiver) = sync::mpsc::unbounded_channel();
 
         (
             BackupClient {
@@ -102,17 +159,29 @@ impl BackupClient {
         )
     }
 
-    /// Send a backup request.
+    /// Ask for a backup of the state and pending databases.
     ///
-    /// This function will send the request to the backup engine.
-    pub fn backup(&self, request: BackupRequest) -> eyre::Result<()> {
+    /// Best effort by design and infallible. The receiver lives as long as the
+    /// engine, and dropping the engine cancels the node, so a send only fails
+    /// when shutdown is already under way.
+    pub fn backup_state(&self) {
         if let Some(sender) = &self.sender {
-            sender
-                .try_send(request)
-                .map_err(|_| eyre!("Unable to send backup request"))?;
+            if sender.send(BackupRequest::State).is_err() {
+                error!("Backup engine is gone, state databases will not be backed up");
+            }
         }
+    }
 
-        Ok(())
+    /// Ask for a backup of a packed epoch database.
+    pub fn backup_epoch(&self, db: Arc<DB>, epoch_number: EpochNumber) {
+        if let Some(sender) = &self.sender {
+            if sender
+                .send(BackupRequest::Epoch { db, epoch_number })
+                .is_err()
+            {
+                error!(%epoch_number, "Backup engine is gone, epoch database will not be backed up");
+            }
+        }
     }
 }
 
@@ -125,7 +194,7 @@ pub struct BackupEngine {
     state_db: Arc<DB>,
     pending_db: Arc<DB>,
     config: BackupEngineConfig,
-    backup_request: sync::mpsc::Receiver<BackupRequest>,
+    requests: sync::mpsc::UnboundedReceiver<BackupRequest>,
     state_max_backup_number: usize,
     pending_max_backup_number: usize,
     cancellation_token: CancellationToken,
@@ -144,10 +213,10 @@ impl BackupEngine {
     ) -> eyre::Result<(Self, BackupClient)> {
         let env = rocksdb::Env::new()?;
         let config: BackupEngineConfig = path.into();
-        let pending_opts = rocksdb::backup::BackupEngineOptions::new(&config.pending_backup_path)?;
-        let state_opts = rocksdb::backup::BackupEngineOptions::new(&config.state_backup_path)?;
+        let pending_opts = backup_engine_options(&config.pending_backup_path)?;
+        let state_opts = backup_engine_options(&config.state_backup_path)?;
 
-        let (sender, backup_request) = sync::mpsc::channel(10);
+        let (sender, requests) = sync::mpsc::unbounded_channel();
 
         std::fs::create_dir_all(&config.epochs_backup_path)?;
 
@@ -159,7 +228,7 @@ impl BackupEngine {
                 env,
                 state_db,
                 pending_db,
-                backup_request,
+                requests,
                 state_max_backup_number,
                 pending_max_backup_number,
                 cancellation_token,
@@ -170,85 +239,159 @@ impl BackupEngine {
         ))
     }
 
-    /// Create a new backup for the state, pending and epochs databases.
-    /// This function will also purge old backups as configured.
-    pub fn create_new_backup(&mut self, request: &BackupRequest) -> eyre::Result<()> {
-        #[cfg(test)]
-        test_hooks::backup_started();
+    /// Run the backup engine, listen for new backup requests.
+    pub async fn run(mut self) -> eyre::Result<()> {
+        loop {
+            let request = tokio::select! {
+                _ = self.cancellation_token.cancelled() => break,
+                request = self.requests.recv() => match request {
+                    Some(request) => request,
+                    None => break,
+                }
+            };
 
-        info!("Creating new backup");
-
-        if let Some((db, epoch_number)) = request.epoch_db.as_ref() {
-            let epochs_opts = rocksdb::backup::BackupEngineOptions::new(
-                self.config
-                    .epochs_backup_path
-                    .join(format!("{epoch_number}")),
-            )?;
-
-            if let Ok(mut engine) = RocksBackupEngine::open(&epochs_opts, &self.env)
-                .log_err("Failed to open backup engine for epoch db")
-            {
-                let _ = engine
-                    .create_new_backup_flush(db.raw_rocksdb(), true)
-                    .log_err("Failed to create backup for epoch db");
-            }
-        } else {
-            let _ = self
-                .state_engine
-                .create_new_backup_flush(self.state_db.raw_rocksdb(), true)
-                .log_err("Failed to create backup for state db");
-
-            let _ = self
-                .state_engine
-                .purge_old_backups(self.state_max_backup_number)
-                .log_err("Failed to purge old backup for state db");
-
-            let _ = self
-                .pending_engine
-                .create_new_backup_flush(self.pending_db.raw_rocksdb(), true)
-                .log_err("Failed to create backup for pending db");
-
-            let _ = self
-                .pending_engine
-                .purge_old_backups(self.pending_max_backup_number)
-                .log_err("Failed to purge old backup for pending db");
+            let batch = self.take_queued(vec![request]);
+            self = self.run_blocking(batch).await?;
         }
 
-        info!("Backup successfully created");
+        info!("Backup engine stopping, finishing outstanding work");
+
+        // Cancellation must not abandon what is queued: an epoch is only ever
+        // offered once, and the writes made just before shutdown are the ones
+        // least likely to be covered by a backup already. The trailing request
+        // is unconditional so the last writes are always captured.
+        let mut batch = self.take_queued(Vec::new());
+        batch.push(BackupRequest::State);
+        self.run_blocking(batch).await?;
 
         Ok(())
     }
 
-    /// Run the backup engine, listen for new backup requests.
-    pub async fn run(mut self) -> eyre::Result<()> {
-        loop {
-            tokio::select! {
-                _ = self.cancellation_token.cancelled() => {
-                    info!("Backup engine cancelled");
-                    break;
-                }
-                Some(request) = self.backup_request.recv() =>{
-                    let (backup_engine, result) = tokio::task::spawn_blocking(move || {
-                        let mut backup_engine = self;
-                        let result = backup_engine.create_new_backup(&request);
+    /// Add everything already queued to `batch`.
+    fn take_queued(&mut self, mut batch: Vec<BackupRequest>) -> Vec<BackupRequest> {
+        while let Ok(request) = self.requests.try_recv() {
+            batch.push(request);
+        }
 
-                        (backup_engine, result)
-                    })
-                    .await?;
+        batch
+    }
 
-                    self = backup_engine;
-                    result?;
-                }
+    /// Carry out a batch off the async runtime.
+    ///
+    /// Creating a backup blocks on file I/O for as long as it takes to walk the
+    /// backup directory, so it must not run on an async worker.
+    async fn run_blocking(self, batch: Vec<BackupRequest>) -> eyre::Result<Self> {
+        Ok(tokio::task::spawn_blocking(move || {
+            let mut engine = self;
+            engine.run_batch(batch);
+
+            engine
+        })
+        .await?)
+    }
+
+    /// Carry out one batch of requests.
+    ///
+    /// State backups are interchangeable, so however many the batch holds they
+    /// collapse into a single run. Epoch backups are not, so each is carried
+    /// out.
+    fn run_batch(&mut self, batch: Vec<BackupRequest>) {
+        let mut state_requested = false;
+
+        for request in batch {
+            match request {
+                BackupRequest::Epoch { db, epoch_number } => self.backup_epoch(&db, epoch_number),
+                BackupRequest::State => state_requested = true,
             }
         }
 
-        Ok(())
+        if state_requested {
+            self.backup_state_and_pending();
+        }
+    }
+
+    /// Back up the state and pending databases and purge backups beyond the
+    /// configured retention.
+    ///
+    /// Every step runs even when an earlier one fails, but the run is only
+    /// reported as successful when all of them succeeded. Reporting success
+    /// unconditionally, as this used to, made the count of successful backups
+    /// indistinguishable from the count of attempts.
+    fn backup_state_and_pending(&mut self) {
+        #[cfg(test)]
+        test_hooks::backup_started();
+
+        let started = Instant::now();
+        info!("Creating new backup of the state and pending databases");
+
+        let mut failures = 0;
+
+        step(
+            &mut failures,
+            self.state_engine
+                .create_new_backup_flush(self.state_db.raw_rocksdb(), FLUSH_BEFORE_BACKUP),
+            "Failed to create backup for state db",
+        );
+        step(
+            &mut failures,
+            self.state_engine
+                .purge_old_backups(self.state_max_backup_number),
+            "Failed to purge old backup for state db",
+        );
+        step(
+            &mut failures,
+            self.pending_engine
+                .create_new_backup_flush(self.pending_db.raw_rocksdb(), FLUSH_BEFORE_BACKUP),
+            "Failed to create backup for pending db",
+        );
+        step(
+            &mut failures,
+            self.pending_engine
+                .purge_old_backups(self.pending_max_backup_number),
+            "Failed to purge old backup for pending db",
+        );
+
+        let elapsed_ms = started.elapsed().as_millis();
+        if failures == 0 {
+            info!(elapsed_ms, "Backup successfully created");
+        } else {
+            error!(elapsed_ms, failures, "Backup completed with failures");
+        }
+    }
+
+    /// Back up one packed epoch database.
+    ///
+    /// The flush is kept on here, unlike the state and pending databases: an
+    /// epoch database is packed, small, and closed right after, so the flush
+    /// costs a single file and leaves the backup with no write-ahead log to
+    /// replay.
+    fn backup_epoch(&mut self, db: &DB, epoch_number: EpochNumber) {
+        let started = Instant::now();
+
+        let backup = backup_engine_options(
+            self.config
+                .epochs_backup_path
+                .join(format!("{epoch_number}")),
+        )
+        .and_then(|options| RocksBackupEngine::open(&options, &self.env))
+        .and_then(|mut engine| engine.create_new_backup_flush(db.raw_rocksdb(), true));
+
+        match backup {
+            Ok(()) => {
+                let elapsed_ms = started.elapsed().as_millis();
+                info!(%epoch_number, elapsed_ms, "Epoch database backup created");
+            }
+            Err(error) => error!(
+                %epoch_number, %error,
+                "Failed to back up epoch database; this epoch has no backup"
+            ),
+        }
     }
 
     /// Restore the state database from the latest backup.
     pub fn restore(path: &Path, db_path: &Path) -> eyre::Result<()> {
         let env = rocksdb::Env::new()?;
-        let opts = rocksdb::backup::BackupEngineOptions::new(path)?;
+        let opts = backup_engine_options(path)?;
 
         let mut engine = RocksBackupEngine::open(&opts, &env)?;
 
@@ -260,7 +403,7 @@ impl BackupEngine {
     /// Restore the state database from the defined backup version.
     pub fn restore_at(path: &Path, db_path: &Path, version: u32) -> eyre::Result<()> {
         let env = rocksdb::Env::new()?;
-        let opts = rocksdb::backup::BackupEngineOptions::new(path)?;
+        let opts = backup_engine_options(path)?;
 
         let mut engine = RocksBackupEngine::open(&opts, &env)?;
 
@@ -273,7 +416,7 @@ impl BackupEngine {
         let env = rocksdb::Env::new()?;
 
         let config: BackupEngineConfig = path.into();
-        let opts = BackupEngineOptions::new(&config.state_backup_path)?;
+        let opts = backup_engine_options(&config.state_backup_path)?;
         let engine = RocksBackupEngine::open(&opts, &env)?;
 
         let state = engine
@@ -281,7 +424,7 @@ impl BackupEngine {
             .into_iter()
             .map(BackupEngineInfo::from);
 
-        let opts = BackupEngineOptions::new(&config.pending_backup_path)?;
+        let opts = backup_engine_options(&config.pending_backup_path)?;
         let engine = RocksBackupEngine::open(&opts, &env)?;
 
         let pending = engine
@@ -307,7 +450,7 @@ impl BackupEngine {
         let epochs = epochs
             .into_iter()
             .map(|(epoch_number, path)| -> eyre::Result<_> {
-                let opts = BackupEngineOptions::new(path)?;
+                let opts = backup_engine_options(path)?;
                 let engine = RocksBackupEngine::open(&opts, &env)?;
 
                 Ok((
@@ -401,62 +544,4 @@ impl BackupReport {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::{
-        sync::Arc,
-        time::{Duration, Instant},
-    };
-
-    use tokio_util::sync::CancellationToken;
-
-    use super::*;
-    use crate::{
-        stores::{pending::PendingStore, state::StateStore},
-        tests::TempDBDir,
-    };
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn backup_creation_does_not_block_the_async_runtime_worker() {
-        let tmp = TempDBDir::new();
-        let state_db = Arc::new(
-            StateStore::init_db(&tmp.path.join("state")).expect("state db should initialize"),
-        );
-        let pending_db = Arc::new(
-            PendingStore::init_db(&tmp.path.join("pending")).expect("pending db should initialize"),
-        );
-        let cancellation_token = CancellationToken::new();
-        let (backup_engine, backup_client) = BackupEngine::new(
-            &tmp.path.join("backup"),
-            state_db,
-            pending_db,
-            10,
-            10,
-            cancellation_token.clone(),
-        )
-        .expect("backup engine should initialize");
-
-        let (started_sender, started_receiver) = std::sync::mpsc::channel();
-        test_hooks::observe_backup_started(started_sender);
-
-        let backup_handle = tokio::spawn(backup_engine.run());
-        let started_at = Instant::now();
-        backup_client
-            .backup(BackupRequest { epoch_db: None })
-            .expect("backup request should be queued");
-
-        let _backup_thread = tokio::task::spawn_blocking(move || {
-            started_receiver.recv_timeout(Duration::from_secs(1))
-        })
-        .await
-        .expect("backup started receiver task should complete")
-        .expect("backup should start");
-
-        assert!(
-            started_at.elapsed() < Duration::from_millis(100),
-            "backup creation ran on the async runtime worker and delayed unrelated async tasks"
-        );
-
-        cancellation_token.cancel();
-        backup_handle.abort();
-    }
-}
+mod tests;

--- a/crates/agglayer-storage/src/backup/tests.rs
+++ b/crates/agglayer-storage/src/backup/tests.rs
@@ -1,0 +1,247 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use agglayer_types::SettlementJobId;
+use tokio_util::sync::CancellationToken;
+
+use super::*;
+use crate::{
+    columns::settlement_jobs::SettlementJobsColumn,
+    storage::DB,
+    stores::{pending::PendingStore, state::StateStore},
+    tests::TempDBDir,
+};
+
+struct Harness {
+    engine: BackupEngine,
+    client: BackupClient,
+    cancellation_token: CancellationToken,
+    state_db: Arc<DB>,
+    state_path: PathBuf,
+    backup_path: PathBuf,
+}
+
+fn harness(tmp: &TempDBDir) -> Harness {
+    let state_path = tmp.path.join("state");
+    let backup_path = tmp.path.join("backup");
+    let state_db = Arc::new(StateStore::init_db(&state_path).expect("state db"));
+    let pending_db =
+        Arc::new(PendingStore::init_db(&tmp.path.join("pending")).expect("pending db"));
+    let cancellation_token = CancellationToken::new();
+
+    let (engine, client) = BackupEngine::new(
+        &backup_path,
+        state_db.clone(),
+        pending_db,
+        100,
+        100,
+        cancellation_token.clone(),
+    )
+    .expect("backup engine");
+
+    Harness {
+        engine,
+        client,
+        cancellation_token,
+        state_db,
+        state_path,
+        backup_path,
+    }
+}
+
+fn live_sst_count(db_path: &Path) -> usize {
+    read_dir(db_path)
+        .expect("read db dir")
+        .flatten()
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "sst"))
+        .count()
+}
+
+/// Write one settlement job row. Job ids are ULIDs, so successive rows sort
+/// above every row already on disk — the write pattern that makes flushed
+/// files pile up untouched at the bottom level.
+fn write_settlement_job(db: &DB, id: u128) {
+    db.put::<SettlementJobsColumn>(
+        &SettlementJobId::from(id),
+        &crate::types::generated::agglayer::storage::v0::SettlementJob::default(),
+    )
+    .expect("write settlement job");
+}
+
+async fn until<F: FnMut() -> bool>(label: &str, mut condition: F) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while !condition() {
+        assert!(Instant::now() < deadline, "timed out waiting for {label}");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn backup_creation_does_not_block_the_async_runtime_worker() {
+    let tmp = TempDBDir::new();
+    let Harness {
+        engine,
+        client,
+        cancellation_token,
+        ..
+    } = harness(&tmp);
+
+    let (started_sender, started_receiver) = std::sync::mpsc::channel();
+    test_hooks::observe_backup_started(started_sender);
+
+    // A current-thread runtime drives the async work on this very thread, so
+    // whichever thread the backup reports having run on tells us whether it
+    // stayed off the runtime. Comparing threads rather than timing the backup
+    // keeps this from turning into a flake under load.
+    let runtime_thread = std::thread::current()
+        .name()
+        .unwrap_or("unnamed")
+        .to_string();
+
+    let backup_handle = tokio::spawn(engine.run());
+    client.backup_state();
+
+    let backup_thread =
+        tokio::task::spawn_blocking(move || started_receiver.recv_timeout(Duration::from_secs(5)))
+            .await
+            .expect("backup started receiver task should complete")
+            .expect("backup should start");
+
+    assert_ne!(
+        backup_thread, runtime_thread,
+        "backup creation ran on the async runtime thread, so it would stall unrelated async work"
+    );
+
+    cancellation_token.cancel();
+    backup_handle.abort();
+}
+
+/// Backing up repeatedly must not grow the live file count of the database.
+///
+/// Forcing a memtable flush per backup used to leave one small SST file behind
+/// every time. Those files are never merged away, and the backup engine stats
+/// every live file on each run, so the cost of a backup grew with the number
+/// of backups already taken.
+#[test]
+fn repeated_backups_do_not_accumulate_sst_files() {
+    let tmp = TempDBDir::new();
+    let mut harness = harness(&tmp);
+
+    // One write per backup, as a settling certificate would produce.
+    for id in 0..25 {
+        write_settlement_job(&harness.state_db, id);
+        harness.engine.backup_state_and_pending();
+    }
+
+    let ssts = live_sst_count(&harness.state_path);
+    assert!(
+        ssts <= 2,
+        "25 backups over 25 writes left {ssts} live SST files; backups are forcing a flush again \
+         and the file count will grow without bound"
+    );
+}
+
+/// Everything written before a backup must survive a restore from it, even
+/// though the backup no longer forces a flush and so leans on the write-ahead
+/// log to carry the most recent writes.
+#[test]
+fn backups_restore_every_write() {
+    let tmp = TempDBDir::new();
+    let mut harness = harness(&tmp);
+
+    for id in 0..50 {
+        write_settlement_job(&harness.state_db, id);
+    }
+    harness.engine.backup_state_and_pending();
+
+    let restore_path = tmp.path.join("restored");
+    BackupEngine::restore(&harness.backup_path.join("state"), &restore_path).expect("restore");
+
+    let restored = StateStore::init_db(&restore_path).expect("open restored db");
+    let restored_rows = (0..50)
+        .filter(|id| {
+            restored
+                .get::<SettlementJobsColumn>(&SettlementJobId::from(*id))
+                .expect("read restored row")
+                .is_some()
+        })
+        .count();
+
+    assert_eq!(restored_rows, 50, "restore lost rows held in the WAL");
+}
+
+/// State backup requests queued together collapse into one backup instead of
+/// one backup each.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn queued_state_requests_collapse_into_one_backup() {
+    let tmp = TempDBDir::new();
+    let Harness {
+        engine,
+        client,
+        cancellation_token,
+        backup_path,
+        ..
+    } = harness(&tmp);
+
+    // Raised before the engine polls, so they are all taken as one batch.
+    for _ in 0..20 {
+        client.backup_state();
+    }
+
+    let handle = tokio::spawn(engine.run());
+
+    until("the batched backup to land", || {
+        !BackupEngine::list_backups(&backup_path)
+            .expect("list backups")
+            .get_state()
+            .is_empty()
+    })
+    .await;
+
+    let taken = BackupEngine::list_backups(&backup_path)
+        .expect("list backups")
+        .get_state()
+        .len();
+    assert_eq!(taken, 1, "20 requests produced {taken} backups, expected 1");
+
+    cancellation_token.cancel();
+    handle.abort();
+}
+
+/// Writes made just before the engine is cancelled must still be backed up.
+/// They are the ones least likely to be covered by a backup already.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_finishes_outstanding_work() {
+    let tmp = TempDBDir::new();
+    let Harness {
+        engine,
+        client,
+        cancellation_token,
+        state_db,
+        backup_path,
+        ..
+    } = harness(&tmp);
+
+    let handle = tokio::spawn(engine.run());
+
+    write_settlement_job(&state_db, 1);
+    client.backup_state();
+
+    // Cancel straight away: the request above may not have been picked up.
+    cancellation_token.cancel();
+    handle
+        .await
+        .expect("engine task should finish")
+        .expect("engine should stop cleanly");
+
+    assert!(
+        !BackupEngine::list_backups(&backup_path)
+            .expect("list backups")
+            .get_state()
+            .is_empty(),
+        "state was not backed up at shutdown"
+    );
+}

--- a/crates/agglayer-storage/src/storage/migration/mod.rs
+++ b/crates/agglayer-storage/src/storage/migration/mod.rs
@@ -126,7 +126,7 @@ impl Builder {
     fn open_rocksdb_fresh(path: &Path, cfs: Vec<ColumnFamilyDescriptor>) -> Result<DB, DBError> {
         debug!("Opening fresh database");
 
-        let mut options = rocksdb::Options::default();
+        let mut options = crate::storage::base_db_options();
         options.create_if_missing(true);
         options.create_missing_column_families(true);
 
@@ -139,7 +139,7 @@ impl Builder {
     fn open_rocksdb_existing(path: &Path, cfs: &BTreeSet<impl AsRef<str>>) -> Result<DB, DBError> {
         debug!("Opening existing database");
 
-        let mut options = rocksdb::Options::default();
+        let mut options = crate::storage::base_db_options();
         options.create_missing_column_families(true);
 
         Ok(DB {

--- a/crates/agglayer-storage/src/storage/mod.rs
+++ b/crates/agglayer-storage/src/storage/mod.rs
@@ -39,6 +39,24 @@ pub struct DB {
     default_write_options: Option<WriteOptions>,
 }
 
+/// Cap on the combined size of the live write-ahead logs of one database.
+///
+/// Backups no longer force a memtable flush, so the write-ahead log is what
+/// carries the most recent writes into a backup, and it is copied in full on
+/// every backup. Left at the RocksDB default this cap is derived from the
+/// per-column-family write buffers, which works out to several gigabytes for
+/// the state schema. Capping it bounds both the bytes each backup copies and
+/// the replay a restore has to perform, at the cost of an occasional flush.
+pub(crate) const MAX_TOTAL_WAL_SIZE: u64 = 64 * 1024 * 1024;
+
+/// Database-wide options shared by every way we open a database.
+pub(crate) fn base_db_options() -> Options {
+    let mut options = Options::default();
+    options.set_max_total_wal_size(MAX_TOTAL_WAL_SIZE);
+
+    options
+}
+
 impl DB {
     /// Open a new RocksDB instance at the given path with initial column
     /// families and a possibility to migrate the database.
@@ -55,7 +73,7 @@ impl DB {
     /// column families. This prevents concurrency issues when multiple
     /// processes need to read from the database.
     pub fn open_cf_readonly(path: &Path, cfs: &[ColumnDescriptor]) -> Result<DB, DBError> {
-        let mut options = Options::default();
+        let mut options = base_db_options();
         options.create_if_missing(false); // Don't create if missing in readonly mode
         options.create_missing_column_families(false); // Don't create missing column families
 

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -486,11 +486,8 @@ where
             &PerEpochMetadataValue::Packed(true),
         )?;
 
-        if let Err(error) = self.backup_client.backup(crate::backup::BackupRequest {
-            epoch_db: Some((self.db.clone(), *self.epoch_number)),
-        }) {
-            error!("Couldn't trigger the backup of the epoch DB: {}", error);
-        }
+        self.backup_client
+            .backup_epoch(self.db.clone(), *self.epoch_number);
 
         *lock = true;
         match self

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -21,7 +21,7 @@ use tracing::{info, instrument, warn};
 use self::LET::LocalExitTreePerNetworkColumn;
 use super::{MetadataReader, MetadataWriter, StateReader, StateWriter};
 use crate::{
-    backup::{BackupClient, BackupRequest},
+    backup::BackupClient,
     columns::{
         balance_tree_per_network::BalanceTreePerNetworkColumn,
         certificate_header::CertificateHeaderColumn,
@@ -288,13 +288,6 @@ impl StateWriter for StateStore {
                     &certificate_header.certificate_id,
                 )?;
             }
-
-            // A `Proven` certificate is submitted to L1 from a spawned task shortly
-            // after, so this is the last status write still ordered ahead of the
-            // settlement tx. Its proof is already persisted by now.
-            if let CertificateStatus::Proven = status {
-                self.request_backup();
-            }
         }
 
         Ok(())
@@ -409,9 +402,7 @@ impl StateWriter for StateStore {
 impl StateStore {
     /// Requests a best-effort backup of the state and pending databases.
     fn request_backup(&self) {
-        if let Err(error) = self.backup_client.backup(BackupRequest { epoch_db: None }) {
-            warn!("Unable to trigger backup for the state database: {}", error);
-        }
+        self.backup_client.backup_state();
     }
 
     fn write_smt<C, const DEPTH: usize>(

--- a/crates/agglayer-storage/src/stores/state/tests/backup.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/backup.rs
@@ -4,7 +4,7 @@ use agglayer_types::{
     Certificate, CertificateStatus, CertificateStatusError, Digest, Height, NetworkId,
     SettlementTxHash,
 };
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::{
     backup::{BackupClient, BackupRequest},
@@ -16,7 +16,12 @@ use crate::{
 
 fn setup_store(
     status: CertificateStatus,
-) -> (TempDBDir, StateStore, Certificate, Receiver<BackupRequest>) {
+) -> (
+    TempDBDir,
+    StateStore,
+    Certificate,
+    UnboundedReceiver<BackupRequest>,
+) {
     let tmp = TempDBDir::new();
     let db = Arc::new(StateStore::init_db(tmp.path.as_path()).expect("Unable to init db"));
     let (backup_client, backups) = BackupClient::observable();
@@ -30,32 +35,16 @@ fn setup_store(
     (tmp, store, certificate, backups)
 }
 
+/// No certificate status change should request a backup on its own.
+///
+/// The backup that has to precede an L1 settlement is taken by the settlement
+/// service, which waits for it; a status write here cannot make that promise
+/// and used only to duplicate it moments beforehand.
 #[test]
-fn proven_status_triggers_a_state_backup() {
-    let (_tmp, store, certificate, mut backups) = setup_store(CertificateStatus::Pending);
-
-    store
-        .update_certificate_header_status(&certificate.hash(), &CertificateStatus::Proven)
-        .expect("Unable to update certificate header status");
-
-    let request = backups
-        .try_recv()
-        .expect("Moving a certificate to Proven should request a backup");
-
-    assert!(
-        request.epoch_db.is_none(),
-        "Proven should back up the state and pending DBs, not an epoch DB"
-    );
-    assert!(
-        backups.try_recv().is_err(),
-        "A single status update should request a single backup"
-    );
-}
-
-#[test]
-fn non_proven_statuses_do_not_trigger_a_state_backup() {
+fn certificate_status_changes_do_not_trigger_a_state_backup() {
     for status in [
         CertificateStatus::Pending,
+        CertificateStatus::Proven,
         CertificateStatus::Candidate,
         CertificateStatus::Settled,
         CertificateStatus::error(CertificateStatusError::InternalError("failed".to_string())),

--- a/tests/integrations/tests/storage_backups/main.rs
+++ b/tests/integrations/tests/storage_backups/main.rs
@@ -24,17 +24,49 @@ mod common;
 
 const RESOURCE_NOT_FOUND_ERROR: i32 = -10008;
 
-async fn wait_for_backup_counts(
-    backup_dir: &std::path::Path,
-    minimum_state_backups: usize,
-    minimum_pending_backups: usize,
-) {
-    wait_for_condition("backup creation", Duration::from_secs(30), || async {
-        let backup_report = BackupEngine::list_backups(backup_dir).unwrap();
-        backup_report.get_state().len() >= minimum_state_backups
-            && backup_report.get_pending().len() >= minimum_pending_backups
-    })
-    .await;
+/// How long the backup engine must stay idle before its newest backup is taken
+/// to cover everything written so far.
+const BACKUP_QUIESCENT_FOR: Duration = Duration::from_secs(5);
+
+/// Waits until at least one backup exists and no new one has appeared for
+/// [`BACKUP_QUIESCENT_FOR`], then returns the newest backup id.
+///
+/// Backup requests coalesce, so a certificate no longer produces a fixed
+/// number of backups and tests cannot count them. What they can rely on is
+/// that once the engine has gone quiet, its newest backup covers every write
+/// made before it did.
+async fn wait_for_backup_quiescence(backup_dir: &std::path::Path) -> u32 {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    let mut newest = None;
+    let mut unchanged_since = tokio::time::Instant::now();
+
+    loop {
+        let report = BackupEngine::list_backups(backup_dir).unwrap();
+        let state = latest_backup_id(report.get_state());
+
+        // The two databases are backed up in lockstep, so a mismatch means a
+        // run is still in progress.
+        let quiet = if state.is_none() || state != latest_backup_id(report.get_pending()) {
+            unchanged_since = tokio::time::Instant::now();
+            false
+        } else if state != newest {
+            newest = state;
+            unchanged_since = tokio::time::Instant::now();
+            false
+        } else {
+            unchanged_since.elapsed() >= BACKUP_QUIESCENT_FOR
+        };
+
+        if quiet {
+            return newest.expect("quiescence implies at least one backup");
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for backups to settle"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
 }
 
 fn latest_backup_id(backups: &[BackupEngineInfo]) -> Option<u32> {
@@ -62,28 +94,6 @@ fn restore_snapshot(
     let pending = PendingStore::new_with_path(&pending_path).unwrap();
 
     (restored, state, pending)
-}
-
-/// Waits until the latest state and pending backup ids reach at least the given
-/// values.
-///
-/// Unlike [`wait_for_backup_counts`], this works under aggressive purging
-/// (where the retained backup count stays at 1) because RocksDB backup ids are
-/// monotonic. Each settled certificate produces three backups (one when it is
-/// proven, one when the L1 tx hash is known, one when it is settled), so the
-/// Nth settled certificate's durable state has backup id `3 * N`.
-async fn wait_for_backup_ids(
-    backup_dir: &std::path::Path,
-    minimum_state_backup_id: u32,
-    minimum_pending_backup_id: u32,
-) {
-    wait_for_condition("backup id advance", Duration::from_secs(30), || async {
-        let backup_report = BackupEngine::list_backups(backup_dir).unwrap();
-        latest_backup_id(backup_report.get_state()).is_some_and(|id| id >= minimum_state_backup_id)
-            && latest_backup_id(backup_report.get_pending())
-                .is_some_and(|id| id >= minimum_pending_backup_id)
-    })
-    .await;
 }
 
 #[rstest]
@@ -119,43 +129,35 @@ async fn recover_with_backup(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    // Each settled certificate produces three backups (proven, tx-hash known,
-    // then settled). Wait for all of them so the restore captures the settled
-    // state rather than an earlier snapshot, which would leave the certificate
-    // non-Settled after restart.
-    wait_for_backup_counts(&backup_dir.path, 3, 3).await;
+    let newest_backup = wait_for_backup_quiescence(&backup_dir.path).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
 
-    // The invariant the `Proven` trigger exists for: backup 1 is requested before
-    // the settlement tx is submitted, and must carry the certificate header and
-    // its generated proof together — they live in two different databases, and
-    // the later backups no longer hold the proof.
+    // The invariant the `Proven` trigger exists for: a backup is requested
+    // before the settlement tx is submitted, and it must carry the certificate
+    // header and its generated proof together — they live in two different
+    // databases, and once the certificate settles the proof is gone.
     //
-    // The status is asserted as a range rather than exactly `Proven`: the backup
-    // engine flushes on a blocking task, so under load it can run after the
-    // certificate task has advanced to `Candidate`. Both are pre-settlement and
-    // both recover; pinning `Proven` would only buy a flaky test.
+    // Which backup that is, is not pinned. Requests coalesce, so the snapshot
+    // that predates settlement is whichever one the engine happened to take
+    // first; asserting on an id would only buy a flaky test.
     {
-        let (_restored, state, pending) = restore_snapshot(&backup_dir.path, 1);
+        let pre_settlement = (1..=newest_backup).find(|backup_id| {
+            let (_restored, state, pending) = restore_snapshot(&backup_dir.path, *backup_id);
 
-        let header = state
-            .get_certificate_header(&certificate_id)
-            .unwrap()
-            .expect("backup 1 should contain the certificate header");
-        assert!(
-            matches!(
-                header.status,
-                CertificateStatus::Proven | CertificateStatus::Candidate
-            ),
-            "backup 1 should predate settlement, got {:?}",
-            header.status
-        );
+            let predates_settlement = state
+                .get_certificate_header(&certificate_id)
+                .unwrap()
+                .is_some_and(|header| header.status != CertificateStatus::Settled);
+
+            predates_settlement && pending.get_proof(certificate_id).unwrap().is_some()
+        });
 
         assert!(
-            pending.get_proof(certificate_id).unwrap().is_some(),
-            "backup 1 should contain the generated proof"
+            pre_settlement.is_some(),
+            "no backup carries the certificate header and its proof together from before \
+             settlement; the proof is unrecoverable from any backup"
         );
     }
 
@@ -227,10 +229,9 @@ async fn purge_after_n_backup(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    // Each settled certificate produces three backups (proven, tx-hash known,
-    // then settled). Wait for certificate1 to be fully backed up (state/pending
-    // backup id >= 3) before sending certificate2.
-    wait_for_backup_ids(&backup_dir.path, 3, 3).await;
+    // Let certificate1 finish being backed up before sending certificate2, so
+    // the retention behaviour is exercised across two distinct settlements.
+    wait_for_backup_quiescence(&backup_dir.path).await;
 
     let certificate_id2: CertificateId = client
         .request("interop_sendCertificate", rpc_params![certificate2])
@@ -241,14 +242,8 @@ async fn purge_after_n_backup(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    // This configuration purges state and pending backups eagerly, so the
-    // retained backup count stays at 1 after both settlements. Backup ids are
-    // monotonic, so wait for certificate2's settled backup (id >= 6) to be
-    // durable before shutting the node down; otherwise the restore can capture
-    // one of certificate2's pre-settlement snapshots and the post-restart
-    // status assertion flakes.
-    wait_for_backup_ids(&backup_dir.path, 6, 6).await;
-
+    // Shutdown drains whatever is still outstanding, so the single retained
+    // backup covers both settlements by the time the node is down.
     handle.cancel();
     _ = agglayer_shutdowned.await;
 
@@ -337,8 +332,6 @@ async fn report_contains_all_backups(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    wait_for_backup_counts(&backup_dir.path, 6, 6).await;
-
     handle.cancel();
     _ = agglayer_shutdowned.await;
 
@@ -349,12 +342,31 @@ async fn report_contains_all_backups(#[case] state: Forest) {
 
     let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
 
-    // There are 6 backups because 3 actions trigger a backup per cert:
-    // - One when the `Certificate` is proven
-    // - One when the L1 `tx_hash` is known
-    // - One when the `Certificate` is settled and the network state is updated
-    assert_eq!(backup_report.get_state().len(), 6);
-    assert_eq!(backup_report.get_pending().len(), 6);
+    // How many backups two settlements produce is not fixed: requests coalesce,
+    // so a burst collapses into a single run. What does hold is that the state
+    // and pending databases are backed up together on every run, and that the
+    // report lists every one of them.
+    let state_ids: Vec<u32> = backup_report
+        .get_state()
+        .iter()
+        .map(|backup| backup.backup_id)
+        .collect();
+    let pending_ids: Vec<u32> = backup_report
+        .get_pending()
+        .iter()
+        .map(|backup| backup.backup_id)
+        .collect();
+
+    assert!(!state_ids.is_empty(), "no backup was reported");
+    assert_eq!(
+        state_ids, pending_ids,
+        "state and pending backups are written in lockstep"
+    );
+    assert_eq!(
+        state_ids,
+        (1..=state_ids.len() as u32).collect::<Vec<_>>(),
+        "the report should list every backup taken, without gaps"
+    );
 
     BackupEngine::restore(
         &backup_dir.path.join("state"),
@@ -422,7 +434,9 @@ async fn restore_at_particular_level(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    wait_for_backup_counts(&backup_dir.path, 3, 3).await;
+    // The snapshot this test restores to: taken once certificate1 has settled
+    // and before certificate2 exists at all.
+    let after_certificate1 = wait_for_backup_quiescence(&backup_dir.path).await;
 
     let certificate_id2: CertificateId = client
         .request("interop_sendCertificate", rpc_params![certificate2])
@@ -432,8 +446,6 @@ async fn restore_at_particular_level(#[case] state: Forest) {
     let result = wait_for_settlement_or_error!(client, certificate_id2).await;
 
     assert_eq!(result.status, CertificateStatus::Settled);
-
-    wait_for_backup_counts(&backup_dir.path, 6, 6).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
@@ -445,15 +457,15 @@ async fn restore_at_particular_level(#[case] state: Forest) {
 
     let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
 
-    assert_eq!(backup_report.get_state().len(), 6);
-    assert_eq!(backup_report.get_pending().len(), 6);
+    assert!(
+        latest_backup_id(backup_report.get_state()).is_some_and(|id| id > after_certificate1),
+        "certificate2 should have produced backups after the one being restored"
+    );
 
-    // Backup 3 is certificate1's settled snapshot, taken before certificate2
-    // was ever submitted.
     BackupEngine::restore_at(
         &backup_dir.path.join("state"),
         &config.storage.state_db_path,
-        3,
+        after_certificate1,
     )
     .unwrap();
 


### PR DESCRIPTION
- No forced write to disk before a backup. Files now appear as data is written rather than once per backup: over the same 800 rows, 800 backups used to leave 801 files and now leave one.
- Cap the write-ahead log, which now carries recent writes into the backup in place of that forced write.
- Unbounded request queue, so nothing is dropped. Requests raised while a backup runs are served by the next one.
- Finish queued work at shutdown instead of abandoning it.
- Drop the backup taken when a certificate is proven, which only duplicated the ones around settlement.
- Log "Backup successfully created" only when it was.
- Restore copies files in parallel instead of one at a time.