### PR TITLE
fix(storage): split the backup queue so epoch backups are never dropped

### DIFF
--- a/crates/agglayer-storage/src/backup/mod.rs
+++ b/crates/agglayer-storage/src/backup/mod.rs
@@ -13,7 +13,7 @@ use rocksdb::backup::{
     BackupEngineOptions, RestoreOptions,
 };
 use serde::Serialize;
-use tokio::sync;
+use tokio::sync::{self, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -47,10 +47,12 @@ mod test_hooks {
     }
 }
 
-/// Request to create a new backup.
-pub struct BackupRequest {
-    /// Optional epoch db to backup.
-    pub epoch_db: Option<(Arc<DB>, EpochNumber)>,
+/// Request to back up one epoch database.
+pub struct EpochBackupRequest {
+    /// Epoch db to back up.
+    pub db: Arc<DB>,
+    /// Number of the epoch stored in `db`.
+    pub epoch_number: EpochNumber,
 }
 
 struct BackupEngineConfig {
@@ -75,45 +77,96 @@ impl From<&Path> for BackupEngineConfig {
     }
 }
 
+/// Sending halves of the backup queues.
+///
+/// State and epoch requests travel on separate queues so that a burst of
+/// state requests can never push an epoch request out of the queue.
+#[derive(Clone)]
+struct BackupSenders {
+    /// Single-slot queue for state+pending backups. A backup snapshots the
+    /// databases when it runs, not when it is requested, so one queued
+    /// request covers every write made until it is dequeued and extra
+    /// requests can be dropped safely.
+    state: sync::mpsc::Sender<()>,
+    /// Unbounded queue for epoch backups. Each epoch is packed exactly once,
+    /// so a dropped request would mean that epoch is never backed up.
+    epoch: sync::mpsc::UnboundedSender<EpochBackupRequest>,
+}
+
 /// Client used to request a backup.
 #[derive(Clone)]
 pub struct BackupClient {
-    sender: Option<sync::mpsc::Sender<BackupRequest>>,
+    senders: Option<BackupSenders>,
 }
 
 impl BackupClient {
     /// Create a new backup client that do nothing.
     /// This is useful for tests or when the backup is disabled.
     pub fn noop() -> BackupClient {
-        BackupClient { sender: None }
+        BackupClient { senders: None }
     }
 
     /// Create a backup client whose requests are collected instead of being
     /// executed, so tests can assert on the triggers.
     #[cfg(test)]
-    pub(crate) fn observable() -> (BackupClient, sync::mpsc::Receiver<BackupRequest>) {
-        let (sender, receiver) = sync::mpsc::channel(10);
+    pub(crate) fn observable() -> (BackupClient, ObservedBackupRequests) {
+        // Unlike the production queue created by `BackupEngine::new`, the
+        // state queue is large enough for tests to observe every trigger
+        // instead of seeing them coalesced.
+        let (state_sender, state) = sync::mpsc::channel(10);
+        let (epoch_sender, epoch) = sync::mpsc::unbounded_channel();
 
         (
             BackupClient {
-                sender: Some(sender),
+                senders: Some(BackupSenders {
+                    state: state_sender,
+                    epoch: epoch_sender,
+                }),
             },
-            receiver,
+            ObservedBackupRequests { state, epoch },
         )
     }
 
-    /// Send a backup request.
+    /// Request a backup of the state and pending databases.
     ///
-    /// This function will send the request to the backup engine.
-    pub fn backup(&self, request: BackupRequest) -> eyre::Result<()> {
-        if let Some(sender) = &self.sender {
-            sender
-                .try_send(request)
-                .map_err(|_| eyre!("Unable to send backup request"))?;
+    /// If a request is already queued, this one is coalesced into it: the
+    /// queued backup will run after the write that triggered this request,
+    /// so it covers this write too.
+    pub fn backup_state(&self) -> eyre::Result<()> {
+        if let Some(senders) = &self.senders {
+            match senders.state.try_send(()) {
+                Ok(()) | Err(mpsc::error::TrySendError::Full(())) => {}
+                Err(mpsc::error::TrySendError::Closed(())) => {
+                    Err(eyre!("Unable to send state backup request"))?
+                }
+            }
         }
 
         Ok(())
     }
+
+    /// Request a backup of one epoch database.
+    ///
+    /// Epoch requests are queued unbounded and never dropped: each epoch is
+    /// packed exactly once, so this is its only chance to get backed up.
+    pub fn backup_epoch(&self, db: Arc<DB>, epoch_number: EpochNumber) -> eyre::Result<()> {
+        if let Some(senders) = &self.senders {
+            senders
+                .epoch
+                .send(EpochBackupRequest { db, epoch_number })
+                .map_err(|_| eyre!("Unable to send epoch backup request"))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Receiving halves of an observable [`BackupClient`], so tests can assert
+/// on the requested backups.
+#[cfg(test)]
+pub(crate) struct ObservedBackupRequests {
+    pub(crate) state: sync::mpsc::Receiver<()>,
+    pub(crate) epoch: sync::mpsc::UnboundedReceiver<EpochBackupRequest>,
 }
 
 /// Backup engine that creates backups for the state, pending and epochs
@@ -125,7 +178,8 @@ pub struct BackupEngine {
     state_db: Arc<DB>,
     pending_db: Arc<DB>,
     config: BackupEngineConfig,
-    backup_request: sync::mpsc::Receiver<BackupRequest>,
+    state_backup_request: sync::mpsc::Receiver<()>,
+    epoch_backup_request: sync::mpsc::UnboundedReceiver<EpochBackupRequest>,
     state_max_backup_number: usize,
     pending_max_backup_number: usize,
     cancellation_token: CancellationToken,
@@ -147,7 +201,10 @@ impl BackupEngine {
         let pending_opts = rocksdb::backup::BackupEngineOptions::new(&config.pending_backup_path)?;
         let state_opts = rocksdb::backup::BackupEngineOptions::new(&config.state_backup_path)?;
 
-        let (sender, backup_request) = sync::mpsc::channel(10);
+        // State requests coalesce into a single queue slot while epoch
+        // requests are queued unbounded; see [`BackupSenders`].
+        let (state_sender, state_backup_request) = sync::mpsc::channel(1);
+        let (epoch_sender, epoch_backup_request) = sync::mpsc::unbounded_channel();
 
         std::fs::create_dir_all(&config.epochs_backup_path)?;
 
@@ -159,67 +216,86 @@ impl BackupEngine {
                 env,
                 state_db,
                 pending_db,
-                backup_request,
+                state_backup_request,
+                epoch_backup_request,
                 state_max_backup_number,
                 pending_max_backup_number,
                 cancellation_token,
             },
             BackupClient {
-                sender: Some(sender),
+                senders: Some(BackupSenders {
+                    state: state_sender,
+                    epoch: epoch_sender,
+                }),
             },
         ))
     }
 
-    /// Create a new backup for the state, pending and epochs databases.
+    /// Create a new backup for the state and pending databases.
     /// This function will also purge old backups as configured.
-    pub fn create_new_backup(&mut self, request: &BackupRequest) -> eyre::Result<()> {
+    pub fn backup_state(&mut self) -> eyre::Result<()> {
         #[cfg(test)]
         test_hooks::backup_started();
 
-        info!("Creating new backup");
+        info!("Creating new state backup");
 
-        if let Some((db, epoch_number)) = request.epoch_db.as_ref() {
-            let epochs_opts = rocksdb::backup::BackupEngineOptions::new(
-                self.config
-                    .epochs_backup_path
-                    .join(format!("{epoch_number}")),
-            )?;
+        let _ = self
+            .state_engine
+            .create_new_backup_flush(self.state_db.raw_rocksdb(), true)
+            .log_err("Failed to create backup for state db");
 
-            if let Ok(mut engine) = RocksBackupEngine::open(&epochs_opts, &self.env)
-                .log_err("Failed to open backup engine for epoch db")
-            {
-                let _ = engine
-                    .create_new_backup_flush(db.raw_rocksdb(), true)
-                    .log_err("Failed to create backup for epoch db");
-            }
-        } else {
-            let _ = self
-                .state_engine
-                .create_new_backup_flush(self.state_db.raw_rocksdb(), true)
-                .log_err("Failed to create backup for state db");
+        let _ = self
+            .state_engine
+            .purge_old_backups(self.state_max_backup_number)
+            .log_err("Failed to purge old backup for state db");
 
-            let _ = self
-                .state_engine
-                .purge_old_backups(self.state_max_backup_number)
-                .log_err("Failed to purge old backup for state db");
+        let _ = self
+            .pending_engine
+            .create_new_backup_flush(self.pending_db.raw_rocksdb(), true)
+            .log_err("Failed to create backup for pending db");
 
-            let _ = self
-                .pending_engine
-                .create_new_backup_flush(self.pending_db.raw_rocksdb(), true)
-                .log_err("Failed to create backup for pending db");
+        let _ = self
+            .pending_engine
+            .purge_old_backups(self.pending_max_backup_number)
+            .log_err("Failed to purge old backup for pending db");
 
-            let _ = self
-                .pending_engine
-                .purge_old_backups(self.pending_max_backup_number)
-                .log_err("Failed to purge old backup for pending db");
+        info!("State backup successfully created");
+
+        Ok(())
+    }
+
+    /// Create a new backup for one epoch database.
+    pub fn backup_epoch(&self, request: &EpochBackupRequest) -> eyre::Result<()> {
+        #[cfg(test)]
+        test_hooks::backup_started();
+
+        let EpochBackupRequest { db, epoch_number } = request;
+
+        info!("Creating new backup for epoch {epoch_number}");
+
+        let epochs_opts = rocksdb::backup::BackupEngineOptions::new(
+            self.config
+                .epochs_backup_path
+                .join(format!("{epoch_number}")),
+        )?;
+
+        if let Ok(mut engine) = RocksBackupEngine::open(&epochs_opts, &self.env)
+            .log_err("Failed to open backup engine for epoch db")
+        {
+            let _ = engine
+                .create_new_backup_flush(db.raw_rocksdb(), true)
+                .log_err("Failed to create backup for epoch db");
         }
 
-        info!("Backup successfully created");
+        info!("Epoch backup successfully created");
 
         Ok(())
     }
 
     /// Run the backup engine, listen for new backup requests.
+    ///
+    /// On cancellation, requests that are already queued are drained before
+    /// exiting, so that no epoch backup is ever lost to a shutdown.
     pub async fn run(mut self) -> eyre::Result<()> {
         loop {
             tokio::select! {
@@ -227,22 +303,60 @@ impl BackupEngine {
                     info!("Backup engine cancelled");
                     break;
                 }
-                Some(request) = self.backup_request.recv() =>{
-                    let (backup_engine, result) = tokio::task::spawn_blocking(move || {
-                        let mut backup_engine = self;
-                        let result = backup_engine.create_new_backup(&request);
-
-                        (backup_engine, result)
-                    })
-                    .await?;
-
-                    self = backup_engine;
-                    result?;
+                Some(()) = self.state_backup_request.recv() => {
+                    self = self.run_blocking(|engine| engine.backup_state()).await?;
+                }
+                Some(request) = self.epoch_backup_request.recv() => {
+                    self = self.run_blocking(move |engine| engine.backup_epoch(&request)).await?;
                 }
             }
         }
 
-        Ok(())
+        self.drain().await
+    }
+
+    /// Run one backup on a blocking task, handing the engine back once done.
+    async fn run_blocking(
+        self,
+        backup: impl FnOnce(&mut Self) -> eyre::Result<()> + Send + 'static,
+    ) -> eyre::Result<Self> {
+        let (backup_engine, result) = tokio::task::spawn_blocking(move || {
+            let mut backup_engine = self;
+            let result = backup(&mut backup_engine);
+
+            (backup_engine, result)
+        })
+        .await?;
+
+        result?;
+
+        Ok(backup_engine)
+    }
+
+    /// Process every request still queued, rejecting new ones.
+    ///
+    /// State requests coalesce so at most one can be pending, but a burst of
+    /// epoch requests (which must never be dropped) can leave a backlog.
+    async fn drain(mut self) -> eyre::Result<()> {
+        // Closing the queues rejects new requests while keeping the already
+        // queued ones receivable.
+        self.state_backup_request.close();
+        self.epoch_backup_request.close();
+
+        info!("Draining the queued backup requests");
+
+        tokio::task::spawn_blocking(move || {
+            if self.state_backup_request.try_recv().is_ok() {
+                self.backup_state()?;
+            }
+
+            while let Ok(request) = self.epoch_backup_request.try_recv() {
+                self.backup_epoch(&request)?;
+            }
+
+            Ok(())
+        })
+        .await?
     }
 
     /// Restore the state database from the latest backup.
@@ -441,7 +555,7 @@ mod tests {
         let backup_handle = tokio::spawn(backup_engine.run());
         let started_at = Instant::now();
         backup_client
-            .backup(BackupRequest { epoch_db: None })
+            .backup_state()
             .expect("backup request should be queued");
 
         let _backup_thread = tokio::task::spawn_blocking(move || {
@@ -458,5 +572,93 @@ mod tests {
 
         cancellation_token.cancel();
         backup_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn state_backup_requests_coalesce_when_the_queue_is_full() {
+        let tmp = TempDBDir::new();
+        let state_db = Arc::new(
+            StateStore::init_db(&tmp.path.join("state")).expect("state db should initialize"),
+        );
+        let pending_db = Arc::new(
+            PendingStore::init_db(&tmp.path.join("pending")).expect("pending db should initialize"),
+        );
+        let (_backup_engine, backup_client) = BackupEngine::new(
+            &tmp.path.join("backup"),
+            state_db,
+            pending_db,
+            10,
+            10,
+            CancellationToken::new(),
+        )
+        .expect("backup engine should initialize");
+
+        // The engine is not running, so the first request fills the single
+        // queue slot and the following ones coalesce into it.
+        for _ in 0..3 {
+            backup_client
+                .backup_state()
+                .expect("a full state queue should coalesce the request, not fail");
+        }
+    }
+
+    #[tokio::test]
+    async fn queued_backup_requests_are_drained_on_shutdown() {
+        let tmp = TempDBDir::new();
+        let state_db = Arc::new(
+            StateStore::init_db(&tmp.path.join("state")).expect("state db should initialize"),
+        );
+        let pending_db = Arc::new(
+            PendingStore::init_db(&tmp.path.join("pending")).expect("pending db should initialize"),
+        );
+        let epoch_db = Arc::new(
+            StateStore::init_db(&tmp.path.join("epoch")).expect("epoch db should initialize"),
+        );
+        let cancellation_token = CancellationToken::new();
+        let backup_path = tmp.path.join("backup");
+        let (backup_engine, backup_client) = BackupEngine::new(
+            &backup_path,
+            state_db,
+            pending_db,
+            10,
+            10,
+            cancellation_token.clone(),
+        )
+        .expect("backup engine should initialize");
+
+        // Queue everything before the engine runs, then cancel right away:
+        // the engine must drain the queues instead of dropping the requests.
+        const EPOCHS: u64 = 12;
+
+        backup_client
+            .backup_state()
+            .expect("state backup request should be queued");
+        for epoch in 0..EPOCHS {
+            backup_client
+                .backup_epoch(epoch_db.clone(), EpochNumber::new(epoch))
+                .expect("epoch backup requests should never be rejected");
+        }
+        cancellation_token.cancel();
+
+        backup_engine
+            .run()
+            .await
+            .expect("backup engine should drain the queues and exit cleanly");
+
+        let report = BackupEngine::list_backups(&backup_path).expect("backups should be listable");
+        assert_eq!(report.get_state().len(), 1, "state backup should be taken");
+        assert_eq!(
+            report.get_pending().len(),
+            1,
+            "pending backup should be taken"
+        );
+        assert_eq!(
+            report.get_epochs().len(),
+            EPOCHS as usize,
+            "every queued epoch backup should be taken"
+        );
+        for (epoch, backups) in report.get_epochs() {
+            assert_eq!(backups.len(), 1, "epoch {epoch} should have one backup");
+        }
     }
 }

--- a/crates/agglayer-storage/src/stores/per_epoch/mod.rs
+++ b/crates/agglayer-storage/src/stores/per_epoch/mod.rs
@@ -486,9 +486,10 @@ where
             &PerEpochMetadataValue::Packed(true),
         )?;
 
-        if let Err(error) = self.backup_client.backup(crate::backup::BackupRequest {
-            epoch_db: Some((self.db.clone(), *self.epoch_number)),
-        }) {
+        if let Err(error) = self
+            .backup_client
+            .backup_epoch(self.db.clone(), *self.epoch_number)
+        {
             error!("Couldn't trigger the backup of the epoch DB: {}", error);
         }
 

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -21,7 +21,7 @@ use tracing::{info, instrument, warn};
 use self::LET::LocalExitTreePerNetworkColumn;
 use super::{MetadataReader, MetadataWriter, StateReader, StateWriter};
 use crate::{
-    backup::{BackupClient, BackupRequest},
+    backup::BackupClient,
     columns::{
         balance_tree_per_network::BalanceTreePerNetworkColumn,
         certificate_header::CertificateHeaderColumn,
@@ -409,7 +409,7 @@ impl StateWriter for StateStore {
 impl StateStore {
     /// Requests a best-effort backup of the state and pending databases.
     fn request_backup(&self) {
-        if let Err(error) = self.backup_client.backup(BackupRequest { epoch_db: None }) {
+        if let Err(error) = self.backup_client.backup_state() {
             warn!("Unable to trigger backup for the state database: {}", error);
         }
     }

--- a/crates/agglayer-storage/src/stores/state/tests/backup.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/backup.rs
@@ -4,10 +4,9 @@ use agglayer_types::{
     Certificate, CertificateStatus, CertificateStatusError, Digest, Height, NetworkId,
     SettlementTxHash,
 };
-use tokio::sync::mpsc::Receiver;
 
 use crate::{
-    backup::{BackupClient, BackupRequest},
+    backup::{BackupClient, ObservedBackupRequests},
     stores::{
         state::StateStore, StateWriter as _, UpdateEvenIfAlreadyPresent, UpdateStatusToCandidate,
     },
@@ -16,7 +15,7 @@ use crate::{
 
 fn setup_store(
     status: CertificateStatus,
-) -> (TempDBDir, StateStore, Certificate, Receiver<BackupRequest>) {
+) -> (TempDBDir, StateStore, Certificate, ObservedBackupRequests) {
     let tmp = TempDBDir::new();
     let db = Arc::new(StateStore::init_db(tmp.path.as_path()).expect("Unable to init db"));
     let (backup_client, backups) = BackupClient::observable();
@@ -38,17 +37,18 @@ fn proven_status_triggers_a_state_backup() {
         .update_certificate_header_status(&certificate.hash(), &CertificateStatus::Proven)
         .expect("Unable to update certificate header status");
 
-    let request = backups
+    backups
+        .state
         .try_recv()
-        .expect("Moving a certificate to Proven should request a backup");
+        .expect("Moving a certificate to Proven should request a state backup");
 
     assert!(
-        request.epoch_db.is_none(),
-        "Proven should back up the state and pending DBs, not an epoch DB"
+        backups.state.try_recv().is_err(),
+        "A single status update should request a single backup"
     );
     assert!(
-        backups.try_recv().is_err(),
-        "A single status update should request a single backup"
+        backups.epoch.try_recv().is_err(),
+        "Proven should back up the state and pending DBs, not an epoch DB"
     );
 }
 
@@ -67,7 +67,7 @@ fn non_proven_statuses_do_not_trigger_a_state_backup() {
             .expect("Unable to update certificate header status");
 
         assert!(
-            backups.try_recv().is_err(),
+            backups.state.try_recv().is_err(),
             "Moving a certificate to {status} should not request a backup"
         );
     }
@@ -87,7 +87,7 @@ fn recording_a_settlement_tx_hash_triggers_a_state_backup() {
         .expect("Unable to update settlement tx hash");
 
     assert!(
-        backups.try_recv().is_ok(),
+        backups.state.try_recv().is_ok(),
         "Recording a settlement tx hash should request a backup"
     );
 }

--- a/docs/knowledge-base/src/storage.md
+++ b/docs/knowledge-base/src/storage.md
@@ -96,10 +96,20 @@ The state and pending DBs are backed up together when:
 - A settlement tx hash is recorded on or removed from a certificate header.
 - A local network state is written, which happens on settlement.
 
-An epoch DB is backed up separately when that epoch is edited.
-Every request is best-effort:
-it is dropped with a warning if the backup engine is busy,
-and it never blocks the write that triggered it.
+An epoch DB is backed up separately when that epoch is packed.
+Requests never block the write that triggered them,
+and travel on two separate queues so state requests cannot crowd out epoch requests:
+
+- State+pending requests coalesce into a single queue slot.
+  Extra requests are dropped, which is safe because a backup snapshots
+  the databases when it runs, not when it is requested,
+  so the queued backup also covers the write that got its request dropped.
+- Epoch requests are queued unbounded and never dropped:
+  an epoch is packed exactly once,
+  so a dropped request would mean that epoch is never backed up.
+
+On shutdown, the backup engine drains both queues before exiting,
+so requests that were already queued still produce backups.
 
 When changing storage schemas or keys:
 


### PR DESCRIPTION
## Problem

State and epoch backup requests share one 10-slot queue, and any request hitting a full queue is dropped. For state requests that is harmless — the next write re-triggers one, and the backup snapshots the databases when it runs anyway. But an epoch is packed exactly once, so a dropped epoch request means that epoch DB is **never** backed up.

## Change

The queue is split in two, with semantics matched to each request type:

- **State+pending requests coalesce into a single queue slot** (`BackupClient::backup_state`). A backup snapshots the databases when it runs, not when it is requested, so the one queued request covers every write made until it is dequeued; a full queue is success, not an error.
- **Epoch requests are queued unbounded and never dropped** (`BackupClient::backup_epoch`). Bounded in practice by one request per packed epoch.

On shutdown, the engine now also **drains both queues before exiting** (previously, queued requests were abandoned on cancellation), so a queued epoch backup is not lost to a restart either.

`BackupEngine::new`'s signature, the on-disk backup layout, and the restore/list CLI paths are unchanged. The knowledge base (`docs/knowledge-base/src/storage.md`) is updated to describe the new queue semantics.

## Testing

- New unit tests: state requests coalesce instead of failing when the slot is taken; a shutdown with 1 state + 12 queued epoch requests (more than the old shared queue could hold) produces all 12 epoch backups plus the state/pending pair.
- `cargo nextest run --workspace`: 952 passed.
- `cargo nextest run -P integrations -E 'binary(storage_backups)'`: 4 passed.
- `cargo make ci-all`, `cargo check --workspace --tests --all-features`, `mdbook build docs/knowledge-base/`: all clean.

## Note

`fix/backup-reliability` reworks the same area and will be rebased/reworked on top of this change (synced with Monir).

Closes agglayer/issues#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)