### PR TITLE
fix(storage): back up newly accepted pending certificates

### DIFF
--- a/crates/agglayer-rpc/src/lib.rs
+++ b/crates/agglayer-rpc/src/lib.rs
@@ -998,7 +998,11 @@ where
             .insert_pending_certificate(certificate.network_id, certificate.height, &certificate)
             .inspect_err(|e| error!("Failed to insert certificate into pending store: {e}"))?;
 
-        // Insert the certificate header into the state store.
+        // Insert the certificate header into the state store. Inserting a
+        // `Pending` header also requests the backup of the newly accepted
+        // certificate, so this write must stay ordered after the
+        // pending-store insert above: the backup has to capture the
+        // certificate body together with the header.
         self.state
             .insert_certificate_header(&certificate, CertificateStatus::Pending)
             .inspect_err(|e| error!("Failed to insert certificate into state store: {e}"))?;

--- a/crates/agglayer-storage/src/stores/interfaces/writer.rs
+++ b/crates/agglayer-storage/src/stores/interfaces/writer.rs
@@ -69,6 +69,13 @@ pub trait StateWriter: Send + Sync {
 
     fn remove_settlement_tx_hash(&self, certificate_id: &CertificateId) -> Result<(), Error>;
 
+    /// Inserts the header of `certificate` with the given `status`.
+    ///
+    /// Inserting a [`CertificateStatus::Pending`] header also requests a
+    /// backup of the state and pending databases: it is the write that
+    /// accepts a newly submitted certificate. Callers must persist the
+    /// certificate body to the pending store *before* inserting the header,
+    /// so the backup is guaranteed to capture the body together with it.
     fn insert_certificate_header(
         &self,
         certificate: &Certificate,

--- a/crates/agglayer-storage/src/stores/state/mod.rs
+++ b/crates/agglayer-storage/src/stores/state/mod.rs
@@ -263,6 +263,15 @@ impl StateWriter for StateStore {
             )?;
         }
 
+        // A `Pending` header is written when a certificate is accepted from
+        // the RPC, after its body reached the pending db and before the
+        // orchestrator picks it up. The certificate body only exists in the
+        // pending db until then, so this backup is what lets a submitted but
+        // not yet processed certificate survive a loss of the live databases.
+        if let CertificateStatus::Pending = status {
+            self.request_backup();
+        }
+
         Ok(())
     }
 

--- a/crates/agglayer-storage/src/stores/state/tests/backup.rs
+++ b/crates/agglayer-storage/src/stores/state/tests/backup.rs
@@ -14,20 +14,75 @@ use crate::{
     tests::TempDBDir,
 };
 
-fn setup_store(
-    status: CertificateStatus,
-) -> (TempDBDir, StateStore, Certificate, Receiver<BackupRequest>) {
+fn raw_store() -> (TempDBDir, StateStore, Receiver<BackupRequest>) {
     let tmp = TempDBDir::new();
     let db = Arc::new(StateStore::init_db(tmp.path.as_path()).expect("Unable to init db"));
     let (backup_client, backups) = BackupClient::observable();
     let store = StateStore::new(db, backup_client);
+
+    (tmp, store, backups)
+}
+
+fn setup_store(
+    status: CertificateStatus,
+) -> (TempDBDir, StateStore, Certificate, Receiver<BackupRequest>) {
+    let (tmp, store, mut backups) = raw_store();
 
     let certificate = Certificate::new_for_test(NetworkId::new(1), Height::ZERO);
     store
         .insert_certificate_header(&certificate, status)
         .expect("Unable to insert certificate header");
 
+    // Drain the requests triggered by the setup insert so each test only
+    // observes the requests of the operation under test.
+    while backups.try_recv().is_ok() {}
+
     (tmp, store, certificate, backups)
+}
+
+#[test]
+fn accepting_a_pending_certificate_triggers_a_state_backup() {
+    let (_tmp, store, mut backups) = raw_store();
+
+    let certificate = Certificate::new_for_test(NetworkId::new(1), Height::ZERO);
+    store
+        .insert_certificate_header(&certificate, CertificateStatus::Pending)
+        .expect("Unable to insert certificate header");
+
+    let request = backups
+        .try_recv()
+        .expect("Accepting a Pending certificate should request a backup");
+
+    assert!(
+        request.epoch_db.is_none(),
+        "Pending acceptance should back up the state and pending DBs, not an epoch DB"
+    );
+    assert!(
+        backups.try_recv().is_err(),
+        "A single certificate acceptance should request a single backup"
+    );
+}
+
+#[test]
+fn non_pending_header_inserts_do_not_trigger_a_state_backup() {
+    for status in [
+        CertificateStatus::Proven,
+        CertificateStatus::Candidate,
+        CertificateStatus::Settled,
+        CertificateStatus::error(CertificateStatusError::InternalError("failed".to_string())),
+    ] {
+        let (_tmp, store, mut backups) = raw_store();
+
+        let certificate = Certificate::new_for_test(NetworkId::new(1), Height::ZERO);
+        store
+            .insert_certificate_header(&certificate, status.clone())
+            .expect("Unable to insert certificate header");
+
+        assert!(
+            backups.try_recv().is_err(),
+            "Inserting a certificate header as {status} should not request a backup"
+        );
+    }
 }
 
 #[test]

--- a/docs/knowledge-base/src/storage.md
+++ b/docs/knowledge-base/src/storage.md
@@ -89,6 +89,13 @@ Backups are requested by the write paths themselves,
 so a restored database stays usable without operator action.
 The state and pending DBs are backed up together when:
 
+- A certificate is accepted as pending,
+  which is when its header is inserted with the `Pending` status.
+  The acceptance path writes the certificate body to the pending DB
+  before inserting the header, so the snapshot contains both.
+  This backup is what keeps a submitted but unprocessed certificate
+  recoverable, since nothing outside the live databases references it
+  until the orchestrator picks it up.
 - A certificate is proven.
   Settlement is submitted from a spawned task shortly after,
   so this is the last write still ordered ahead of the certificate reaching L1.

--- a/tests/integrations/tests/storage_backups/main.rs
+++ b/tests/integrations/tests/storage_backups/main.rs
@@ -24,19 +24,6 @@ mod common;
 
 const RESOURCE_NOT_FOUND_ERROR: i32 = -10008;
 
-async fn wait_for_backup_counts(
-    backup_dir: &std::path::Path,
-    minimum_state_backups: usize,
-    minimum_pending_backups: usize,
-) {
-    wait_for_condition("backup creation", Duration::from_secs(30), || async {
-        let backup_report = BackupEngine::list_backups(backup_dir).unwrap();
-        backup_report.get_state().len() >= minimum_state_backups
-            && backup_report.get_pending().len() >= minimum_pending_backups
-    })
-    .await;
-}
-
 fn latest_backup_id(backups: &[BackupEngineInfo]) -> Option<u32> {
     backups.iter().map(|backup| backup.backup_id).max()
 }
@@ -64,27 +51,48 @@ fn restore_snapshot(
     (restored, state, pending)
 }
 
-/// Waits until the latest state and pending backup ids reach at least the given
-/// values.
+/// Returns the id of the latest state backup if restoring it yields
+/// `certificate_id` as settled, `None` otherwise (including while a backup is
+/// mid-write, when listing or restoring can transiently fail).
+fn settled_snapshot_id(backup_dir: &std::path::Path, certificate_id: CertificateId) -> Option<u32> {
+    let backup_id = latest_backup_id(BackupEngine::list_backups(backup_dir).ok()?.get_state())?;
+
+    let restored = TempDBDir::new();
+    let state_path = restored.path.join("state");
+    BackupEngine::restore_at(&backup_dir.join("state"), &state_path, backup_id).ok()?;
+    let state = StateStore::new_with_path(&state_path, BackupClient::noop()).ok()?;
+
+    (state.get_certificate_header(&certificate_id).ok()??.status == CertificateStatus::Settled)
+        .then_some(backup_id)
+}
+
+/// Waits until the latest state backup contains `certificate_id` as settled,
+/// and returns that backup's id.
 ///
-/// Unlike [`wait_for_backup_counts`], this works under aggressive purging
-/// (where the retained backup count stays at 1) because RocksDB backup ids are
-/// monotonic. Each settled certificate produces four backups (one when it is
-/// accepted as pending, one when it is proven, one when the L1 tx hash is
-/// known, one when it is settled), so the Nth settled certificate's durable
-/// state has backup id `4 * N`.
-async fn wait_for_backup_ids(
+/// The settled write requests a backup, so this always completes; but exact
+/// backup counts are not deterministic: state backup requests coalesce into a
+/// single queue slot, so two requests close together (such as the
+/// accepted-as-pending and proven triggers, or any pair when backups are slow
+/// under load) can produce one backup covering both writes. Waiting on the
+/// restored snapshot content instead of on backup counts or ids stays correct
+/// however many requests coalesced.
+async fn wait_for_settled_snapshot(
     backup_dir: &std::path::Path,
-    minimum_state_backup_id: u32,
-    minimum_pending_backup_id: u32,
-) {
-    wait_for_condition("backup id advance", Duration::from_secs(30), || async {
-        let backup_report = BackupEngine::list_backups(backup_dir).unwrap();
-        latest_backup_id(backup_report.get_state()).is_some_and(|id| id >= minimum_state_backup_id)
-            && latest_backup_id(backup_report.get_pending())
-                .is_some_and(|id| id >= minimum_pending_backup_id)
-    })
-    .await;
+    certificate_id: CertificateId,
+) -> u32 {
+    let start = tokio::time::Instant::now();
+
+    loop {
+        if let Some(backup_id) = settled_snapshot_id(backup_dir, certificate_id) {
+            return backup_id;
+        }
+
+        if start.elapsed() >= Duration::from_secs(30) {
+            panic!("Timed out waiting for a settled backup snapshot of {certificate_id}");
+        }
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
 }
 
 #[rstest]
@@ -122,11 +130,10 @@ async fn recover_with_backup(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    // Each settled certificate produces four backups (pending, proven,
-    // tx-hash known, then settled). Wait for all of them so the restore
-    // captures the settled state rather than an earlier snapshot, which would
-    // leave the certificate non-Settled after restart.
-    wait_for_backup_counts(&backup_dir.path, 4, 4).await;
+    // Wait until the settled state is durably backed up before shutting the
+    // node down, so the final restore-from-latest captures a Settled
+    // certificate rather than an earlier snapshot.
+    wait_for_settled_snapshot(&backup_dir.path, certificate_id).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
@@ -268,10 +275,9 @@ async fn purge_after_n_backup(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    // Each settled certificate produces four backups (pending, proven,
-    // tx-hash known, then settled). Wait for certificate1 to be fully backed
-    // up (state/pending backup id >= 4) before sending certificate2.
-    wait_for_backup_ids(&backup_dir.path, 4, 4).await;
+    // Wait for certificate1's settled state to be durably backed up before
+    // sending certificate2.
+    wait_for_settled_snapshot(&backup_dir.path, certificate_id).await;
 
     let certificate_id2: CertificateId = client
         .request("interop_sendCertificate", rpc_params![certificate2])
@@ -283,12 +289,11 @@ async fn purge_after_n_backup(#[case] state: Forest) {
     assert_eq!(result.status, CertificateStatus::Settled);
 
     // This configuration purges state and pending backups eagerly, so the
-    // retained backup count stays at 1 after both settlements. Backup ids are
-    // monotonic, so wait for certificate2's settled backup (id >= 8) to be
-    // durable before shutting the node down; otherwise the restore can capture
-    // one of certificate2's pre-settlement snapshots and the post-restart
-    // status assertion flakes.
-    wait_for_backup_ids(&backup_dir.path, 8, 8).await;
+    // retained backup count stays at 1 after both settlements. Wait for
+    // certificate2's settled backup to be durable before shutting the node
+    // down; otherwise the restore can capture one of certificate2's
+    // pre-settlement snapshots and the post-restart status assertion flakes.
+    wait_for_settled_snapshot(&backup_dir.path, certificate_id2).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
@@ -378,7 +383,7 @@ async fn report_contains_all_backups(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    wait_for_backup_counts(&backup_dir.path, 8, 8).await;
+    wait_for_settled_snapshot(&backup_dir.path, certificate_id2).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
@@ -390,13 +395,17 @@ async fn report_contains_all_backups(#[case] state: Forest) {
 
     let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
 
-    // There are 8 backups because 4 actions trigger a backup per cert:
-    // - One when the `Certificate` is accepted as pending
-    // - One when the `Certificate` is proven
-    // - One when the L1 `tx_hash` is known
-    // - One when the `Certificate` is settled and the network state is updated
-    assert_eq!(backup_report.get_state().len(), 8);
-    assert_eq!(backup_report.get_pending().len(), 8);
+    // Four actions request a backup per certificate: accepted as pending,
+    // proven, L1 tx hash known, and settled. Close-together requests coalesce
+    // into the single state queue slot, so the exact count depends on timing;
+    // it is bounded by the request total, and state and pending snapshots are
+    // always taken in pairs.
+    let state_backups = backup_report.get_state().len();
+    assert!(
+        (2..=8).contains(&state_backups),
+        "expected between 2 and 8 state backups, got {state_backups}"
+    );
+    assert_eq!(state_backups, backup_report.get_pending().len());
 
     BackupEngine::restore(
         &backup_dir.path.join("state"),
@@ -464,7 +473,10 @@ async fn restore_at_particular_level(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    wait_for_backup_counts(&backup_dir.path, 4, 4).await;
+    // Captured before certificate2 is submitted, so this backup is
+    // certificate1's settled snapshot and cannot contain certificate2.
+    let certificate1_settled_backup =
+        wait_for_settled_snapshot(&backup_dir.path, certificate_id).await;
 
     let certificate_id2: CertificateId = client
         .request("interop_sendCertificate", rpc_params![certificate2])
@@ -475,7 +487,7 @@ async fn restore_at_particular_level(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    wait_for_backup_counts(&backup_dir.path, 8, 8).await;
+    wait_for_settled_snapshot(&backup_dir.path, certificate_id2).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
@@ -485,17 +497,10 @@ async fn restore_at_particular_level(#[case] state: Forest) {
     std::fs::remove_dir_all(&config.storage.epochs_db_path).unwrap();
     std::fs::remove_dir_all(&config.storage.state_db_path).unwrap();
 
-    let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
-
-    assert_eq!(backup_report.get_state().len(), 8);
-    assert_eq!(backup_report.get_pending().len(), 8);
-
-    // Backup 4 is certificate1's settled snapshot, taken before certificate2
-    // was ever submitted.
     BackupEngine::restore_at(
         &backup_dir.path.join("state"),
         &config.storage.state_db_path,
-        4,
+        certificate1_settled_backup,
     )
     .unwrap();
 

--- a/tests/integrations/tests/storage_backups/main.rs
+++ b/tests/integrations/tests/storage_backups/main.rs
@@ -69,9 +69,10 @@ fn restore_snapshot(
 ///
 /// Unlike [`wait_for_backup_counts`], this works under aggressive purging
 /// (where the retained backup count stays at 1) because RocksDB backup ids are
-/// monotonic. Each settled certificate produces three backups (one when it is
-/// proven, one when the L1 tx hash is known, one when it is settled), so the
-/// Nth settled certificate's durable state has backup id `3 * N`.
+/// monotonic. Each settled certificate produces four backups (one when it is
+/// accepted as pending, one when it is proven, one when the L1 tx hash is
+/// known, one when it is settled), so the Nth settled certificate's durable
+/// state has backup id `4 * N`.
 async fn wait_for_backup_ids(
     backup_dir: &std::path::Path,
     minimum_state_backup_id: u32,
@@ -109,6 +110,8 @@ async fn recover_with_backup(#[case] state: Forest) {
     let withdrawals = vec![];
 
     let certificate = state.clone().apply_events(&[], &withdrawals);
+    let network_id = certificate.network_id;
+    let height = certificate.height;
 
     let certificate_id: CertificateId = client
         .request("interop_sendCertificate", rpc_params![certificate])
@@ -119,24 +122,24 @@ async fn recover_with_backup(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    // Each settled certificate produces three backups (proven, tx-hash known,
-    // then settled). Wait for all of them so the restore captures the settled
-    // state rather than an earlier snapshot, which would leave the certificate
-    // non-Settled after restart.
-    wait_for_backup_counts(&backup_dir.path, 3, 3).await;
+    // Each settled certificate produces four backups (pending, proven,
+    // tx-hash known, then settled). Wait for all of them so the restore
+    // captures the settled state rather than an earlier snapshot, which would
+    // leave the certificate non-Settled after restart.
+    wait_for_backup_counts(&backup_dir.path, 4, 4).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
 
-    // The invariant the `Proven` trigger exists for: backup 1 is requested
-    // before the settlement tx is submitted, and must carry the certificate
-    // header and its generated proof together — they live in two different
-    // databases, and the later backups no longer hold the proof.
+    // The invariant the `Pending` trigger exists for: backup 1 is requested
+    // as soon as the certificate is accepted, before the orchestrator picks
+    // it up, and must carry the certificate body — it only lives in the
+    // pending database until the certificate is processed.
     //
-    // The status is asserted as a range rather than exactly `Proven`: the
+    // The status is asserted as a range rather than exactly `Pending`: the
     // backup engine flushes on a blocking task, so under load it can run
-    // after the certificate task has advanced to `Candidate`. Both are
-    // pre-settlement and both recover; pinning `Proven` would only buy a
+    // after the certificate task has advanced. All allowed statuses are
+    // pre-settlement and all recover; pinning `Pending` would only buy a
     // flaky test.
     {
         let (_restored, state, pending) = restore_snapshot(&backup_dir.path, 1);
@@ -148,15 +151,52 @@ async fn recover_with_backup(#[case] state: Forest) {
         assert!(
             matches!(
                 header.status,
-                CertificateStatus::Proven | CertificateStatus::Candidate
+                CertificateStatus::Pending
+                    | CertificateStatus::Proven
+                    | CertificateStatus::Candidate
             ),
             "backup 1 should predate settlement, got {:?}",
             header.status
         );
 
         assert!(
+            pending
+                .get_certificate(network_id, height)
+                .unwrap()
+                .is_some(),
+            "backup 1 should contain the submitted certificate body"
+        );
+    }
+
+    // The invariant the `Proven` trigger exists for: backup 2 is requested
+    // before the settlement tx is submitted, and must carry the certificate
+    // header and its generated proof together — they live in two different
+    // databases, and the later backups no longer hold the proof.
+    //
+    // The status is asserted as a range rather than exactly `Proven`: the
+    // backup engine flushes on a blocking task, so under load it can run
+    // after the certificate task has advanced to `Candidate`. Both are
+    // pre-settlement and both recover; pinning `Proven` would only buy a
+    // flaky test.
+    {
+        let (_restored, state, pending) = restore_snapshot(&backup_dir.path, 2);
+
+        let header = state
+            .get_certificate_header(&certificate_id)
+            .unwrap()
+            .expect("backup 2 should contain the certificate header");
+        assert!(
+            matches!(
+                header.status,
+                CertificateStatus::Proven | CertificateStatus::Candidate
+            ),
+            "backup 2 should predate settlement, got {:?}",
+            header.status
+        );
+
+        assert!(
             pending.get_proof(certificate_id).unwrap().is_some(),
-            "backup 1 should contain the generated proof"
+            "backup 2 should contain the generated proof"
         );
     }
 
@@ -228,10 +268,10 @@ async fn purge_after_n_backup(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    // Each settled certificate produces three backups (proven, tx-hash known,
-    // then settled). Wait for certificate1 to be fully backed up (state/pending
-    // backup id >= 3) before sending certificate2.
-    wait_for_backup_ids(&backup_dir.path, 3, 3).await;
+    // Each settled certificate produces four backups (pending, proven,
+    // tx-hash known, then settled). Wait for certificate1 to be fully backed
+    // up (state/pending backup id >= 4) before sending certificate2.
+    wait_for_backup_ids(&backup_dir.path, 4, 4).await;
 
     let certificate_id2: CertificateId = client
         .request("interop_sendCertificate", rpc_params![certificate2])
@@ -244,11 +284,11 @@ async fn purge_after_n_backup(#[case] state: Forest) {
 
     // This configuration purges state and pending backups eagerly, so the
     // retained backup count stays at 1 after both settlements. Backup ids are
-    // monotonic, so wait for certificate2's settled backup (id >= 6) to be
+    // monotonic, so wait for certificate2's settled backup (id >= 8) to be
     // durable before shutting the node down; otherwise the restore can capture
     // one of certificate2's pre-settlement snapshots and the post-restart
     // status assertion flakes.
-    wait_for_backup_ids(&backup_dir.path, 6, 6).await;
+    wait_for_backup_ids(&backup_dir.path, 8, 8).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
@@ -338,7 +378,7 @@ async fn report_contains_all_backups(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    wait_for_backup_counts(&backup_dir.path, 6, 6).await;
+    wait_for_backup_counts(&backup_dir.path, 8, 8).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
@@ -350,12 +390,13 @@ async fn report_contains_all_backups(#[case] state: Forest) {
 
     let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
 
-    // There are 6 backups because 3 actions trigger a backup per cert:
+    // There are 8 backups because 4 actions trigger a backup per cert:
+    // - One when the `Certificate` is accepted as pending
     // - One when the `Certificate` is proven
     // - One when the L1 `tx_hash` is known
     // - One when the `Certificate` is settled and the network state is updated
-    assert_eq!(backup_report.get_state().len(), 6);
-    assert_eq!(backup_report.get_pending().len(), 6);
+    assert_eq!(backup_report.get_state().len(), 8);
+    assert_eq!(backup_report.get_pending().len(), 8);
 
     BackupEngine::restore(
         &backup_dir.path.join("state"),
@@ -423,7 +464,7 @@ async fn restore_at_particular_level(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    wait_for_backup_counts(&backup_dir.path, 3, 3).await;
+    wait_for_backup_counts(&backup_dir.path, 4, 4).await;
 
     let certificate_id2: CertificateId = client
         .request("interop_sendCertificate", rpc_params![certificate2])
@@ -434,7 +475,7 @@ async fn restore_at_particular_level(#[case] state: Forest) {
 
     assert_eq!(result.status, CertificateStatus::Settled);
 
-    wait_for_backup_counts(&backup_dir.path, 6, 6).await;
+    wait_for_backup_counts(&backup_dir.path, 8, 8).await;
 
     handle.cancel();
     _ = agglayer_shutdowned.await;
@@ -446,15 +487,15 @@ async fn restore_at_particular_level(#[case] state: Forest) {
 
     let backup_report = BackupEngine::list_backups(&backup_dir.path).unwrap();
 
-    assert_eq!(backup_report.get_state().len(), 6);
-    assert_eq!(backup_report.get_pending().len(), 6);
+    assert_eq!(backup_report.get_state().len(), 8);
+    assert_eq!(backup_report.get_pending().len(), 8);
 
-    // Backup 3 is certificate1's settled snapshot, taken before certificate2
+    // Backup 4 is certificate1's settled snapshot, taken before certificate2
     // was ever submitted.
     BackupEngine::restore_at(
         &backup_dir.path.join("state"),
         &config.storage.state_db_path,
-        3,
+        4,
     )
     .unwrap();
 


### PR DESCRIPTION
## Description

Fixes agglayer/issues#8.

A certificate accepted as `Pending` previously got its first backup only when it reached `Proven`. A submitted-but-unprocessed certificate therefore only existed in the live pending/state databases: losing them before the orchestrator picked the certificate up lost the certificate entirely.

`StateStore::insert_certificate_header` now requests a state+pending backup when a header is inserted with the `Pending` status — the write that accepts a newly submitted certificate, ordered after the certificate body is persisted to the pending store and before the certificate is handed to the orchestrator. The snapshot is therefore guaranteed to contain both the body and the header. The ordering requirement is documented at the `send_certificate` call site and in the `StateWriter::insert_certificate_header` trait doc, and the trigger placement follows the existing store-side pattern (`Proven` trigger in `update_certificate_header_status`).

### Backup cadence change

Each settled certificate now *requests* four state/pending backups instead of three (accepted-as-pending, proven, tx-hash known, settled). Since #1777, close-together requests coalesce into the single state queue slot, so the number of backups actually produced depends on timing; the coalesced backup runs after every write it covers. Operationally, restore-from-latest (plus the drain-on-shutdown guarantee) remains the contract; exact backup ids were already not load-bearing after #1777 and the integration tests now wait on restored snapshot content instead of on backup counts.

## Testing

- New storage unit tests: inserting a `Pending` header requests exactly one state+pending backup; other statuses request none.
- `storage_backups` integration tests: new assertion that the first backup contains the submitted certificate body, and the milestone waits now restore the latest backup and check its content (`wait_for_settled_snapshot`), which is stable under request coalescing — the previous exact-count waits timed out under parallel test load once the accepted-as-pending trigger created the first close-spaced request pair.
- `cargo nextest run --profile integrations -p integrations --test storage_backups`: 4/4 pass locally, twice in parallel and once serially, post-merge with #1777/#1783.
- `cargo check --workspace --tests --all-features`, `cargo make ci-all`, and `cargo nextest run --workspace` (952 passed) pass locally on the pre-merge tree; unit tests and fmt re-verified post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)